### PR TITLE
v1 Workstream B: branded CLI theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ No tool in this class can promise absolute secrecy, and we'd rather tell you exa
 7. **The master password never crosses any inter-process channel**, in any form — it's consumed only inside the process that prompted you for it.
 8. **Avoid `ka set NAME VALUE` with the value inline.** It's supported for scripting, but an inline value briefly appears on the calling process's command line — visible to same-user process inspection and Windows command-line auditing. Prefer plain `ka set NAME` and type the value at the hidden prompt. (If an agent tries the inline form, the approval window shows you the incoming value before asking for your password — so you can still deny it.)
 
+## CLI appearance
+
+On a real terminal, status lines use a restrained brand palette (teal for info/success, amber for warnings, red only for hard denials). Set `NO_COLOR` or redirect output to a pipe/file and all ANSI escapes are omitted — agent-facing and scrubbed paths stay plain text. Glyphs fall back to ASCII (`[OK]` / `[DENIED]` / `[LOCKED]`) when color or unicode is unavailable. Scrubbed command output and raw revealed secret values are never styled.
+
 ## Development
 
 ```bash

--- a/src/key_amnesia/theme.py
+++ b/src/key_amnesia/theme.py
@@ -1,36 +1,234 @@
-"""CLI output helpers (Phase 0: plain print; branding lands later)."""
+"""Branded CLI output helpers.
+
+Palette (forged/tempered restraint — one accent per state):
+  teal  #00E5FF  — info / success
+  amber #E0A458  — warn / prompt
+  red   #E85D5D  — hard denials only
+  slate #8B9AAB  — neutrals / non-denial errors
+
+Respects NO_COLOR and non-TTY streams: never emits escapes when not a TTY
+(agent parsing / scrubbing safety). Glyphs fall back to ASCII when unicode
+or color is unsupported.
+
+Scrubbed run relays and raw revealed secret values must NEVER go through
+these helpers — keep those on plain sys.stdout/stderr.write.
+"""
 
 from __future__ import annotations
 
+import os
+import re
 import sys
-from typing import Any
+from typing import Any, TextIO
+
+# --- palette -----------------------------------------------------------------
+
+_TEAL = (0, 229, 255)  # #00E5FF
+_AMBER = (224, 164, 88)  # #E0A458
+_RED = (232, 93, 93)  # #E85D5D — hard denials only
+_SLATE = (139, 154, 171)  # #8B9AAB
+
+# Approximate 256-color indices for the same hues
+_TEAL_256 = 51
+_AMBER_256 = 179
+_RED_256 = 167
+_SLATE_256 = 109
+
+_RESET = "\033[0m"
+_CSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+# Glyphs (unicode) / ASCII fallbacks
+_OK_U, _OK_A = "✓", "[OK]"
+_DENIED_U, _DENIED_A = "✗", "[DENIED]"
+_LOCKED_U, _LOCKED_A = "🔒", "[LOCKED]"
+
+_VT_ENABLED = False
+
+
+def _enable_windows_vt() -> None:
+    """Best-effort enable ANSI VT processing on Windows consoles."""
+    global _VT_ENABLED
+    if _VT_ENABLED or sys.platform != "win32":
+        return
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        enable = 0x0004  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        for std_id in (-11, -12):  # STD_OUTPUT_HANDLE, STD_ERROR_HANDLE
+            handle = kernel32.GetStdHandle(std_id)
+            mode = ctypes.c_uint32()
+            if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                kernel32.SetConsoleMode(handle, mode.value | enable)
+        _VT_ENABLED = True
+    except Exception:
+        pass
+
+
+def _no_color_env() -> bool:
+    return bool(os.environ.get("NO_COLOR"))
+
+
+def _stream_is_tty(stream: TextIO) -> bool:
+    try:
+        return bool(stream.isatty())
+    except Exception:
+        return False
+
+
+def color_enabled(stream: TextIO | None = None) -> bool:
+    """True when ANSI color escapes may be emitted on *stream*."""
+    if _no_color_env():
+        return False
+    target = stream if stream is not None else sys.stdout
+    if not _stream_is_tty(target):
+        return False
+    _enable_windows_vt()
+    return True
+
+
+def _color_mode(stream: TextIO) -> str | None:
+    """Return 'truecolor', '256', or None."""
+    if not color_enabled(stream):
+        return None
+    colorterm = (os.environ.get("COLORTERM") or "").lower()
+    if "truecolor" in colorterm or "24bit" in colorterm:
+        return "truecolor"
+    # Modern Windows Terminal / conhost VT: prefer truecolor
+    if sys.platform == "win32" and (
+        os.environ.get("WT_SESSION")
+        or os.environ.get("TERM_PROGRAM") == "vscode"
+        or _VT_ENABLED
+    ):
+        return "truecolor"
+    term = (os.environ.get("TERM") or "").lower()
+    if "256color" in term or term in ("xterm-kitty", "alacritty", "wezterm"):
+        return "256"
+    if term and term not in ("dumb",):
+        return "256"
+    return "truecolor"
+
+
+def unicode_enabled(stream: TextIO | None = None) -> bool:
+    """True when unicode glyphs are safe to emit on *stream*."""
+    if not color_enabled(stream):
+        # Plain / agent-facing paths: stick to ASCII for parseability
+        return False
+    target = stream if stream is not None else sys.stdout
+    encoding = getattr(target, "encoding", None) or "utf-8"
+    try:
+        (_OK_U + _DENIED_U + _LOCKED_U).encode(encoding)
+        return True
+    except (LookupError, UnicodeEncodeError):
+        return False
+
+
+def _fg(rgb: tuple[int, int, int], idx256: int, stream: TextIO) -> str:
+    mode = _color_mode(stream)
+    if mode is None:
+        return ""
+    if mode == "truecolor":
+        r, g, b = rgb
+        return f"\033[38;2;{r};{g};{b}m"
+    return f"\033[38;5;{idx256}m"
+
+
+def _paint(msg: str, rgb: tuple[int, int, int], idx256: int, stream: TextIO) -> str:
+    prefix = _fg(rgb, idx256, stream)
+    if not prefix:
+        return msg
+    return f"{prefix}{msg}{_RESET}"
+
+
+def _glyph(kind: str, stream: TextIO) -> str:
+    use_u = unicode_enabled(stream)
+    if kind == "ok":
+        return _OK_U if use_u else _OK_A
+    if kind == "denied":
+        return _DENIED_U if use_u else _DENIED_A
+    if kind == "locked":
+        return _LOCKED_U if use_u else _LOCKED_A
+    return ""
+
+
+def _is_denial(msg: Any) -> bool:
+    text = str(msg).lstrip()
+    return text.lower().startswith("denied")
+
+
+def _is_locked(msg: Any) -> bool:
+    text = str(msg).lstrip()
+    return text.lower().startswith("locked")
+
+
+def _is_rule(msg: Any) -> bool:
+    text = str(msg)
+    return len(text) >= 3 and set(text) <= {"=", "─", "-", "═"}
+
+
+def _emit(msg: Any, *, stream: TextIO, style: str | None = None, **kwargs: Any) -> None:
+    text = "" if msg is None else str(msg)
+    if style == "success":
+        if _is_locked(text):
+            g = _glyph("locked", stream)
+        else:
+            g = _glyph("ok", stream)
+        body = f"{g} {text}" if text else g
+        text = _paint(body, _TEAL, _TEAL_256, stream)
+    elif style == "info":
+        if _is_rule(text):
+            text = _paint(text, _SLATE, _SLATE_256, stream)
+        else:
+            text = _paint(text, _TEAL, _TEAL_256, stream)
+    elif style == "warn":
+        text = _paint(text, _AMBER, _AMBER_256, stream)
+    elif style == "error":
+        if _is_denial(text):
+            g = _glyph("denied", stream)
+            body = f"{g} {text}" if text else g
+            text = _paint(body, _RED, _RED_256, stream)
+        else:
+            text = _paint(text, _SLATE, _SLATE_256, stream)
+    elif style == "out":
+        # Neutrals — slate only for sparse rule lines; otherwise plain
+        if _is_rule(text):
+            text = _paint(text, _SLATE, _SLATE_256, stream)
+    # style None / "err": plain (no accent)
+
+    kwargs.setdefault("file", stream)
+    print(text, **kwargs)
 
 
 def info(msg: Any = "", **kwargs: Any) -> None:
-    kwargs.setdefault("file", sys.stdout)
-    print(msg, **kwargs)
+    stream = kwargs.pop("file", sys.stdout)
+    _emit(msg, stream=stream, style="info", **kwargs)
 
 
 def success(msg: Any = "", **kwargs: Any) -> None:
-    kwargs.setdefault("file", sys.stdout)
-    print(msg, **kwargs)
+    stream = kwargs.pop("file", sys.stdout)
+    _emit(msg, stream=stream, style="success", **kwargs)
 
 
 def warn(msg: Any = "", **kwargs: Any) -> None:
-    kwargs.setdefault("file", sys.stderr)
-    print(msg, **kwargs)
+    stream = kwargs.pop("file", sys.stderr)
+    _emit(msg, stream=stream, style="warn", **kwargs)
 
 
 def error(msg: Any = "", **kwargs: Any) -> None:
-    kwargs.setdefault("file", sys.stderr)
-    print(msg, **kwargs)
+    stream = kwargs.pop("file", sys.stderr)
+    _emit(msg, stream=stream, style="error", **kwargs)
 
 
 def out(msg: Any = "", **kwargs: Any) -> None:
-    kwargs.setdefault("file", sys.stdout)
-    print(msg, **kwargs)
+    stream = kwargs.pop("file", sys.stdout)
+    _emit(msg, stream=stream, style="out", **kwargs)
 
 
 def err(msg: Any = "", **kwargs: Any) -> None:
-    kwargs.setdefault("file", sys.stderr)
-    print(msg, **kwargs)
+    stream = kwargs.pop("file", sys.stderr)
+    _emit(msg, stream=stream, style=None, **kwargs)
+
+
+# Test helpers (not part of the public CLI surface, but stable for unit tests)
+def strip_csi(text: str) -> str:
+    return _CSI_RE.sub("", text)

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,181 @@
+"""Tests for branded theme.py — color gates, CSI, ASCII glyph fallback."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from key_amnesia import theme
+
+
+class _FakeTTY:
+    """Writable stream that reports as a TTY with a fixed encoding."""
+
+    def __init__(self, encoding: str = "utf-8") -> None:
+        self._buf = io.StringIO()
+        self.encoding = encoding
+
+    def isatty(self) -> bool:
+        return True
+
+    def write(self, s: str) -> int:
+        return self._buf.write(s)
+
+    def flush(self) -> None:
+        self._buf.flush()
+
+    def getvalue(self) -> str:
+        return self._buf.getvalue()
+
+
+class _FakePipe:
+    """Writable stream that reports as a non-TTY (agent / capture path)."""
+
+    encoding = "utf-8"
+
+    def __init__(self) -> None:
+        self._buf = io.StringIO()
+
+    def isatty(self) -> bool:
+        return False
+
+    def write(self, s: str) -> int:
+        return self._buf.write(s)
+
+    def flush(self) -> None:
+        self._buf.flush()
+
+    def getvalue(self) -> str:
+        return self._buf.getvalue()
+
+
+def test_no_color_env_suppresses_escapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    buf = _FakeTTY()
+    theme.success("Vault ready", file=buf)
+    theme.error("Denied: no", file=buf)
+    out = buf.getvalue()
+    assert "\033[" not in out
+    assert "Vault ready" in out
+    assert "Denied: no" in out
+
+
+def test_non_tty_suppresses_escapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    buf = _FakePipe()
+    theme.success("ok line", file=buf)
+    theme.error("Denied: nope", file=buf)
+    theme.warn("careful", file=buf)
+    theme.info("note", file=buf)
+    out = buf.getvalue()
+    assert "\033[" not in out
+    assert "ok line" in out
+    assert "Denied: nope" in out
+
+
+def test_tty_color_success_uses_teal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    buf = _FakeTTY()
+    theme.success("Vault initialized", file=buf)
+    out = buf.getvalue()
+    assert "\033[38;2;0;229;255m" in out  # teal #00E5FF
+    assert "\033[0m" in out
+    assert "Vault initialized" in theme.strip_csi(out)
+
+
+def test_tty_color_denial_uses_red(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    buf = _FakeTTY()
+    theme.error("Denied: timeout", file=buf)
+    out = buf.getvalue()
+    assert "\033[38;2;232;93;93m" in out  # denial red
+    assert "Denied: timeout" in theme.strip_csi(out)
+
+
+def test_non_denial_error_is_not_red(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    buf = _FakeTTY()
+    theme.error("Error: passwords do not match", file=buf)
+    out = buf.getvalue()
+    assert "\033[38;2;232;93;93m" not in out
+    assert "\033[38;2;139;154;171m" in out  # slate
+    assert "Error: passwords do not match" in theme.strip_csi(out)
+
+
+def test_ascii_fallback_when_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    buf = _FakeTTY()
+    theme.success("done", file=buf)
+    theme.error("Denied: x", file=buf)
+    theme.success("Locked.", file=buf)
+    out = buf.getvalue()
+    assert "[OK]" in out
+    assert "[DENIED]" in out
+    assert "[LOCKED]" in out
+    assert "✓" not in out
+    assert "✗" not in out
+    assert "🔒" not in out
+
+
+def test_ascii_fallback_on_non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    buf = _FakePipe()
+    theme.success("done", file=buf)
+    theme.error("Denied: x", file=buf)
+    out = buf.getvalue()
+    assert "[OK]" in out
+    assert "[DENIED]" in out
+
+
+def test_unicode_glyphs_on_color_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    buf = _FakeTTY(encoding="utf-8")
+    theme.success("done", file=buf)
+    theme.error("Denied: x", file=buf)
+    theme.success("Locked.", file=buf)
+    out = theme.strip_csi(buf.getvalue())
+    assert "✓" in out
+    assert "✗" in out
+    assert "🔒" in out
+    assert "[OK]" not in out
+    assert "[DENIED]" not in out
+
+
+def test_256_color_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.delenv("WT_SESSION", raising=False)
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    # Force non-Windows truecolor heuristics off for this unit test
+    monkeypatch.setattr(theme, "_VT_ENABLED", False)
+    monkeypatch.setattr(theme, "_enable_windows_vt", lambda: None)
+    buf = _FakeTTY()
+    theme.info("hello", file=buf)
+    out = buf.getvalue()
+    assert "\033[38;5;51m" in out  # teal 256
+    assert "\033[38;2;" not in out
+
+
+def test_warn_uses_amber(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    buf = _FakeTTY()
+    theme.warn("Guard session expired", file=buf)
+    out = buf.getvalue()
+    assert "\033[38;2;224;164;88m" in out  # amber #E0A458
+
+
+def test_out_and_err_plain_message_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lists / status stay undecorated aside from optional rule tinting."""
+    monkeypatch.setenv("NO_COLOR", "1")
+    buf = _FakePipe()
+    theme.out("api_key", file=buf)
+    theme.err("plain err", file=buf)
+    out = buf.getvalue()
+    assert out.splitlines() == ["api_key", "plain err"]


### PR DESCRIPTION
## Summary
- Brand `theme.py` with teal (#00E5FF) info/success, amber (#E0A458) warn, red only for hard denials, and slate neutrals; truecolor with 256-color fallback.
- Respect `NO_COLOR` and non-TTY streams (no CSI escapes); unicode glyphs fall back to ASCII `[OK]`/`[DENIED]`/`[LOCKED]`.
- Add `tests/test_theme.py` and a short README CLI appearance note (Install caveat untouched). Scrubbed relays / raw secrets remain unstyled.

## Test plan
- [x] `pytest tests/test_theme.py` — 11 passed
- [x] Sanity: `test_init` + `test_audit_cli` with theme tests — 22 passed
- [ ] Full suite after merge with Phase 0 / Workstream A
