### PR TITLE
Bump DESIGN to v1; detect Linux emulators that exit immediately

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,8 +1,8 @@
-# key-amnesia v0 — Design
+# key-amnesia v1 — Design
 
 Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted vault storage, Windows `CREATE_NEW_CONSOLE` human-prompt routing, a bounded-capability cached guard over named-pipe IPC (authkey only), and buffer-then-scrub output redaction.
 
-**Out of scope for v0:** browser injection, MCP wrapper, GUI, macOS isolated-console spawn (`Terminal.app` / `osascript`), DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
+**Out of scope for v1:** browser injection (planned as a distinct v3 sub-project), MCP wrapper, GUI, macOS isolated-console spawn (`Terminal.app` / `osascript`), DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
 
 ---
 
@@ -63,7 +63,7 @@ KDF: `argon2id.kdf` with **OPSLIMIT_SENSITIVE / MEMLIMIT_SENSITIVE only** (delib
 
 Whole-vault AEAD cannot list names without the password. Sidecar `~/.key-amnesia/vault.names.json` = `{"names":[...]}` updated on every successful `set`/`remove`.
 
-**Tradeoff:** secret *names* are plaintext at rest on disk; values never are. Acceptable for v0 to keep `list` agent-callable with no prompt. Future option (DPAPI-protect sidecar on Windows) is explicitly out of scope for v0.
+**Tradeoff:** secret *names* are plaintext at rest on disk; values never are. Acceptable for v1 to keep `list` agent-callable with no prompt. Future option (DPAPI-protect sidecar on Windows) is explicitly out of scope for v1.
 
 ### Config (`config.json`)
 
@@ -115,7 +115,7 @@ Helper behavior after env handoff:
 
 ## Output scrubbing (buffer-then-scrub-then-relay)
 
-**No streaming in v0.** For every `run` path (CLI per-call, helper per-call, guard):
+**No streaming in v1.** For every `run` path (CLI per-call, helper per-call, guard):
 
 1. Collect the child’s stdout and stderr **fully** as bytes (`communicate()` / equivalent).
 2. Decode each stream once at the end.
@@ -204,4 +204,4 @@ The guard and helper IPC replies expose only: status, scrubbed stdout/stderr, ex
 
 ## Testing
 
-Vault round-trip / wrong password / tamper; `init` mismatch creates nothing, match creates an unlockable vault, refuses if a vault already exists; `set` refuses when no vault exists yet; scrubbing on both per-call and guard paths; crafted IPC client never gets raw values; `isatty=False` asserts `CREATE_NEW_CONSOLE`, bare argv, env handoff; password never in IPC; reveal/copy non-interactive returns status only; helper parent-death cancels; unlock→run→lock→fallback; reveal/copy ignore live guard; config/remove/`set` need password; audit with no plaintext; `--help` (including `init`); scrubber uses replace not regex.
+Vault round-trip / wrong password / tamper; `init` mismatch creates nothing, match creates an unlockable vault, refuses if a vault already exists; `set` refuses when no vault exists yet; scrubbing on both per-call and guard paths; crafted IPC client never gets raw values; `isatty=False` asserts `CREATE_NEW_CONSOLE`, bare argv, env handoff; password never in IPC; reveal/copy non-interactive returns status only; helper parent-death cancels; unlock→run→lock→fallback; reveal/copy ignore live guard; config/remove/`set` need password; audit with no plaintext; `--help` (including `init`); scrubber uses replace not regex; Linux emulator selection order and env/argv handoff, immediate-exit fallthrough to the next emulator, headless and no-emulator fail-closed, macOS/other-platform fail-closed (`test_posix.py`); themed output respects `NO_COLOR` and non-TTY streams, ASCII glyph fallback, scrubbed/revealed values stay unstyled (`test_theme.py`).

--- a/src/key_amnesia/platform.py
+++ b/src/key_amnesia/platform.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from typing import Any, Callable
 
 # Linux X11/Wayland terminal emulators, tried in order (first on PATH wins).
@@ -15,6 +16,11 @@ _LINUX_EMULATORS: tuple[str, ...] = (
     "konsole",
     "xterm",
 )
+
+# Brief pause after spawn to catch an emulator that launches then exits right
+# away (e.g. a broken alias, or a build that doesn't accept our -e/-- flag).
+# Overridable so tests don't pay this cost.
+_POLL_DELAY_S = 0.15
 
 
 def _has_interactive_display() -> bool:
@@ -30,6 +36,22 @@ def _linux_emulator_argv(emulator: str, argv: list[str]) -> list[str]:
     return [emulator, "-e", *argv]
 
 
+def _process_alive(proc: Any) -> bool:
+    """Best-effort liveness check shortly after spawn.
+
+    Treat a stub without a working `.poll()` (e.g. an unconfigured test
+    double) as alive rather than reject it — this only needs to catch a
+    *real* process that has already exited.
+    """
+    poll = getattr(proc, "poll", None)
+    if not callable(poll):
+        return True
+    try:
+        return poll() is None
+    except Exception:
+        return True
+
+
 def _spawn_linux(
     argv: list[str],
     env: dict[str, str],
@@ -42,17 +64,31 @@ def _spawn_linux(
             "cannot spawn isolated console. Fail closed."
         )
 
+    tried: list[str] = []
     for name in _LINUX_EMULATORS:
         path = shutil.which(name)
         if not path:
             continue
+        tried.append(name)
         cmd = _linux_emulator_argv(path, argv)
         try:
             # No stdin/stdout/stderr kwargs — emulator owns stdio.
-            return popen_fn(cmd, env=env, close_fds=True)
+            proc = popen_fn(cmd, env=env, close_fds=True)
         except OSError:
             continue
+        if _POLL_DELAY_S:
+            time.sleep(_POLL_DELAY_S)
+        if _process_alive(proc):
+            return proc
+        # Launched but exited immediately (bad invocation, broken alias) —
+        # don't report false success; try the next emulator instead.
+        continue
 
+    if tried:
+        raise OSError(
+            f"Terminal emulator(s) found ({', '.join(tried)}) but none stayed "
+            "running (bad invocation or immediate exit). Fail closed."
+        )
     raise OSError(
         "No suitable terminal emulator found "
         f"(tried {', '.join(_LINUX_EMULATORS)}). Fail closed."

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -28,6 +28,12 @@ def _fake_which(available: dict[str, str]):
     return which
 
 
+@pytest.fixture(autouse=True)
+def _no_poll_delay(monkeypatch):
+    """Skip the real post-spawn liveness pause so this suite stays fast."""
+    monkeypatch.setattr("key_amnesia.platform._POLL_DELAY_S", 0)
+
+
 def test_linux_prefers_x_terminal_emulator(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setenv("DISPLAY", ":0")
@@ -47,7 +53,9 @@ def test_linux_prefers_x_terminal_emulator(monkeypatch) -> None:
     def fake_popen(cmd, **kwargs):
         captured["cmd"] = cmd
         captured["kwargs"] = kwargs
-        return MagicMock()
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        return proc
 
     spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
 
@@ -82,7 +90,9 @@ def test_linux_falls_through_to_gnome_terminal(monkeypatch) -> None:
     def fake_popen(cmd, **kwargs):
         captured["cmd"] = cmd
         captured["kwargs"] = kwargs
-        return MagicMock()
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        return proc
 
     spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
 
@@ -109,10 +119,63 @@ def test_linux_konsole_and_xterm_wiring(monkeypatch) -> None:
 
         def fake_popen(cmd, **kwargs):
             captured["cmd"] = cmd
-            return MagicMock()
+            proc = MagicMock()
+            proc.poll.return_value = None  # still running
+            return proc
 
         spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
         assert captured["cmd"] == [path, "-e", *HELPER_ARGV]
+
+
+def test_linux_emulator_exits_immediately_falls_through(monkeypatch) -> None:
+    """A found emulator that dies right after spawn is not reported as success."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which(
+            {
+                "x-terminal-emulator": "/usr/bin/x-terminal-emulator",
+                "gnome-terminal": "/usr/bin/gnome-terminal",
+            }
+        ),
+    )
+    captured: dict[str, Any] = {"cmds": []}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmds"].append(cmd)
+        proc = MagicMock()
+        if cmd[0] == "/usr/bin/x-terminal-emulator":
+            proc.poll.return_value = 1  # exited immediately (bad flag / broken alias)
+        else:
+            proc.poll.return_value = None  # gnome-terminal stays running
+        return proc
+
+    result = spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
+
+    assert [c[0] for c in captured["cmds"]] == [
+        "/usr/bin/x-terminal-emulator",
+        "/usr/bin/gnome-terminal",
+    ]
+    assert result.poll() is None
+
+
+def test_linux_all_emulators_exit_immediately_fail_closed(monkeypatch) -> None:
+    """If every found emulator dies right after spawn, fail closed with a clear reason."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which({"xterm": "/usr/bin/xterm"}),
+    )
+
+    def fake_popen(cmd, **kwargs):
+        proc = MagicMock()
+        proc.poll.return_value = 1  # exited immediately
+        return proc
+
+    with pytest.raises(OSError, match="none stayed running|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
 
 
 def test_linux_headless_fail_closed(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Align DESIGN.md title/scope notes with v1 (theme/platform/Linux/skills landed).
- On Linux, if a found terminal emulator exits right after spawn (bad flag, broken alias), fall through to the next emulator instead of hanging until the 90s prompt timeout; if all die immediately, fail closed with a clear reason.

## Test plan
- [x] New tests: immediate-exit fallthrough + all-exit fail-closed
- [ ] Full pytest on merge