### PR TITLE
Add Linux isolated-console spawn

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted vault storage, Windows `CREATE_NEW_CONSOLE` human-prompt routing, a bounded-capability cached guard over named-pipe IPC (authkey only), and buffer-then-scrub output redaction.
 
-**Out of scope for v0:** browser injection, MCP wrapper, GUI, POSIX terminal-spawn equivalent, DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
+**Out of scope for v0:** browser injection, MCP wrapper, GUI, macOS isolated-console spawn (`Terminal.app` / `osascript`), DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
 
 ---
 
@@ -31,7 +31,7 @@ key-amnesia/
     run_exec.py                    # buffer-then-scrub-then-relay
     clipboard.py
     theme.py                       # CLI output helpers (Phase 0 seam; plain print today)
-    platform.py                    # isolated-console spawn (Phase 0 seam; Windows only today)
+    platform.py                    # isolated-console spawn (Windows CREATE_NEW_CONSOLE; Linux terminal emulators)
   tests/
 ```
 
@@ -39,7 +39,7 @@ Entry points: `key-amnesia` and `ka` both → `key_amnesia.cli:main`.
 
 Deps: `pynacl`, `pyperclip`. Dev: `pytest`.
 
-**Phase 0 seams:** `theme.py` and `platform.py` exist so later branding and Linux spawn can land without thrashing `cli.py` / `prompt_route.py`. They are extraction-only today — no visual theme and no non-Windows spawn behavior yet.
+**Phase 0 seams:** `theme.py` and `platform.py` exist so branding and Linux spawn can land without thrashing `cli.py` / `prompt_route.py`. `theme.py` remains extraction-only (plain print) until Workstream B; `platform.py` spawns isolated consoles on Windows and Linux.
 
 ---
 
@@ -85,8 +85,11 @@ Whole-vault AEAD cannot list names without the password. Sidecar `~/.key-amnesia
 Needs human auth
   → stdin.isatty?
       yes → getpass/input inline → KDF decrypt in-process
-      no  → Popen helper CREATE_NEW_CONSOLE (bare argv, env handoff)
-              → console ok? no → fail closed
+      no  → spawn isolated console (bare argv, env handoff)
+              → Windows: CREATE_NEW_CONSOLE
+              → Linux: first of x-terminal-emulator / gnome-terminal / konsole / xterm
+                (requires DISPLAY or WAYLAND_DISPLAY)
+              → macOS / other / headless / no emulator → fail closed
               → parent waits on IPC (timeout 90s)
               → helper already did KDF locally; status-only reply
 ```
@@ -104,7 +107,7 @@ Helper behavior after env handoff:
 - Prints clear UX, collects input, KDF/decrypts in-process.
 - Watches parent PID / IPC disconnect → cancel and exit (no orphan window).
 - Parent receives status-only replies — never password, never raw secrets.
-- **POSIX non-interactive spawn: out of scope for v0; fail closed / unsupported.**
+- **Linux non-interactive spawn:** try `x-terminal-emulator`, then `gnome-terminal`, `konsole`, `xterm` (first on `PATH`). Headless (no `DISPLAY` / `WAYLAND_DISPLAY`), missing emulator, or spawn failure → fail closed. **macOS isolated-console spawn remains out of scope** (fail closed).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install git+https://github.com/fujitoid/key-amnesia
 
 Or from a local clone: `pip install .` — either way you get both the full `key-amnesia` command and the short `ka` alias.
 
-> **Windows-first.** v0 targets Windows. On Linux/Mac the interactive commands work in your own terminal, but the pop-up-console flow for agent-triggered approval is not implemented yet (such calls fail safely with a clear error).
+> Windows and Linux supported; macOS still falls back to fail-closed (not yet implemented).
 
 ## Two modes: ask every time, or unlock a session
 

--- a/src/key_amnesia/platform.py
+++ b/src/key_amnesia/platform.py
@@ -1,10 +1,62 @@
-"""OS-specific process spawn helpers (Phase 0: Windows CREATE_NEW_CONSOLE only)."""
+"""OS-specific process spawn helpers for isolated-console prompts."""
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 import sys
 from typing import Any, Callable
+
+# Linux X11/Wayland terminal emulators, tried in order (first on PATH wins).
+_LINUX_EMULATORS: tuple[str, ...] = (
+    "x-terminal-emulator",
+    "gnome-terminal",
+    "konsole",
+    "xterm",
+)
+
+
+def _has_interactive_display() -> bool:
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _linux_emulator_argv(emulator: str, argv: list[str]) -> list[str]:
+    """Build emulator + helper argv. Secrets stay in env, never on argv."""
+    name = os.path.basename(emulator)
+    if name == "gnome-terminal":
+        # gnome-terminal deprecated -e; -- separates options from the command.
+        return [emulator, "--", *argv]
+    return [emulator, "-e", *argv]
+
+
+def _spawn_linux(
+    argv: list[str],
+    env: dict[str, str],
+    *,
+    popen_fn: Callable[..., Any],
+) -> Any:
+    if not _has_interactive_display():
+        raise OSError(
+            "No interactive display available (DISPLAY/WAYLAND_DISPLAY unset); "
+            "cannot spawn isolated console. Fail closed."
+        )
+
+    for name in _LINUX_EMULATORS:
+        path = shutil.which(name)
+        if not path:
+            continue
+        cmd = _linux_emulator_argv(path, argv)
+        try:
+            # No stdin/stdout/stderr kwargs — emulator owns stdio.
+            return popen_fn(cmd, env=env, close_fds=True)
+        except OSError:
+            continue
+
+    raise OSError(
+        "No suitable terminal emulator found "
+        f"(tried {', '.join(_LINUX_EMULATORS)}). Fail closed."
+    )
 
 
 def spawn_isolated_console(
@@ -16,20 +68,26 @@ def spawn_isolated_console(
     """Spawn *argv* in an isolated console; sensitive data only in *env*.
 
     Windows: CREATE_NEW_CONSOLE, no stdio kwargs.
-    Non-win32: fail closed (POSIX console spawn is out of scope for v0).
+    Linux: first available of x-terminal-emulator / gnome-terminal / konsole /
+    xterm when DISPLAY or WAYLAND_DISPLAY is set; otherwise fail closed.
+    macOS and other platforms: fail closed (not yet implemented).
     """
-    if sys.platform != "win32":
-        raise OSError(
-            "Non-interactive prompt spawn is Windows-only in v0; "
-            "POSIX console spawn is out of scope. Fail closed."
+    popen = popen_fn or subprocess.Popen
+
+    if sys.platform == "win32":
+        creationflags = subprocess.CREATE_NEW_CONSOLE  # type: ignore[attr-defined]
+        # No stdin/stdout/stderr kwargs — new console owns stdio.
+        return popen(
+            argv,
+            env=env,
+            creationflags=creationflags,
+            close_fds=False,
         )
 
-    creationflags = subprocess.CREATE_NEW_CONSOLE  # type: ignore[attr-defined]
-    popen = popen_fn or subprocess.Popen
-    # No stdin/stdout/stderr kwargs — new console owns stdio.
-    return popen(
-        argv,
-        env=env,
-        creationflags=creationflags,
-        close_fds=False,
+    if sys.platform.startswith("linux"):
+        return _spawn_linux(argv, env, popen_fn=popen)
+
+    raise OSError(
+        "Isolated-console spawn is not implemented on this platform "
+        f"({sys.platform}); macOS and others remain fail-closed. Fail closed."
     )

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -1,0 +1,151 @@
+"""Linux isolated-console spawn: emulator choice, env handoff, fail-closed."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from key_amnesia.platform import spawn_isolated_console
+
+
+HELPER_ARGV = [sys.executable, "-m", "key_amnesia", "_prompt-helper"]
+SENSITIVE_ENV = {
+    "PATH": "/usr/bin",
+    "KEY_AMNESIA_PROMPT_REQUEST": '{"action":"reveal","secret_names":["api_key"]}',
+    "KEY_AMNESIA_PROMPT_AUTHKEY": "a" * 64,
+    "KEY_AMNESIA_PROMPT_ADDRESS": "/tmp/key-amnesia-test.sock",
+    "DISPLAY": ":0",
+}
+
+
+def _fake_which(available: dict[str, str]):
+    def which(name: str) -> str | None:
+        return available.get(name)
+
+    return which
+
+
+def test_linux_prefers_x_terminal_emulator(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which(
+            {
+                "x-terminal-emulator": "/usr/bin/x-terminal-emulator",
+                "gnome-terminal": "/usr/bin/gnome-terminal",
+                "xterm": "/usr/bin/xterm",
+            }
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "/usr/bin/x-terminal-emulator"
+    assert cmd[1] == "-e"
+    assert cmd[2:] == HELPER_ARGV
+    assert "_prompt-helper" in cmd
+    joined = " ".join(cmd)
+    assert "api_key" not in joined
+    assert "authkey" not in joined.lower()
+    assert "a" * 64 not in joined
+
+    kwargs = captured["kwargs"]
+    assert "stdin" not in kwargs
+    assert "stdout" not in kwargs
+    assert "stderr" not in kwargs
+    assert kwargs["env"]["KEY_AMNESIA_PROMPT_AUTHKEY"] == "a" * 64
+    assert kwargs["env"]["KEY_AMNESIA_PROMPT_REQUEST"]
+
+
+def test_linux_falls_through_to_gnome_terminal(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which({"gnome-terminal": "/usr/bin/gnome-terminal"}),
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
+
+    assert captured["cmd"] == [
+        "/usr/bin/gnome-terminal",
+        "--",
+        *HELPER_ARGV,
+    ]
+
+
+def test_linux_konsole_and_xterm_wiring(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":1")
+
+    for name, path in (
+        ("konsole", "/usr/bin/konsole"),
+        ("xterm", "/usr/bin/xterm"),
+    ):
+        monkeypatch.setattr(
+            "key_amnesia.platform.shutil.which",
+            _fake_which({name: path}),
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return MagicMock()
+
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
+        assert captured["cmd"] == [path, "-e", *HELPER_ARGV]
+
+
+def test_linux_headless_fail_closed(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    with pytest.raises(OSError, match="DISPLAY/WAYLAND_DISPLAY|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
+
+
+def test_linux_no_emulator_fail_closed(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which({}),
+    )
+
+    with pytest.raises(OSError, match="terminal emulator|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
+
+
+def test_darwin_fail_closed(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("DISPLAY", ":0")
+
+    with pytest.raises(OSError, match="not implemented|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
+
+
+def test_other_platform_fail_closed(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "freebsd14")
+
+    with pytest.raises(OSError, match="not implemented|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())

--- a/tests/test_prompt_route.py
+++ b/tests/test_prompt_route.py
@@ -78,12 +78,22 @@ def test_noninteractive_spawns_create_new_console_bare_argv_env(
 
 
 def test_posix_noninteractive_fail_closed(monkeypatch) -> None:
+    """Headless / non-Linux POSIX still fails closed (no insecure fallback)."""
     if sys.platform == "win32":
         pytest.skip("POSIX fail-closed path")
+    # Force headless so Linux CI with a display still hits fail-closed.
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     req = PromptRequest(action="reveal", secret_names=["x"])
     outcome = require_human_auth(req, timeout_s=1, isatty_fn=lambda: False)
     assert outcome.ok is False
-    assert "Windows-only" in outcome.reason or "out of scope" in outcome.reason.lower()
+    reason = (outcome.reason or "").lower()
+    assert (
+        "fail closed" in reason
+        or "display" in reason
+        or "not implemented" in reason
+        or "terminal emulator" in reason
+    )
 
 
 def test_inline_auth_returns_password(ka_home) -> None:


### PR DESCRIPTION
## Summary
- Linux `platform.spawn_isolated_console` tries `x-terminal-emulator` → `gnome-terminal` → `konsole` → `xterm` with the same bare helper argv and env handoff as Windows
- Headless (no DISPLAY/WAYLAND_DISPLAY), missing emulator, darwin/other platforms remain fail-closed
- Docs: README Install caveat + DESIGN Linux spawn / macOS still out of scope; `test_posix.py` + updated POSIX fail-closed prompt_route test

## Test plan
- [x] `pytest tests/test_posix.py` + affected prompt_route spawn tests (8 passed, 1 skipped on Windows)
- [ ] Confirm Linux with DISPLAY + an emulator can spawn the helper window
- [ ] Confirm headless Linux still fails closed with a clear error