### PR TITLE
Add agent usage skill (Workstream C)

### DIFF
--- a/docs/agent-usage.md
+++ b/docs/agent-usage.md
@@ -1,0 +1,48 @@
+# Agent usage with key-amnesia
+
+How humans and AI agents should use `ka` so secrets stay out of chat, logs, and agent context.
+
+## The contract
+
+- Agents may **trigger** commands that need secrets.
+- Agents must **never** read vault values.
+- Humans type the master password (and secret values on `set`) at a real keyboard — in their own TTY, or in the isolated approval console when an agent invokes a privileged command.
+
+There is no MCP “get secret” API. That is intentional.
+
+## What agents should do
+
+1. Discover secret names with `ka list` (safe; names only; no password).
+2. Run tools through injection:
+
+   ```bash
+   ka run --secret OPENAI_API_KEY --as OPENAI_API_KEY -- python my_script.py
+   ```
+
+3. Use scrubbed stdout/stderr and the exit code. Do not try to recover the original secret from output.
+
+## What agents must not do
+
+- Paste API keys or passwords into chat, commits, `.env` files, or command lines.
+- Call `ka reveal` / `ka copy` to obtain a value for the agent. Even if invoked by an agent, the value appears only for the human (TTY or helper window / clipboard); the agent process gets a status flag only.
+- Rely on a cached session (`ka unlock`) to unlock `reveal` or `copy` — it does not. Fresh human auth is always required for those commands (and for `remove`, `config set`, and `set`).
+- Run `ka init` non-interactively. Vault creation is TTY-only with a double-confirmed master password. If the vault is missing, the human runs `ka init` locally.
+
+## Human-only commands (summary)
+
+| Command | Why |
+|---------|-----|
+| `ka init` | TTY-only; creates the vault |
+| `ka set` | Stores a value; password required; prefer hidden prompt over inline argv |
+| `ka remove` | Deletes a secret; password required |
+| `ka config set` | Changes settings; password required |
+| `ka reveal` / `ka copy` | Surfaces a value to the human only; always fresh auth |
+
+## Cached vs per-call
+
+- **per-call** (default): each privileged use prompts.
+- **cached**: after `ka unlock`, `run` and `list` can proceed without prompts until timeout or `ka lock`. `reveal` / `copy` still always prompt.
+
+## Related
+
+Agent-oriented short form: [skills/using-key-amnesia/SKILL.md](../skills/using-key-amnesia/SKILL.md).

--- a/skills/using-key-amnesia/SKILL.md
+++ b/skills/using-key-amnesia/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: using-key-amnesia
+description: >-
+  Use key-amnesia (`ka`) so agents can run commands with secrets without ever
+  reading vault values. Prefer `ka run --secret/--as`; use `ka list` for names
+  only. Never paste keys into chat, argv, or files the agent can read. Use when
+  needing API keys, passwords, env injection, vault secrets, or `ka`/`key-amnesia`
+  commands.
+---
+
+# Using key-amnesia
+
+key-amnesia lets you **use** secrets without **seeing** them. Values are injected into a child process environment; scrubbed output comes back. There is no MCP server and no agent path that returns raw vault values.
+
+## Preferred pattern
+
+```bash
+ka run --secret NAME --as ENV_VAR -- <command> [args...]
+```
+
+- Inject secrets only via `--secret` / `--as`. Never paste keys into chat, scripts, `.env`, or command argv.
+- Multiple secrets: repeat `--secret` / `--as` pairs as needed.
+- Prefer discovering names with `ka list` before inventing them.
+
+## Safe for agents
+
+| Action | OK? | Notes |
+|--------|-----|-------|
+| `ka run --secret … --as … -- …` | Yes | Primary agent path; may prompt the human |
+| `ka list` | Yes | Names only; no password; never values |
+| `ka status` | Yes | Session metadata only |
+| `ka unlock` / `ka lock` | Human | Cached-session control; human TTY / approval |
+| Reading vault files / inventing `get-value` | **No** | Guard has no value-return verb |
+
+## Always human (do not rely on agent automation)
+
+These always require a fresh human password prompt (or fail closed). A **cached session does not unlock** them:
+
+- `ka reveal NAME` — value shown only to the human (TTY or helper window); agent gets status only
+- `ka copy NAME` — clipboard for the human only; same rule
+- `ka remove NAME`
+- `ka config set …`
+- `ka set NAME` — prefer interactive value entry; avoid `ka set NAME VALUE` (value briefly on argv)
+
+**`ka init`** is human **TTY-only**: double-confirm master password; never route through agent/spawned-console flows. If no vault exists, tell the user to run `ka init` themselves — do not attempt it non-interactively.
+
+## Cached session caveat
+
+`ka unlock` (with `session-mode cached`) lets subsequent `ka run` / `ka list` skip prompts until timeout or `ka lock`. It does **not** authorize `reveal` or `copy`. Never treat an open session as permission to surface secret values.
+
+## Anti-patterns
+
+- Pasting secrets into chat or committing them to the repo
+- Running tools that print env/secrets and expecting to "just look"
+- Calling `reveal`/`copy` to "check" a value for the agent
+- Creating the vault via agent-driven `init`
+- Assuming a live guard can return raw values over IPC — it cannot
+
+## Human reference
+
+Longer prose for operators: [docs/agent-usage.md](../../docs/agent-usage.md).


### PR DESCRIPTION
## Summary
- Add `skills/using-key-amnesia/SKILL.md` teaching agents to prefer `ka run --secret/--as`, never read vault values, and treat `list` as safe (names only).
- Document that `reveal`/`copy`/`remove`/`config set`/`set` always require a human prompt, `init` is TTY-only, and a cached session does not unlock `reveal`/`copy`.
- Optional human mirror at `docs/agent-usage.md`. No `src/` changes.

## Test plan
- [ ] Confirm PR diff contains only `skills/using-key-amnesia/SKILL.md` and `docs/agent-usage.md`
- [ ] Skim skill frontmatter + body for the rules above
- [ ] No pytest impact expected (docs-only)
