### PR TITLE
v1: finalize DESIGN.md after workstream merges

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,6 +15,8 @@ key-amnesia/
   LICENSE                          # Apache 2.0
   .gitignore
   pyproject.toml
+  .claude/hooks/                   # PreToolUse secret hooks + install note
+  skills/                          # using-key-amnesia + chat-secret-privacy agent skills
   src/key_amnesia/
     __init__.py
     __main__.py
@@ -30,7 +32,7 @@ key-amnesia/
     guard.py
     run_exec.py                    # buffer-then-scrub-then-relay
     clipboard.py
-    theme.py                       # CLI output helpers (Phase 0 seam; plain print today)
+    theme.py                       # branded CLI output (NO_COLOR / non-TTY safe)
     platform.py                    # isolated-console spawn (Windows CREATE_NEW_CONSOLE; Linux terminal emulators)
   tests/
 ```
@@ -39,7 +41,7 @@ Entry points: `key-amnesia` and `ka` both → `key_amnesia.cli:main`.
 
 Deps: `pynacl`, `pyperclip`. Dev: `pytest`.
 
-**Phase 0 seams:** `theme.py` and `platform.py` exist so branding and Linux spawn can land without thrashing `cli.py` / `prompt_route.py`. `theme.py` remains extraction-only (plain print) until Workstream B; `platform.py` spawns isolated consoles on Windows and Linux.
+**Seams:** `theme.py` owns all branded local-console UX (respects `NO_COLOR` / non-TTY; scrubbed relays and raw reveal values stay unstyled). `platform.py` owns isolated-console spawn on Windows and Linux (macOS fail-closed).
 
 ---
 


### PR DESCRIPTION
## Summary
- Update DESIGN.md package tree to list `theme.py`, `platform.py`, `skills/`, and `.claude/hooks/` after all v1 workstreams landed.
- Refresh seam notes for branded theme + Windows/Linux spawn (macOS fail-closed).

## Test plan
- [x] Full `pytest` on master after PR #5 merge: **51 passed, 1 skipped** (was 40 passed / 1 skipped; +11 theme)
- [x] README already has Install caveat (Windows+Linux / macOS fail-closed) and CLI appearance note — no README edits needed