### PR TITLE
Phase 0: extract theme and platform seams

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,12 +30,16 @@ key-amnesia/
     guard.py
     run_exec.py                    # buffer-then-scrub-then-relay
     clipboard.py
+    theme.py                       # CLI output helpers (Phase 0 seam; plain print today)
+    platform.py                    # isolated-console spawn (Phase 0 seam; Windows only today)
   tests/
 ```
 
 Entry points: `key-amnesia` and `ka` both → `key_amnesia.cli:main`.
 
 Deps: `pynacl`, `pyperclip`. Dev: `pytest`.
+
+**Phase 0 seams:** `theme.py` and `platform.py` exist so later branding and Linux spawn can land without thrashing `cli.py` / `prompt_route.py`. They are extraction-only today — no visual theme and no non-Windows spawn behavior yet.
 
 ---
 

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -14,6 +14,7 @@ from key_amnesia.audit import audit_event
 from key_amnesia.config import ConfigError, load_config, set_config_value
 from key_amnesia.paths import vault_path
 from key_amnesia.prompt_route import PromptRequest, require_human_auth
+from key_amnesia import theme
 from key_amnesia.vault import (
     VaultError,
     empty_payload,
@@ -132,12 +133,11 @@ def _prompt_new_master_password() -> str | None:
     p1 = getpass.getpass("Master password: ")
     p2 = getpass.getpass("Confirm master password: ")
     if not p1:
-        print("Error: master password cannot be empty.", file=sys.stderr)
+        theme.error("Error: master password cannot be empty.")
         return None
     if p1 != p2:
-        print(
+        theme.error(
             "Error: passwords do not match — vault not created.",
-            file=sys.stderr,
         )
         return None
     return p1
@@ -146,16 +146,14 @@ def _prompt_new_master_password() -> str | None:
 def cmd_init(_args: argparse.Namespace) -> int:
     vp = vault_path()
     if vp.exists():
-        print(
+        theme.error(
             "vault already initialized, use ka set to add secrets",
-            file=sys.stderr,
         )
         return 1
     if not sys.stdin.isatty():
-        print(
+        theme.error(
             "Error: ka init requires an interactive terminal "
             "(run it directly in your console).",
-            file=sys.stderr,
         )
         return 1
     password = _prompt_new_master_password()
@@ -164,10 +162,10 @@ def cmd_init(_args: argparse.Namespace) -> int:
     try:
         save_vault(vp, password, empty_payload())
     except VaultError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        theme.error(f"Error: {e}")
         return 1
-    print(f"Vault initialized at {vp}")
-    print(
+    theme.success(f"Vault initialized at {vp}")
+    theme.info(
         "Remember your master password — it cannot be recovered if forgotten."
     )
     return 0
@@ -189,9 +187,8 @@ def cmd_set(args: argparse.Namespace) -> int:
     name = args.name
     value = args.value
     if not vault_path().exists():
-        print(
+        theme.error(
             "Vault not initialized. Run 'ka init' first.",
-            file=sys.stderr,
         )
         return 1
     # Prefer not putting secret values on argv — if omitted, prompt (inline only)
@@ -203,7 +200,7 @@ def cmd_set(args: argparse.Namespace) -> int:
     # If value missing and interactive, collect value after password inline.
     ok, password, outcome = _auth_password(request)
     if not ok:
-        print(f"Denied: {outcome.reason}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason}")
         return 1
 
     if password is not None:
@@ -213,7 +210,7 @@ def cmd_set(args: argparse.Namespace) -> int:
         try:
             payload = load_vault(None, password)
         except VaultError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            theme.error(f"Error: {e}")
             audit_event(
                 "set",
                 secret_names=[name],
@@ -230,21 +227,20 @@ def cmd_set(args: argparse.Namespace) -> int:
             route=outcome.route,
             result="allowed",
         )
-        print(f"Set secret '{name}'.")
+        theme.success(f"Set secret '{name}'.")
         return 0
 
     # Spawned helper already mutated (or failed).
     if outcome.status_only and outcome.status_only.get("action") == "set":
-        print(f"Set secret '{name}'.")
+        theme.success(f"Set secret '{name}'.")
         return 0
     # If value was None and we went non-interactive without detail, fail.
     if value is None:
-        print(
+        theme.error(
             "Non-interactive set requires the value (or an interactive terminal).",
-            file=sys.stderr,
         )
         return 1
-    print(f"Denied: {outcome.reason or 'set failed'}", file=sys.stderr)
+    theme.error(f"Denied: {outcome.reason or 'set failed'}")
     return 1
 
 
@@ -253,17 +249,17 @@ def cmd_remove(args: argparse.Namespace) -> int:
     request = PromptRequest(action="remove", secret_names=[name])
     ok, password, outcome = _auth_password(request)
     if not ok:
-        print(f"Denied: {outcome.reason}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason}")
         return 1
 
     if password is not None:
         try:
             payload = load_vault(None, password)
         except VaultError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            theme.error(f"Error: {e}")
             return 1
         if name not in payload["secrets"]:
-            print(f"Unknown secret: {name}", file=sys.stderr)
+            theme.error(f"Unknown secret: {name}")
             audit_event(
                 "remove",
                 secret_names=[name],
@@ -277,13 +273,13 @@ def cmd_remove(args: argparse.Namespace) -> int:
         audit_event(
             "remove", secret_names=[name], route=outcome.route, result="allowed"
         )
-        print(f"Removed secret '{name}'.")
+        theme.success(f"Removed secret '{name}'.")
         return 0
 
     if outcome.status_only and outcome.status_only.get("action") == "remove":
-        print(f"Removed secret '{name}'.")
+        theme.success(f"Removed secret '{name}'.")
         return 0
-    print(f"Denied: {outcome.reason or 'remove failed'}", file=sys.stderr)
+    theme.error(f"Denied: {outcome.reason or 'remove failed'}")
     return 1
 
 
@@ -292,7 +288,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if cmd and cmd[0] == "--":
         cmd = cmd[1:]
     if not cmd:
-        print("Usage: key-amnesia run --secret NAME [--as NAME=ENV] -- command...", file=sys.stderr)
+        theme.error("Usage: key-amnesia run --secret NAME [--as NAME=ENV] -- command...")
         return 2
 
     inject_as = _parse_as_mappings(args.as_env)
@@ -302,7 +298,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         if n not in secret_names:
             secret_names.append(n)
     if not secret_names:
-        print("At least one --secret or --as is required.", file=sys.stderr)
+        theme.error("At least one --secret or --as is required.")
         return 2
 
     # Try live guard first (cached mode).
@@ -323,12 +319,12 @@ def cmd_run(args: argparse.Namespace) -> int:
             sys.stderr.write(resp.get("scrubbed_stderr", ""))
             return int(resp.get("exit_code", 0))
         if resp and resp.get("expired"):
-            print("Guard session expired; falling back to per-call auth.", file=sys.stderr)
+            theme.warn("Guard session expired; falling back to per-call auth.")
         elif resp and not resp.get("ok"):
             # Guard reachable but denied (e.g. unknown secret) — don't fall through
             # with a password prompt unless it's expiry/connectivity.
             if "unknown" in str(resp.get("reason", "")):
-                print(f"Error: {resp.get('reason')}", file=sys.stderr)
+                theme.error(f"Error: {resp.get('reason')}")
                 return 1
 
     request = PromptRequest(
@@ -340,7 +336,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
-        print(f"Denied: {outcome.reason}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason}")
         return 1
 
     if password is not None:
@@ -349,7 +345,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         try:
             payload = load_vault(None, password)
         except VaultError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            theme.error(f"Error: {e}")
             audit_event(
                 "run",
                 secret_names=secret_names,
@@ -362,7 +358,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         secrets_map = {k: str(v) for k, v in payload["secrets"].items()}
         missing = [n for n in secret_names if n not in secrets_map]
         if missing:
-            print(f"Unknown secrets: {', '.join(missing)}", file=sys.stderr)
+            theme.error(f"Unknown secrets: {', '.join(missing)}")
             return 1
         env_inject = {inject_as.get(n, n): secrets_map[n] for n in secret_names}
         by_name = {n: secrets_map[n] for n in secret_names}
@@ -383,7 +379,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         sys.stdout.write(outcome.run_result.get("scrubbed_stdout", ""))
         sys.stderr.write(outcome.run_result.get("scrubbed_stderr", ""))
         return int(outcome.run_result.get("exit_code") or 0)
-    print(f"Denied: {outcome.reason or 'run failed'}", file=sys.stderr)
+    theme.error(f"Denied: {outcome.reason or 'run failed'}")
     return 1
 
 
@@ -396,11 +392,11 @@ def cmd_list(_args: argparse.Namespace) -> int:
         if resp and resp.get("ok"):
             names = list(resp.get("names") or [])
             for n in names:
-                print(n)
+                theme.out(n)
             return 0
     names = read_names()
     for n in names:
-        print(n)
+        theme.out(n)
     return 0
 
 
@@ -408,7 +404,7 @@ def cmd_unlock(_args: argparse.Namespace) -> int:
     from key_amnesia.guard import guard_is_alive, start_guard_process
 
     if guard_is_alive():
-        print("Guard session already active.", file=sys.stderr)
+        theme.warn("Guard session already active.")
         return 0
 
     cfg = load_config()
@@ -420,28 +416,28 @@ def cmd_unlock(_args: argparse.Namespace) -> int:
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
-        print(f"Denied: {outcome.reason}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason}")
         return 1
 
     if password is not None:
         try:
             payload = load_vault(None, password)
         except VaultError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            theme.error(f"Error: {e}")
             return 1
         try:
             pid = start_guard_process(payload, timeout_min)
         except Exception as e:  # noqa: BLE001
-            print(f"Failed to start guard: {e}", file=sys.stderr)
+            theme.error(f"Failed to start guard: {e}")
             return 1
         audit_event("unlock", route=outcome.route, result="allowed")
-        print(f"Unlocked (guard pid {pid}, timeout {timeout_min}m).")
+        theme.success(f"Unlocked (guard pid {pid}, timeout {timeout_min}m).")
         return 0
 
     if outcome.status_only and outcome.status_only.get("action") == "unlock":
-        print(f"Unlocked (timeout {timeout_min}m).")
+        theme.success(f"Unlocked (timeout {timeout_min}m).")
         return 0
-    print(f"Denied: {outcome.reason or 'unlock failed'}", file=sys.stderr)
+    theme.error(f"Denied: {outcome.reason or 'unlock failed'}")
     return 1
 
 
@@ -450,14 +446,14 @@ def cmd_lock(_args: argparse.Namespace) -> int:
 
     if not guard_is_alive():
         clear_guard_lock()
-        print("No active guard session.")
+        theme.info("No active guard session.")
         return 0
     resp = guard_request({"verb": "lock"})
     clear_guard_lock()
     if resp and resp.get("ok"):
-        print("Locked.")
+        theme.success("Locked.")
         return 0
-    print("Lock signal sent; cleared local lock file.")
+    theme.info("Lock signal sent; cleared local lock file.")
     return 0
 
 
@@ -471,20 +467,21 @@ def cmd_reveal(args: argparse.Namespace) -> int:
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
-        print(f"Denied: {outcome.reason}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason}")
         return 1
 
     if password is not None:
         try:
             payload = load_vault(None, password)
         except VaultError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            theme.error(f"Error: {e}")
             return 1
         secrets_map = payload.get("secrets", {})
         if name not in secrets_map:
-            print(f"Unknown secret: {name}", file=sys.stderr)
+            theme.error(f"Unknown secret: {name}")
             return 1
-        print(secrets_map[name])
+        # Raw secret value — never themed.
+        sys.stdout.write(f"{secrets_map[name]}\n")
         audit_event(
             "reveal", secret_names=[name], route=outcome.route, result="allowed"
         )
@@ -492,9 +489,9 @@ def cmd_reveal(args: argparse.Namespace) -> int:
 
     # Non-interactive: helper showed in its window; caller gets status only.
     if outcome.status_only and outcome.status_only.get("shown"):
-        print(f"Secret '{name}' displayed in authentication console.")
+        theme.info(f"Secret '{name}' displayed in authentication console.")
         return 0
-    print(f"Denied: {outcome.reason or 'reveal failed'}", file=sys.stderr)
+    theme.error(f"Denied: {outcome.reason or 'reveal failed'}")
     return 1
 
 
@@ -507,7 +504,7 @@ def cmd_copy(args: argparse.Namespace) -> int:
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
-        print(f"Denied: {outcome.reason}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason}")
         return 1
 
     if password is not None:
@@ -516,30 +513,30 @@ def cmd_copy(args: argparse.Namespace) -> int:
         try:
             payload = load_vault(None, password)
         except VaultError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            theme.error(f"Error: {e}")
             return 1
         secrets_map = payload.get("secrets", {})
         if name not in secrets_map:
-            print(f"Unknown secret: {name}", file=sys.stderr)
+            theme.error(f"Unknown secret: {name}")
             return 1
         copy_to_clipboard(str(secrets_map[name]))
         audit_event(
             "copy", secret_names=[name], route=outcome.route, result="allowed"
         )
-        print(f"Copied '{name}' to clipboard.")
+        theme.success(f"Copied '{name}' to clipboard.")
         return 0
 
     if outcome.status_only and outcome.status_only.get("copied"):
-        print(f"Secret '{name}' copied in authentication console.")
+        theme.info(f"Secret '{name}' copied in authentication console.")
         return 0
-    print(f"Denied: {outcome.reason or 'copy failed'}", file=sys.stderr)
+    theme.error(f"Denied: {outcome.reason or 'copy failed'}")
     return 1
 
 
 def cmd_config(args: argparse.Namespace) -> int:
     if args.config_command == "show" or args.config_command is None:
         cfg = load_config()
-        print(json.dumps(cfg, indent=2))
+        theme.out(json.dumps(cfg, indent=2))
         return 0
     if args.config_command == "set":
         request = PromptRequest(
@@ -548,7 +545,7 @@ def cmd_config(args: argparse.Namespace) -> int:
         )
         ok, password, outcome = _auth_password(request)
         if not ok:
-            print(f"Denied: {outcome.reason}", file=sys.stderr)
+            theme.error(f"Denied: {outcome.reason}")
             return 1
         if password is not None:
             # Verify password against vault if it exists (fresh auth proof).
@@ -557,12 +554,12 @@ def cmd_config(args: argparse.Namespace) -> int:
                 try:
                     load_vault(None, password)
                 except VaultError as e:
-                    print(f"Error: {e}", file=sys.stderr)
+                    theme.error(f"Error: {e}")
                     return 1
             try:
                 set_config_value(args.key, args.value)
             except ConfigError as e:
-                print(f"Error: {e}", file=sys.stderr)
+                theme.error(f"Error: {e}")
                 return 1
             audit_event(
                 "config",
@@ -570,14 +567,14 @@ def cmd_config(args: argparse.Namespace) -> int:
                 result="allowed",
                 reason=f"set {args.key}",
             )
-            print(f"Set {args.key} = {args.value}")
+            theme.success(f"Set {args.key} = {args.value}")
             return 0
         if outcome.status_only and outcome.status_only.get("action") == "config":
-            print(f"Set {args.key} = {args.value}")
+            theme.success(f"Set {args.key} = {args.value}")
             return 0
-        print(f"Denied: {outcome.reason or 'config failed'}", file=sys.stderr)
+        theme.error(f"Denied: {outcome.reason or 'config failed'}")
         return 1
-    print("Usage: key-amnesia config [show|set KEY VALUE]", file=sys.stderr)
+    theme.error("Usage: key-amnesia config [show|set KEY VALUE]")
     return 2
 
 
@@ -586,19 +583,19 @@ def cmd_status(_args: argparse.Namespace) -> int:
 
     lock = read_guard_lock()
     if not lock or not guard_is_alive(lock):
-        print("guard: inactive")
+        theme.out("guard: inactive")
         cfg = load_config()
-        print(f"session-mode: {cfg.get('session-mode')}")
+        theme.out(f"session-mode: {cfg.get('session-mode')}")
         return 0
     resp = guard_request({"verb": "status"})
-    print("guard: active")
+    theme.out("guard: active")
     if resp and resp.get("ok"):
-        print(f"pid: {resp.get('pid')}")
-        print(f"expires_at: {resp.get('expires_at')}")
-        print(f"secret_count: {resp.get('secret_count')}")
+        theme.out(f"pid: {resp.get('pid')}")
+        theme.out(f"expires_at: {resp.get('expires_at')}")
+        theme.out(f"secret_count: {resp.get('secret_count')}")
     else:
-        print(f"pid: {lock.get('pid')}")
-        print(f"expires_at: {lock.get('expires_at')}")
+        theme.out(f"pid: {lock.get('pid')}")
+        theme.out(f"expires_at: {lock.get('expires_at')}")
     return 0
 
 

--- a/src/key_amnesia/guard.py
+++ b/src/key_amnesia/guard.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from key_amnesia import ipc
+from key_amnesia import theme
 from key_amnesia.audit import audit_event
 from key_amnesia.paths import guard_lock_path
 from key_amnesia.run_exec import run_with_secrets
@@ -238,10 +239,12 @@ def guard_serve(state: GuardState, listener: Any) -> None:
         ):
             extend_prompted = True
             try:
-                ans = input(
+                theme.out(
                     f"key-amnesia guard: session expires in "
-                    f"{int(state.expires_at - now)}s. Extend? [y/N] "
-                ).strip().lower()
+                    f"{int(state.expires_at - now)}s. Extend? [y/N] ",
+                    end="",
+                )
+                ans = input().strip().lower()
                 if ans in ("y", "yes"):
                     # Default extend by original remaining window or 30m
                     state.expires_at = time.time() + 30 * 60
@@ -401,7 +404,7 @@ def run_guard_main() -> int:
     """Entry for `_guard`: read bootstrap env, serve, exit."""
     boot_path = os.environ.pop("KEY_AMNESIA_GUARD_BOOTSTRAP", "")
     if not boot_path:
-        print("guard: missing bootstrap", file=sys.stderr)
+        theme.error("guard: missing bootstrap")
         return 1
     try:
         with open(boot_path, encoding="utf-8") as f:

--- a/src/key_amnesia/platform.py
+++ b/src/key_amnesia/platform.py
@@ -1,0 +1,35 @@
+"""OS-specific process spawn helpers (Phase 0: Windows CREATE_NEW_CONSOLE only)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any, Callable
+
+
+def spawn_isolated_console(
+    argv: list[str],
+    env: dict[str, str],
+    *,
+    popen_fn: Callable[..., Any] | None = None,
+) -> Any:
+    """Spawn *argv* in an isolated console; sensitive data only in *env*.
+
+    Windows: CREATE_NEW_CONSOLE, no stdio kwargs.
+    Non-win32: fail closed (POSIX console spawn is out of scope for v0).
+    """
+    if sys.platform != "win32":
+        raise OSError(
+            "Non-interactive prompt spawn is Windows-only in v0; "
+            "POSIX console spawn is out of scope. Fail closed."
+        )
+
+    creationflags = subprocess.CREATE_NEW_CONSOLE  # type: ignore[attr-defined]
+    popen = popen_fn or subprocess.Popen
+    # No stdin/stdout/stderr kwargs — new console owns stdio.
+    return popen(
+        argv,
+        env=env,
+        creationflags=creationflags,
+        close_fds=False,
+    )

--- a/src/key_amnesia/prompt_route.py
+++ b/src/key_amnesia/prompt_route.py
@@ -17,8 +17,10 @@ from multiprocessing.connection import Connection
 from typing import Any, Callable
 
 from key_amnesia import ipc
+from key_amnesia import theme
 from key_amnesia.audit import audit_event
 from key_amnesia.config import load_config
+from key_amnesia.platform import spawn_isolated_console
 
 # Environment keys for helper handoff (never put these on argv).
 ENV_REQUEST = "KEY_AMNESIA_PROMPT_REQUEST"
@@ -63,11 +65,14 @@ def _isatty() -> bool:
 
 
 def _prompt_password_inline(request: PromptRequest) -> str:
-    print(f"key-amnesia: authentication required for '{request.action}'", file=sys.stderr)
+    theme.info(
+        f"key-amnesia: authentication required for '{request.action}'",
+        file=sys.stderr,
+    )
     if request.secret_names:
-        print(f"  secrets: {', '.join(request.secret_names)}", file=sys.stderr)
+        theme.info(f"  secrets: {', '.join(request.secret_names)}", file=sys.stderr)
     if request.detail:
-        print(f"  {request.detail}", file=sys.stderr)
+        theme.info(f"  {request.detail}", file=sys.stderr)
     return getpass.getpass("Master password: ")
 
 
@@ -86,14 +91,6 @@ def _spawn_helper(
     popen_fn: Callable[..., Any] | None = None,
 ) -> Any:
     """Spawn helper with CREATE_NEW_CONSOLE; sensitive data only in env."""
-    import subprocess
-
-    if sys.platform != "win32":
-        raise OSError(
-            "Non-interactive prompt spawn is Windows-only in v0; "
-            "POSIX console spawn is out of scope. Fail closed."
-        )
-
     env = os.environ.copy()
     env[ENV_REQUEST] = json.dumps(asdict(request))
     env[ENV_AUTHKEY] = ipc.authkey_to_hex(authkey)
@@ -101,16 +98,8 @@ def _spawn_helper(
     env[ENV_PARENT_PID] = str(os.getpid())
     env[ENV_TIMEOUT] = str(timeout_s)
 
-    creationflags = subprocess.CREATE_NEW_CONSOLE  # type: ignore[attr-defined]
     cmd = _helper_command()
-    popen = popen_fn or subprocess.Popen
-    # No stdin/stdout/stderr kwargs — new console owns stdio.
-    return popen(
-        cmd,
-        env=env,
-        creationflags=creationflags,
-        close_fds=False,
-    )
+    return spawn_isolated_console(cmd, env, popen_fn=popen_fn)
 
 
 def require_human_auth(
@@ -356,7 +345,7 @@ def run_prompt_helper() -> int:
         parent_pid = int(env.get(ENV_PARENT_PID, "0"))
         timeout_s = int(env.get(ENV_TIMEOUT, "90"))
     except (KeyError, ValueError) as e:
-        print(f"key-amnesia helper: missing/invalid env handoff: {e}", file=sys.stderr)
+        theme.error(f"key-amnesia helper: missing/invalid env handoff: {e}")
         input("Press Enter to close...")
         return 1
 
@@ -383,20 +372,20 @@ def run_prompt_helper() -> int:
     )
 
     if parent_pid and not parent_alive(parent_pid):
-        print("key-amnesia helper: parent process gone; cancelling.", file=sys.stderr)
+        theme.error("key-amnesia helper: parent process gone; cancelling.")
         return 1
 
-    print("=" * 50)
-    print("  key-amnesia — human authentication")
-    print("=" * 50)
-    print(f"Action : {request.action}")
+    theme.info("=" * 50)
+    theme.info("  key-amnesia — human authentication")
+    theme.info("=" * 50)
+    theme.out(f"Action : {request.action}")
     if request.secret_names:
-        print(f"Secrets: {', '.join(request.secret_names)}")
+        theme.out(f"Secrets: {', '.join(request.secret_names)}")
     if request.command:
-        print(f"Command: {' '.join(request.command)}")
+        theme.out(f"Command: {' '.join(request.command)}")
     if request.detail:
-        print(request.detail)
-    print()
+        theme.out(request.detail)
+    theme.out()
 
     # Watch parent in background
     cancel = {"flag": False}
@@ -417,7 +406,7 @@ def run_prompt_helper() -> int:
         password = ""
 
     if cancel["flag"]:
-        print("Cancelled (parent exited).", file=sys.stderr)
+        theme.error("Cancelled (parent exited).")
         return 1
 
     reply: dict[str, Any] = {"ok": False, "reason": ""}
@@ -467,10 +456,11 @@ def run_prompt_helper() -> int:
                     if name not in secrets_map:
                         reply["reason"] = f"unknown secret: {name}"
                     else:
-                        print()
-                        print(f"--- {name} ---")
-                        print(secrets_map[name])
-                        print("--- end ---")
+                        theme.out()
+                        theme.out(f"--- {name} ---")
+                        # Raw secret value — never themed.
+                        sys.stdout.write(f"{secrets_map[name]}\n")
+                        theme.out("--- end ---")
                         reply["ok"] = True
                         reply["status_only"] = {
                             "shown": True,
@@ -484,7 +474,7 @@ def run_prompt_helper() -> int:
                         reply["reason"] = f"unknown secret: {name}"
                     else:
                         copy_to_clipboard(secrets_map[name])
-                        print(f"Copied '{name}' to clipboard (this window only).")
+                        theme.success(f"Copied '{name}' to clipboard (this window only).")
                         reply["ok"] = True
                         reply["status_only"] = {
                             "copied": True,
@@ -586,7 +576,7 @@ def run_prompt_helper() -> int:
     # Connect back to parent and send status-only reply.
     try:
         if parent_pid and not parent_alive(parent_pid):
-            print("Parent gone; discarding reply.", file=sys.stderr)
+            theme.error("Parent gone; discarding reply.")
             return 1
         conn = ipc.connect(address, authkey)
         try:
@@ -607,15 +597,15 @@ def run_prompt_helper() -> int:
         finally:
             conn.close()
     except Exception as e:  # noqa: BLE001
-        print(f"Failed to reply to parent: {e}", file=sys.stderr)
+        theme.error(f"Failed to reply to parent: {e}")
         input("Press Enter to close...")
         return 1
 
     cancel["flag"] = True
     if reply.get("ok"):
-        print("Done.")
+        theme.success("Done.")
     else:
-        print(f"Failed: {reply.get('reason', 'unknown')}")
+        theme.out(f"Failed: {reply.get('reason', 'unknown')}")
     # Brief pause so user can read the console before it closes.
     time.sleep(0.8)
     return 0 if reply.get("ok") else 1

--- a/src/key_amnesia/theme.py
+++ b/src/key_amnesia/theme.py
@@ -1,0 +1,36 @@
+"""CLI output helpers (Phase 0: plain print; branding lands later)."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+
+def info(msg: Any = "", **kwargs: Any) -> None:
+    kwargs.setdefault("file", sys.stdout)
+    print(msg, **kwargs)
+
+
+def success(msg: Any = "", **kwargs: Any) -> None:
+    kwargs.setdefault("file", sys.stdout)
+    print(msg, **kwargs)
+
+
+def warn(msg: Any = "", **kwargs: Any) -> None:
+    kwargs.setdefault("file", sys.stderr)
+    print(msg, **kwargs)
+
+
+def error(msg: Any = "", **kwargs: Any) -> None:
+    kwargs.setdefault("file", sys.stderr)
+    print(msg, **kwargs)
+
+
+def out(msg: Any = "", **kwargs: Any) -> None:
+    kwargs.setdefault("file", sys.stdout)
+    print(msg, **kwargs)
+
+
+def err(msg: Any = "", **kwargs: Any) -> None:
+    kwargs.setdefault("file", sys.stderr)
+    print(msg, **kwargs)


### PR DESCRIPTION
## Summary
- Add `theme.py` plain print wrappers and wire user-facing output in `cli.py`, `prompt_route.py`, and `guard.py` (raw reveal values and scrubbed run relays stay on `sys.stdout`/`stderr.write`).
- Add `platform.spawn_isolated_console` with the Windows `CREATE_NEW_CONSOLE` body and `popen_fn` passthrough; `prompt_route` builds env then delegates.
- Update DESIGN package tree for the Phase 0 seams only (no visual/Linux behavior yet).

## Test plan
- [x] `python -m pytest -q` → 33 passed, 1 skipped
- [ ] Spot-check `ka status` / `ka list` still print plain lines
- [ ] Spot-check interactive `reveal` still emits undecorated secret values