### PR TITLE
v2 Phase 0: browser-fill foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = ["pytest>=7.0"]
 [project.scripts]
 key-amnesia = "key_amnesia.cli:main"
 ka = "key_amnesia.cli:main"
+key-amnesia-browser-host = "key_amnesia.native_host:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/key_amnesia/browser_fill.py
+++ b/src/key_amnesia/browser_fill.py
@@ -1,0 +1,297 @@
+"""Browser-fill IPC — second Listener co-hosted with the guard child.
+
+Authkey only (no session_key). May return credentials to native_host after
+in-process approval. Dies with ka lock / guard expiry / fill lock.
+Requires ka unlock — no per-call fill path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import Any, Callable
+
+from key_amnesia import ipc
+from key_amnesia.logins import find_logins_for_url
+from key_amnesia.paths import browser_fill_lock_path
+from key_amnesia.prompt_route import PromptRequest, require_browser_fill_approval
+
+
+def _utc_iso(ts: float | None = None) -> str:
+    t = ts if ts is not None else time.time()
+    return datetime.fromtimestamp(t, tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+@dataclass
+class FillState:
+    """Shared with guard child: secrets + login metadata for fill verbs."""
+
+    secrets: dict[str, str]
+    logins: list[dict[str, Any]]
+    browser_associations: list[dict[str, Any]]
+    database_id: str
+    expires_at: float
+    address: str
+    authkey: bytes
+    pid: int = field(default_factory=os.getpid)
+    stop: threading.Event = field(default_factory=threading.Event)
+
+
+def write_browser_fill_lock(
+    address: str,
+    authkey: bytes,
+    pid: int,
+    expires_at: float,
+    path: Path | None = None,
+) -> None:
+    p = path or browser_fill_lock_path()
+    data = {
+        "address": address,
+        "authkey_hex": ipc.authkey_to_hex(authkey),
+        "pid": pid,
+        "expires_at": _utc_iso(expires_at),
+        "expires_at_epoch": expires_at,
+    }
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def read_browser_fill_lock(path: Path | None = None) -> dict[str, Any] | None:
+    p = path or browser_fill_lock_path()
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def clear_browser_fill_lock(path: Path | None = None) -> None:
+    p = path or browser_fill_lock_path()
+    try:
+        p.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def fill_is_alive(lock: dict[str, Any] | None = None) -> bool:
+    lock = lock if lock is not None else read_browser_fill_lock()
+    if not lock:
+        return False
+    pid = int(lock.get("pid") or 0)
+    expires = float(lock.get("expires_at_epoch") or 0)
+    if expires and time.time() > expires:
+        return False
+    if pid <= 0:
+        return False
+    from key_amnesia.prompt_route import parent_alive
+
+    return parent_alive(pid)
+
+
+def connect_fill(lock: dict[str, Any] | None = None) -> Connection | None:
+    lock = lock if lock is not None else read_browser_fill_lock()
+    if not lock or not fill_is_alive(lock):
+        return None
+    try:
+        authkey = ipc.authkey_from_hex(lock["authkey_hex"])
+        return ipc.connect(lock["address"], authkey)
+    except Exception:
+        return None
+
+
+def browser_fill_request(
+    msg: dict[str, Any], timeout: float = 120.0
+) -> dict[str, Any] | None:
+    """Send a message to the live fill IPC; return response or None."""
+    conn = connect_fill()
+    if conn is None:
+        return None
+    try:
+        ipc.send_msg(conn, msg)
+        return ipc.recv_msg(conn, timeout=timeout)
+    except Exception:
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def start_fill_listener(
+    address: str | None = None, authkey: bytes | None = None
+) -> tuple[Any, str, bytes]:
+    return ipc.start_listener(
+        address=address or ipc.make_fill_pipe_address(),
+        authkey=authkey,
+    )
+
+
+def fill_handle_message(
+    msg: dict[str, Any],
+    state: FillState,
+    *,
+    approve_fn: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Handle one browser-fill IPC message."""
+    if not isinstance(msg, dict):
+        return {"ok": False, "reason": "invalid message"}
+
+    verb = str(msg.get("verb") or msg.get("action") or "")
+
+    if time.time() > state.expires_at and verb not in ("lock", "status"):
+        return {"ok": False, "reason": "session expired", "expired": True}
+
+    if verb == "status":
+        return {
+            "ok": True,
+            "expires_at": _utc_iso(state.expires_at),
+            "expires_at_epoch": state.expires_at,
+            "login_count": len(state.logins),
+            "associated": bool(state.browser_associations),
+            "database_id": state.database_id,
+            "expired": time.time() > state.expires_at,
+        }
+
+    if verb == "lock":
+        state.stop.set()
+        return {"ok": True, "lock": True}
+
+    if verb == "test-associate":
+        assoc_id = str(msg.get("id") or "")
+        for entry in state.browser_associations:
+            if str(entry.get("id") or "") == assoc_id:
+                return {"ok": True, "associated": True, "id": assoc_id}
+        return {"ok": False, "associated": False, "reason": "not associated"}
+
+    if verb == "associate-store":
+        assoc_id = str(msg.get("id") or "")
+        id_key_b64 = str(msg.get("id_key_b64") or "")
+        if not assoc_id or not id_key_b64:
+            return {"ok": False, "reason": "id and id_key_b64 required"}
+        # Replace same id if present.
+        state.browser_associations = [
+            e for e in state.browser_associations if str(e.get("id") or "") != assoc_id
+        ]
+        state.browser_associations.append({"id": assoc_id, "id_key_b64": id_key_b64})
+        return {"ok": True, "associated": True, "id": assoc_id}
+
+    if verb == "get-logins-for-url":
+        url = str(msg.get("url") or "")
+        if not url:
+            return {"ok": False, "reason": "url required"}
+        matched = find_logins_for_url(state.logins, url)
+        if not matched:
+            return {"ok": False, "reason": "no matching logins"}
+
+        usernames = [str(e.get("username") or "") for e in matched]
+        secret_names = [str(e.get("secret_name") or "") for e in matched]
+        request = PromptRequest(
+            action="browser-fill-approve",
+            secret_names=secret_names,
+            detail=json.dumps(
+                {
+                    "url": url,
+                    "usernames": usernames,
+                    "secret_names": secret_names,
+                }
+            ),
+        )
+        approver = approve_fn or require_browser_fill_approval
+        outcome = approver(request)
+        so = getattr(outcome, "status_only", None) or {}
+        if "approved" in so:
+            approved = bool(so["approved"])
+        else:
+            approved = bool(getattr(outcome, "ok", False))
+        if not approved:
+            reason = getattr(outcome, "reason", "") or "denied"
+            return {"ok": False, "reason": reason}
+
+        entries: list[dict[str, Any]] = []
+        for entry in matched:
+            sname = str(entry.get("secret_name") or "")
+            password = state.secrets.get(sname)
+            if password is None:
+                continue
+            entries.append(
+                {
+                    "login": str(entry.get("username") or ""),
+                    "name": sname,
+                    "password": password,
+                    "uuid": sname,
+                }
+            )
+        if not entries:
+            return {"ok": False, "reason": "no resolvable secrets"}
+        return {"ok": True, "entries": entries}
+
+    return {"ok": False, "reason": f"unknown verb: {verb}"}
+
+
+def fill_serve(
+    state: FillState,
+    listener: Any,
+    *,
+    approve_fn: Callable[..., Any] | None = None,
+) -> None:
+    """Accept fill connections until stop / lock / expiry."""
+    while not state.stop.is_set():
+        now = time.time()
+        if now > state.expires_at:
+            state.stop.set()
+            break
+
+        accepted: list[Any] = []
+
+        def _accept() -> None:
+            try:
+                accepted.append(listener.accept())
+            except Exception as e:  # noqa: BLE001
+                accepted.append(e)
+
+        t = threading.Thread(target=_accept, daemon=True)
+        t.start()
+        while t.is_alive():
+            if state.stop.is_set() or time.time() > state.expires_at:
+                break
+            t.join(timeout=0.5)
+        if not accepted:
+            if state.stop.is_set() or time.time() > state.expires_at:
+                break
+            continue
+        item = accepted[0]
+        if isinstance(item, Exception):
+            continue
+        conn: Connection = item
+        try:
+            msg = ipc.recv_msg(conn, timeout=30.0)
+            # Keep expires_at in sync if guard renews (shared mutable float via ref —
+            # callers should mutate state.expires_at on the same object).
+            reply = fill_handle_message(msg, state, approve_fn=approve_fn)
+            ipc.send_msg(conn, reply)
+            if reply.get("lock"):
+                state.stop.set()
+                break
+        except Exception:
+            pass
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    try:
+        listener.close()
+    except Exception:
+        pass

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -109,6 +109,13 @@ def _build_parser() -> argparse.ArgumentParser:
     # status
     sub.add_parser("status", help="Show guard session status")
 
+    # Phase 0 seams — handlers filled by later workstreams
+    from key_amnesia.login_cli import build_login_parser
+    from key_amnesia.native_host_install import build_browser_fill_parser
+
+    build_login_parser(sub)
+    build_browser_fill_parser(sub)
+
     # internal helpers (still support --help; omitted from epilog summary)
     sub.add_parser("_prompt-helper", help=argparse.SUPPRESS)
     sub.add_parser("_guard", help=argparse.SUPPRESS)
@@ -442,14 +449,17 @@ def cmd_unlock(_args: argparse.Namespace) -> int:
 
 
 def cmd_lock(_args: argparse.Namespace) -> int:
+    from key_amnesia.browser_fill import clear_browser_fill_lock
     from key_amnesia.guard import clear_guard_lock, guard_is_alive, guard_request
 
     if not guard_is_alive():
         clear_guard_lock()
+        clear_browser_fill_lock()
         theme.info("No active guard session.")
         return 0
     resp = guard_request({"verb": "lock"})
     clear_guard_lock()
+    clear_browser_fill_lock()
     if resp and resp.get("ok"):
         theme.success("Locked.")
         return 0
@@ -615,6 +625,14 @@ def main(argv: list[str] | None = None) -> int:
         from key_amnesia.guard import run_guard_main
 
         return run_guard_main()
+    if args.command == "login":
+        from key_amnesia.login_cli import main as login_main
+
+        return login_main(args)
+    if args.command == "browser-fill":
+        from key_amnesia.native_host_install import main as browser_fill_main
+
+        return browser_fill_main(args)
 
     handlers = {
         "init": cmd_init,

--- a/src/key_amnesia/guard.py
+++ b/src/key_amnesia/guard.py
@@ -3,6 +3,9 @@
 IPC verbs: run, list, lock, status, renew only.
 Never returns raw secret values. No get-value / reveal verb.
 Authkey only (no session_key).
+
+Co-hosts browser-fill as a second Listener in the same child; both die on
+lock / expiry.
 """
 
 from __future__ import annotations
@@ -10,6 +13,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -20,6 +24,13 @@ from typing import Any
 from key_amnesia import ipc
 from key_amnesia import theme
 from key_amnesia.audit import audit_event
+from key_amnesia.browser_fill import (
+    FillState,
+    clear_browser_fill_lock,
+    fill_serve,
+    start_fill_listener,
+    write_browser_fill_lock,
+)
 from key_amnesia.paths import guard_lock_path
 from key_amnesia.run_exec import run_with_secrets
 from key_amnesia.vault import read_names
@@ -33,6 +44,10 @@ class GuardState:
     authkey: bytes
     pid: int = field(default_factory=os.getpid)
     created_at: float = field(default_factory=time.time)
+    stop: threading.Event = field(default_factory=threading.Event)
+    # Shared with fill listener (same process); renew updates expires_at.
+    fill_state: FillState | None = None
+
 
 
 def _utc_iso(ts: float | None = None) -> str:
@@ -155,6 +170,7 @@ def guard_handle_message(msg: dict[str, Any], state: GuardState) -> dict[str, An
 
     if verb == "lock":
         audit_event("lock", route="guard-session", result="allowed")
+        state.stop.set()
         return {"ok": True, "lock": True}
 
     if verb == "renew":
@@ -163,6 +179,14 @@ def guard_handle_message(msg: dict[str, Any], state: GuardState) -> dict[str, An
             return {"ok": False, "reason": "invalid minutes"}
         state.expires_at = time.time() + minutes * 60
         write_guard_lock(state.address, state.authkey, state.pid, state.expires_at)
+        if state.fill_state is not None:
+            state.fill_state.expires_at = state.expires_at
+            write_browser_fill_lock(
+                state.fill_state.address,
+                state.fill_state.authkey,
+                state.pid,
+                state.expires_at,
+            )
         audit_event(
             "renew",
             route="guard-session",
@@ -228,7 +252,7 @@ def guard_handle_message(msg: dict[str, Any], state: GuardState) -> dict[str, An
 def guard_serve(state: GuardState, listener: Any) -> None:
     """Main guard loop: accept connections until lock or expiry."""
     extend_prompted = False
-    while True:
+    while not state.stop.is_set():
         now = time.time()
         # ~2 min before expiry: prompt extend if TTY still interactive
         if (
@@ -251,11 +275,20 @@ def guard_serve(state: GuardState, listener: Any) -> None:
                     write_guard_lock(
                         state.address, state.authkey, state.pid, state.expires_at
                     )
+                    if state.fill_state is not None:
+                        state.fill_state.expires_at = state.expires_at
+                        write_browser_fill_lock(
+                            state.fill_state.address,
+                            state.fill_state.authkey,
+                            state.pid,
+                            state.expires_at,
+                        )
                     extend_prompted = False
             except (EOFError, KeyboardInterrupt):
                 pass
 
         if now > state.expires_at:
+            state.stop.set()
             break
 
         # Accept with short poll via thread-less approach: use listener
@@ -271,17 +304,15 @@ def guard_serve(state: GuardState, listener: Any) -> None:
             except Exception as e:  # noqa: BLE001
                 accepted.append(e)
 
-        import threading
-
         t = threading.Thread(target=_accept, daemon=True)
         t.start()
         while t.is_alive():
-            if time.time() > state.expires_at:
+            if state.stop.is_set() or time.time() > state.expires_at:
                 break
             t.join(timeout=0.5)
         if not accepted:
-            # Timed out waiting / expired
-            if time.time() > state.expires_at:
+            # Timed out waiting / expired / stop
+            if state.stop.is_set() or time.time() > state.expires_at:
                 break
             continue
         item = accepted[0]
@@ -293,6 +324,7 @@ def guard_serve(state: GuardState, listener: Any) -> None:
             reply = guard_handle_message(msg, state)
             ipc.send_msg(conn, reply)
             if reply.get("lock"):
+                state.stop.set()
                 break
         except Exception:
             pass
@@ -302,9 +334,14 @@ def guard_serve(state: GuardState, listener: Any) -> None:
             except Exception:
                 pass
 
+    state.stop.set()
     # Wipe secrets from state
     state.secrets.clear()
+    if state.fill_state is not None:
+        state.fill_state.secrets.clear()
+        state.fill_state.stop.set()
     clear_guard_lock()
+    clear_browser_fill_lock()
     try:
         listener.close()
     except Exception:
@@ -315,10 +352,14 @@ def start_guard_process(payload: dict[str, Any], timeout_minutes: int) -> int:
     """Start guard in a child process holding decrypted secrets.
 
     Returns child PID. Writes guard.lock (authkey only — no session_key).
+    Also starts browser-fill Listener in the same child (browser_fill.lock).
     """
     import subprocess
 
     secrets_map = {k: str(v) for k, v in payload.get("secrets", {}).items()}
+    logins = list(payload.get("logins") or [])
+    associations = list(payload.get("browser_associations") or [])
+    database_id = str(payload.get("database_id") or "")
     # Pass secrets to child via a one-shot pipe file that child deletes —
     # NOT on argv. Use env with a temp file path.
     import tempfile
@@ -360,6 +401,9 @@ def start_guard_process(payload: dict[str, Any], timeout_minutes: int) -> int:
         json.dump(
             {
                 "secrets": secrets_map,
+                "logins": logins,
+                "browser_associations": associations,
+                "database_id": database_id,
                 "expires_at": expires_at,
                 "timeout_minutes": timeout_minutes,
             },
@@ -389,7 +433,19 @@ def start_guard_process(payload: dict[str, Any], timeout_minutes: int) -> int:
         deadline = time.time() + 15
         while time.time() < deadline:
             lock = read_guard_lock()
-            if lock and int(lock.get("pid") or 0) == proc.pid:
+            fill_lock = None
+            try:
+                from key_amnesia.browser_fill import read_browser_fill_lock
+
+                fill_lock = read_browser_fill_lock()
+            except Exception:
+                fill_lock = None
+            if (
+                lock
+                and int(lock.get("pid") or 0) == proc.pid
+                and fill_lock
+                and int(fill_lock.get("pid") or 0) == proc.pid
+            ):
                 return proc.pid
             if proc.poll() is not None:
                 raise RuntimeError("guard process exited before writing lock")
@@ -401,7 +457,7 @@ def start_guard_process(payload: dict[str, Any], timeout_minutes: int) -> int:
 
 
 def run_guard_main() -> int:
-    """Entry for `_guard`: read bootstrap env, serve, exit."""
+    """Entry for `_guard`: read bootstrap env, serve guard + fill, exit."""
     boot_path = os.environ.pop("KEY_AMNESIA_GUARD_BOOTSTRAP", "")
     if not boot_path:
         theme.error("guard: missing bootstrap")
@@ -416,20 +472,55 @@ def run_guard_main() -> int:
             pass
 
     secrets_map = {k: str(v) for k, v in boot.get("secrets", {}).items()}
+    logins = list(boot.get("logins") or [])
+    associations = list(boot.get("browser_associations") or [])
+    database_id = str(boot.get("database_id") or "")
     expires_at = float(boot["expires_at"])
+    stop = threading.Event()
+
     listener, address, authkey = ipc.start_listener()
+    fill_listener, fill_address, fill_authkey = start_fill_listener()
     pid = os.getpid()
-    write_guard_lock(address, authkey, pid, expires_at)
+
+    fill_state = FillState(
+        secrets=secrets_map,
+        logins=logins,
+        browser_associations=associations,
+        database_id=database_id,
+        expires_at=expires_at,
+        address=fill_address,
+        authkey=fill_authkey,
+        pid=pid,
+        stop=stop,
+    )
     state = GuardState(
         secrets=secrets_map,
         expires_at=expires_at,
         address=address,
         authkey=authkey,
         pid=pid,
+        stop=stop,
+        fill_state=fill_state,
     )
+    write_guard_lock(address, authkey, pid, expires_at)
+    write_browser_fill_lock(fill_address, fill_authkey, pid, expires_at)
+
+    fill_thread = threading.Thread(
+        target=fill_serve,
+        args=(fill_state, fill_listener),
+        daemon=True,
+    )
+    fill_thread.start()
     try:
         guard_serve(state, listener)
     finally:
+        stop.set()
         state.secrets.clear()
+        fill_state.secrets.clear()
         clear_guard_lock()
+        clear_browser_fill_lock()
+        try:
+            fill_listener.close()
+        except Exception:
+            pass
     return 0

--- a/src/key_amnesia/ipc.py
+++ b/src/key_amnesia/ipc.py
@@ -26,6 +26,14 @@ def make_pipe_address() -> str:
     return f"/tmp/key-amnesia-{token}.sock"
 
 
+def make_fill_pipe_address() -> str:
+    """Return a platform-appropriate browser-fill listener address."""
+    token = secrets.token_hex(8)
+    if sys.platform == "win32":
+        return rf"\\.\pipe\key-amnesia-fill-{token}"
+    return f"/tmp/key-amnesia-fill-{token}.sock"
+
+
 def start_listener(address: str | None = None, authkey: bytes | None = None) -> tuple[Listener, str, bytes]:
     addr = address or make_pipe_address()
     key = authkey if authkey is not None else make_authkey()

--- a/src/key_amnesia/login_cli.py
+++ b/src/key_amnesia/login_cli.py
@@ -1,0 +1,34 @@
+"""Login CLI stubs — handlers filled by workstream C."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from key_amnesia import theme
+
+
+def build_login_parser(sub: Any) -> argparse.ArgumentParser:
+    """Register `ka login` and its subcommands on the root subparsers."""
+    p = sub.add_parser(
+        "login",
+        help="Manage URL/username ↔ secret associations (browser fill)",
+    )
+    login_sub = p.add_subparsers(dest="login_command")
+    p_add = login_sub.add_parser("add", help="Add a login association")
+    p_add.add_argument("url")
+    p_add.add_argument("username")
+    p_add.add_argument("secret_name")
+    login_sub.add_parser("list", help="List login associations")
+    p_rm = login_sub.add_parser("remove", help="Remove a login association")
+    p_rm.add_argument("url")
+    p_rm.add_argument("username")
+    return p
+
+
+def main(args: argparse.Namespace) -> int:
+    """Phase 0 stub — real handlers land in WS-C."""
+    theme.error(
+        "ka login is not implemented yet (Phase 0 stub; see workstream C).",
+    )
+    return 1

--- a/src/key_amnesia/logins.py
+++ b/src/key_amnesia/logins.py
@@ -1,0 +1,107 @@
+"""Login record CRUD and URL host matching (subdomain-suffix).
+
+Domain match: parse hostnames; match if equal or
+`request_host.endswith("." + login_host)`. Scheme/port ignored.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from key_amnesia.vault import load_vault, save_vault
+
+
+class LoginError(Exception):
+    """Login CRUD or lookup error."""
+
+
+def _hostname(url: str) -> str:
+    raw = (url or "").strip()
+    if not raw:
+        return ""
+    # urlparse needs a scheme for netloc; treat bare hosts as https://host
+    if "://" not in raw:
+        raw = "https://" + raw
+    host = (urlparse(raw).hostname or "").lower().rstrip(".")
+    return host
+
+
+def hosts_match(request_url: str, login_url: str) -> bool:
+    """True if request host equals login host or is a subdomain of it."""
+    req = _hostname(request_url)
+    stored = _hostname(login_url)
+    if not req or not stored:
+        return False
+    return req == stored or req.endswith("." + stored)
+
+
+def find_logins_for_url(
+    logins: list[dict[str, Any]], url: str
+) -> list[dict[str, Any]]:
+    """Return login dicts whose host matches *url* (exact or subdomain-suffix)."""
+    return [dict(entry) for entry in logins if hosts_match(url, str(entry.get("url") or ""))]
+
+
+def list_logins(
+    path: Path | str | None, password: str
+) -> list[dict[str, str]]:
+    payload = load_vault(path, password)
+    out: list[dict[str, str]] = []
+    for entry in payload.get("logins") or []:
+        if not isinstance(entry, dict):
+            continue
+        out.append(
+            {
+                "url": str(entry.get("url") or ""),
+                "username": str(entry.get("username") or ""),
+                "secret_name": str(entry.get("secret_name") or ""),
+            }
+        )
+    return out
+
+
+def add_login(
+    path: Path | str | None,
+    password: str,
+    url: str,
+    username: str,
+    secret_name: str,
+) -> None:
+    payload = load_vault(path, password)
+    secrets_map = payload.get("secrets") or {}
+    if secret_name not in secrets_map:
+        raise LoginError(f"unknown secret: {secret_name}")
+    logins = list(payload.get("logins") or [])
+    for entry in logins:
+        if (
+            str(entry.get("url") or "") == url
+            and str(entry.get("username") or "") == username
+        ):
+            raise LoginError(f"login already exists for {username} @ {url}")
+    logins.append({"url": url, "username": username, "secret_name": secret_name})
+    payload["logins"] = logins
+    save_vault(path, password, payload)
+
+
+def remove_login(
+    path: Path | str | None,
+    password: str,
+    url: str,
+    username: str,
+) -> None:
+    payload = load_vault(path, password)
+    logins = list(payload.get("logins") or [])
+    kept = [
+        e
+        for e in logins
+        if not (
+            str(e.get("url") or "") == url
+            and str(e.get("username") or "") == username
+        )
+    ]
+    if len(kept) == len(logins):
+        raise LoginError(f"no login for {username} @ {url}")
+    payload["logins"] = kept
+    save_vault(path, password, payload)

--- a/src/key_amnesia/native_host.py
+++ b/src/key_amnesia/native_host.py
@@ -1,0 +1,21 @@
+"""KeePassXC-Browser Native Messaging host entry point.
+
+Phase 0 stub — protocol implementation lands in workstream A.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console script `key-amnesia-browser-host` — not implemented until WS-A."""
+    sys.stderr.write(
+        "key-amnesia-browser-host: not implemented yet "
+        "(Phase 0 stub; see workstream A).\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/key_amnesia/native_host_install.py
+++ b/src/key_amnesia/native_host_install.py
@@ -1,0 +1,29 @@
+"""Native Messaging host installer stubs — handlers filled by workstream B."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from key_amnesia import theme
+
+
+def build_browser_fill_parser(sub: Any) -> argparse.ArgumentParser:
+    """Register `ka browser-fill` and its subcommands on the root subparsers."""
+    p = sub.add_parser(
+        "browser-fill",
+        help="Install or inspect KeePassXC-Browser Native Messaging host",
+    )
+    bf_sub = p.add_subparsers(dest="browser_fill_command")
+    bf_sub.add_parser("install", help="Install native messaging manifests")
+    bf_sub.add_parser("status", help="Show per-browser install status")
+    bf_sub.add_parser("uninstall", help="Remove key-amnesia native messaging manifests")
+    return p
+
+
+def main(args: argparse.Namespace) -> int:
+    """Phase 0 stub — real handlers land in WS-B."""
+    theme.error(
+        "ka browser-fill is not implemented yet (Phase 0 stub; see workstream B).",
+    )
+    return 1

--- a/src/key_amnesia/paths.py
+++ b/src/key_amnesia/paths.py
@@ -48,5 +48,9 @@ def guard_lock_path() -> Path:
     return data_dir() / "guard.lock"
 
 
+def browser_fill_lock_path() -> Path:
+    return data_dir() / "browser_fill.lock"
+
+
 def audit_log_path() -> Path:
     return data_dir() / "audit.log"

--- a/src/key_amnesia/prompt_route.py
+++ b/src/key_amnesia/prompt_route.py
@@ -102,6 +102,171 @@ def _spawn_helper(
     return spawn_isolated_console(cmd, env, popen_fn=popen_fn)
 
 
+def _prompt_approve_inline(request: PromptRequest) -> bool:
+    theme.info(
+        "key-amnesia: browser fill approval required",
+        file=sys.stderr,
+    )
+    try:
+        detail = json.loads(request.detail) if request.detail else {}
+    except json.JSONDecodeError:
+        detail = {}
+    url = str(detail.get("url") or request.detail or "")
+    usernames = detail.get("usernames") or []
+    secret_names = detail.get("secret_names") or request.secret_names
+    if url:
+        theme.info(f"  site: {url}", file=sys.stderr)
+    if usernames:
+        theme.info(f"  usernames: {', '.join(str(u) for u in usernames)}", file=sys.stderr)
+    if secret_names:
+        theme.info(
+            f"  secret names: {', '.join(str(n) for n in secret_names)}",
+            file=sys.stderr,
+        )
+    theme.info("  (passwords are never shown here)", file=sys.stderr)
+    ans = input("Allow fill? [y/N] ").strip().lower()
+    return ans in ("y", "yes")
+
+
+def require_browser_fill_approval(
+    request: PromptRequest,
+    timeout_s: int | None = None,
+    *,
+    approve_provider: Callable[[], bool] | None = None,
+    popen_fn: Callable[..., Any] | None = None,
+    isatty_fn: Callable[[], bool] | None = None,
+) -> AuthOutcome:
+    """Yes/No approval for browser fill — never collects a master password.
+
+    Used only when a live unlock/fill session already holds the vault.
+    """
+    if request.action != "browser-fill-approve":
+        request = PromptRequest(
+            action="browser-fill-approve",
+            secret_names=request.secret_names,
+            command=request.command,
+            inject_as=request.inject_as,
+            detail=request.detail,
+            vault_path=request.vault_path,
+        )
+
+    cfg = load_config()
+    if timeout_s is None:
+        timeout_s = int(cfg.get("prompt-timeout-seconds", 90))
+
+    tty = (isatty_fn or _isatty)()
+    if tty:
+        try:
+            if approve_provider is not None:
+                approved = bool(approve_provider())
+            else:
+                approved = _prompt_approve_inline(request)
+        except (EOFError, KeyboardInterrupt):
+            return AuthOutcome(
+                ok=False,
+                route="inline",
+                reason="approval cancelled",
+                status_only={"approved": False, "action": "browser-fill-approve"},
+            )
+        return AuthOutcome(
+            ok=approved,
+            route="inline",
+            reason="" if approved else "denied",
+            status_only={"approved": approved, "action": "browser-fill-approve"},
+        )
+
+    # Non-interactive: spawn helper console for yes/no only (no password).
+    listener = None
+    proc = None
+    try:
+        listener, address, authkey = ipc.start_listener()
+        try:
+            proc = _spawn_helper(
+                request, address, authkey, timeout_s, popen_fn=popen_fn
+            )
+        except OSError as e:
+            return AuthOutcome(ok=False, route="spawned-console", reason=str(e))
+
+        deadline = time.monotonic() + timeout_s
+        conn: Connection | None = None
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            accepted: list[Connection | BaseException] = []
+
+            def _accept() -> None:
+                try:
+                    accepted.append(listener.accept())
+                except BaseException as exc:  # noqa: BLE001
+                    accepted.append(exc)
+
+            t = threading.Thread(target=_accept, daemon=True)
+            t.start()
+            t.join(timeout=min(1.0, max(0.1, remaining)))
+            if accepted:
+                item = accepted[0]
+                if isinstance(item, BaseException):
+                    raise item
+                conn = item
+                break
+            if proc.poll() is not None:
+                break
+        else:
+            return AuthOutcome(
+                ok=False, route="spawned-console", reason="approval timed out"
+            )
+
+        if conn is None:
+            return AuthOutcome(
+                ok=False,
+                route="spawned-console",
+                reason="helper exited without connecting",
+            )
+
+        try:
+            remaining = max(0.1, deadline - time.monotonic())
+            reply = ipc.recv_msg(conn, timeout=remaining)
+        except TimeoutError:
+            return AuthOutcome(
+                ok=False, route="spawned-console", reason="helper reply timed out"
+            )
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+        if "password" in reply or "secret_value" in reply or "secrets" in reply:
+            reply = {
+                k: v
+                for k, v in reply.items()
+                if k not in ("password", "secret_value", "secrets")
+            }
+
+        so = reply.get("status_only") if isinstance(reply.get("status_only"), dict) else {}
+        approved = bool(so.get("approved")) if "approved" in so else bool(reply.get("ok"))
+        reason = str(reply.get("reason", ""))
+        return AuthOutcome(
+            ok=approved,
+            route="spawned-console",
+            reason=reason if not approved else "",
+            status_only={
+                "approved": approved,
+                "action": "browser-fill-approve",
+            },
+        )
+    finally:
+        if listener is not None:
+            try:
+                listener.close()
+            except Exception:
+                pass
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+
+
 def require_human_auth(
     request: PromptRequest,
     timeout_s: int | None = None,
@@ -269,7 +434,7 @@ def require_human_auth(
             outcome.status_only = {
                 k: v
                 for k, v in reply["status_only"].items()
-                if k in ("shown", "copied", "action", "name")
+                if k in ("shown", "copied", "action", "name", "approved", "key")
             }
         return outcome
     finally:
@@ -400,6 +565,66 @@ def run_prompt_helper() -> int:
     watcher = threading.Thread(target=_watch, daemon=True)
     watcher.start()
 
+    reply: dict[str, Any] = {"ok": False, "reason": ""}
+
+    # Browser-fill approval: yes/no only — never collect a master password.
+    if request.action == "browser-fill-approve":
+        try:
+            detail = json.loads(request.detail) if request.detail else {}
+        except json.JSONDecodeError:
+            detail = {}
+        url = str(detail.get("url") or "")
+        usernames = detail.get("usernames") or []
+        secret_names = detail.get("secret_names") or request.secret_names
+        theme.info("Browser fill approval (no password required)")
+        if url:
+            theme.out(f"Site     : {url}")
+        if usernames:
+            theme.out(f"Usernames: {', '.join(str(u) for u in usernames)}")
+        if secret_names:
+            theme.out(f"Secrets  : {', '.join(str(n) for n in secret_names)}")
+        theme.out("(Password values are never shown.)")
+        theme.out()
+        try:
+            ans = input("Allow fill? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            ans = ""
+        if cancel["flag"]:
+            theme.error("Cancelled (parent exited).")
+            return 1
+        approved = ans in ("y", "yes")
+        reply["ok"] = approved
+        reply["reason"] = "" if approved else "denied"
+        reply["status_only"] = {
+            "approved": approved,
+            "action": "browser-fill-approve",
+        }
+        try:
+            if parent_pid and not parent_alive(parent_pid):
+                theme.error("Parent gone; discarding reply.")
+                return 1
+            conn = ipc.connect(address, authkey)
+            try:
+                safe = {
+                    k: v
+                    for k, v in reply.items()
+                    if k in ("ok", "reason", "run_result", "status_only")
+                }
+                ipc.send_msg(conn, safe)
+            finally:
+                conn.close()
+        except Exception as e:  # noqa: BLE001
+            theme.error(f"Failed to reply to parent: {e}")
+            input("Press Enter to close...")
+            return 1
+        cancel["flag"] = True
+        if approved:
+            theme.success("Approved.")
+        else:
+            theme.out("Denied.")
+        time.sleep(0.8)
+        return 0 if approved else 1
+
     try:
         password = getpass.getpass("Master password: ")
     except (EOFError, KeyboardInterrupt):
@@ -408,8 +633,6 @@ def run_prompt_helper() -> int:
     if cancel["flag"]:
         theme.error("Cancelled (parent exited).")
         return 1
-
-    reply: dict[str, Any] = {"ok": False, "reason": ""}
 
     try:
         if not password:
@@ -509,6 +732,12 @@ def run_prompt_helper() -> int:
                                 password,
                                 {
                                     "secrets": secrets_map,
+                                    "logins": payload.get("logins") or [],
+                                    "browser_associations": payload.get(
+                                        "browser_associations"
+                                    )
+                                    or [],
+                                    "database_id": payload.get("database_id") or "",
                                     "created_at": payload.get("created_at"),
                                     "updated_at": payload.get("updated_at"),
                                 },
@@ -531,6 +760,12 @@ def run_prompt_helper() -> int:
                                 password,
                                 {
                                     "secrets": secrets_map,
+                                    "logins": payload.get("logins") or [],
+                                    "browser_associations": payload.get(
+                                        "browser_associations"
+                                    )
+                                    or [],
+                                    "database_id": payload.get("database_id") or "",
                                     "created_at": payload.get("created_at"),
                                     "updated_at": payload.get("updated_at"),
                                 },

--- a/src/key_amnesia/vault.py
+++ b/src/key_amnesia/vault.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import secrets
 import struct
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,9 +26,32 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
+def new_database_id() -> str:
+    """Stable hex id for KeePassXC get-databasehash."""
+    return secrets.token_hex(32)
+
+
 def empty_payload() -> dict[str, Any]:
     now = _utc_now_iso()
-    return {"secrets": {}, "created_at": now, "updated_at": now}
+    return {
+        "secrets": {},
+        "logins": [],
+        "browser_associations": [],
+        "database_id": new_database_id(),
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _normalize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Default additive v2 fields for vaults created before logins schema."""
+    if not isinstance(payload.get("logins"), list):
+        payload["logins"] = []
+    if not isinstance(payload.get("browser_associations"), list):
+        payload["browser_associations"] = []
+    if not payload.get("database_id"):
+        payload["database_id"] = new_database_id()
+    return payload
 
 
 def load_vault(path: Path | str | None, password: str) -> dict[str, Any]:
@@ -62,7 +86,7 @@ def load_vault(path: Path | str | None, password: str) -> dict[str, Any]:
         raise VaultError("Vault payload is corrupt") from e
     if not isinstance(payload, dict) or "secrets" not in payload:
         raise VaultError("Vault payload missing secrets")
-    return payload
+    return _normalize_payload(payload)
 
 
 def save_vault(
@@ -90,7 +114,7 @@ def save_vault(
         opslimit=opslimit,
         memlimit=memlimit,
     )
-    body = dict(payload)
+    body = _normalize_payload(dict(payload))
     if "created_at" not in body:
         body["created_at"] = _utc_now_iso()
     body["updated_at"] = _utc_now_iso()

--- a/tests/test_fill_lifecycle.py
+++ b/tests/test_fill_lifecycle.py
@@ -1,0 +1,188 @@
+"""Browser-fill IPC co-lifecycle with guard — lock clears fill."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from key_amnesia import ipc
+from key_amnesia.browser_fill import (
+    FillState,
+    browser_fill_request,
+    clear_browser_fill_lock,
+    fill_handle_message,
+    fill_is_alive,
+    fill_serve,
+    read_browser_fill_lock,
+    write_browser_fill_lock,
+)
+from key_amnesia.cli import main
+from key_amnesia.guard import (
+    clear_guard_lock,
+)
+from key_amnesia.paths import browser_fill_lock_path, guard_lock_path
+from key_amnesia.prompt_route import AuthOutcome, PromptRequest
+from key_amnesia.vault import load_vault
+
+
+def _auto_approve(request: PromptRequest) -> AuthOutcome:
+    return AuthOutcome(
+        ok=True,
+        route="inline",
+        status_only={"approved": True, "action": "browser-fill-approve"},
+    )
+
+
+def test_fill_handle_get_logins_after_approve() -> None:
+    state = FillState(
+        secrets={"api_key": "super-secret-value-123"},
+        logins=[
+            {
+                "url": "https://example.com",
+                "username": "alice",
+                "secret_name": "api_key",
+            }
+        ],
+        browser_associations=[],
+        database_id="abc",
+        expires_at=time.time() + 600,
+        address="dummy",
+        authkey=b"f" * 32,
+    )
+    reply = fill_handle_message(
+        {"verb": "get-logins-for-url", "url": "https://app.example.com/login"},
+        state,
+        approve_fn=_auto_approve,
+    )
+    assert reply["ok"] is True
+    assert reply["entries"][0]["password"] == "super-secret-value-123"
+    assert reply["entries"][0]["login"] == "alice"
+
+
+def test_fill_handle_denied_without_approve() -> None:
+    state = FillState(
+        secrets={"api_key": "secret"},
+        logins=[
+            {
+                "url": "https://example.com",
+                "username": "alice",
+                "secret_name": "api_key",
+            }
+        ],
+        browser_associations=[],
+        database_id="abc",
+        expires_at=time.time() + 600,
+        address="dummy",
+        authkey=b"f" * 32,
+    )
+
+    def deny(_req: PromptRequest) -> AuthOutcome:
+        return AuthOutcome(
+            ok=False,
+            route="inline",
+            reason="denied",
+            status_only={"approved": False, "action": "browser-fill-approve"},
+        )
+
+    reply = fill_handle_message(
+        {"verb": "get-logins-for-url", "url": "https://example.com"},
+        state,
+        approve_fn=deny,
+    )
+    assert reply["ok"] is False
+    assert "entries" not in reply
+
+
+def test_lock_clears_browser_fill_lock(
+    seeded_vault: Path, password: str, monkeypatch
+) -> None:
+    """After unlock, fill lock exists; after ka lock, fill is unreachable."""
+    payload = load_vault(seeded_vault, password)
+    payload["logins"] = [
+        {
+            "url": "https://example.com",
+            "username": "alice",
+            "secret_name": "api_key",
+        }
+    ]
+    from key_amnesia.vault import save_vault
+
+    save_vault(seeded_vault, password, payload)
+
+    clear_guard_lock()
+    clear_browser_fill_lock()
+
+    monkeypatch.setattr(
+        "key_amnesia.cli.require_human_auth",
+        lambda *a, **k: AuthOutcome(ok=True, route="inline", password=password),
+    )
+
+    assert main(["unlock"]) == 0
+    assert guard_lock_path().exists()
+    assert browser_fill_lock_path().exists()
+    fill_lock = read_browser_fill_lock()
+    assert fill_lock is not None
+    assert fill_is_alive(fill_lock)
+
+    status = browser_fill_request({"verb": "status"}, timeout=5.0)
+    assert status is not None
+    assert status.get("ok") is True
+    assert status.get("login_count") == 1
+
+    assert main(["lock"]) == 0
+
+    # Allow child teardown
+    deadline = time.time() + 5
+    while time.time() < deadline and browser_fill_lock_path().exists():
+        time.sleep(0.05)
+
+    assert not browser_fill_lock_path().exists()
+    assert browser_fill_request({"verb": "status"}, timeout=1.0) is None
+    assert browser_fill_request(
+        {"verb": "get-logins-for-url", "url": "https://example.com"},
+        timeout=1.0,
+    ) is None
+
+
+def test_fill_lock_verb_stops_listener(ka_home: Path) -> None:
+    """Fill IPC lock verb shuts down the fill listener and clears its lock."""
+    listener, address, authkey = ipc.start_listener(
+        address=ipc.make_fill_pipe_address()
+    )
+    stop = __import__("threading").Event()
+    state = FillState(
+        secrets={"k": "v"},
+        logins=[],
+        browser_associations=[],
+        database_id="id",
+        expires_at=time.time() + 600,
+        address=address,
+        authkey=authkey,
+        pid=0,
+        stop=stop,
+    )
+    write_browser_fill_lock(address, authkey, 0, state.expires_at)
+
+    t = threading.Thread(
+        target=fill_serve,
+        args=(state, listener),
+        kwargs={"approve_fn": _auto_approve},
+        daemon=True,
+    )
+    t.start()
+    time.sleep(0.1)
+
+    # Bypass pid liveness for this unit test
+    conn = ipc.connect(address, authkey)
+    try:
+        ipc.send_msg(conn, {"verb": "lock"})
+        reply = ipc.recv_msg(conn, timeout=5)
+        assert reply.get("ok") is True
+        assert reply.get("lock") is True
+    finally:
+        conn.close()
+
+    t.join(timeout=5)
+    assert stop.is_set()
+    clear_browser_fill_lock()

--- a/tests/test_logins.py
+++ b/tests/test_logins.py
@@ -1,0 +1,95 @@
+"""Login CRUD and subdomain-suffix URL matching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from key_amnesia.logins import (
+    LoginError,
+    add_login,
+    find_logins_for_url,
+    hosts_match,
+    list_logins,
+    remove_login,
+)
+from key_amnesia.vault import empty_payload, load_vault
+
+
+def test_empty_payload_has_logins_schema() -> None:
+    p = empty_payload()
+    assert p["logins"] == []
+    assert p["browser_associations"] == []
+    assert isinstance(p["database_id"], str) and len(p["database_id"]) >= 32
+
+
+def test_load_defaults_missing_logins(ka_home: Path, password: str) -> None:
+    import json
+    import struct
+
+    from key_amnesia import crypto
+    from key_amnesia.vault import HEADER_FMT, MAGIC, VERSION, load_vault
+
+    vault = ka_home / "vault.bin"
+    salt = crypto.generate_salt()
+    key = crypto.derive_key(
+        password.encode("utf-8"),
+        salt,
+        opslimit=crypto.OPSLIMIT,
+        memlimit=crypto.MEMLIMIT,
+    )
+    legacy = {
+        "secrets": {"x": "y"},
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    blob = crypto.encrypt(key, json.dumps(legacy).encode("utf-8"))
+    header = struct.pack(
+        HEADER_FMT, MAGIC, VERSION, salt, crypto.OPSLIMIT, crypto.MEMLIMIT
+    )
+    vault.write_bytes(header + blob)
+    loaded = load_vault(vault, password)
+    assert loaded["logins"] == []
+    assert loaded["browser_associations"] == []
+    assert loaded["database_id"]
+
+
+def test_hosts_match_exact_and_subdomain() -> None:
+    assert hosts_match("https://example.com/login", "https://example.com")
+    assert hosts_match("https://app.example.com/x", "https://example.com")
+    assert hosts_match("http://app.example.com:8443/", "example.com")
+    assert not hosts_match("https://evil.com", "https://example.com")
+    assert not hosts_match("https://example.com.evil.com", "https://example.com")
+    assert not hosts_match("https://notexample.com", "https://example.com")
+
+
+def test_find_logins_for_url_filters() -> None:
+    logins = [
+        {"url": "https://example.com", "username": "a", "secret_name": "s1"},
+        {"url": "https://other.org", "username": "b", "secret_name": "s2"},
+    ]
+    found = find_logins_for_url(logins, "https://www.example.com/path")
+    assert len(found) == 1
+    assert found[0]["username"] == "a"
+    assert find_logins_for_url(logins, "https://nope.test") == []
+
+
+def test_login_crud(seeded_vault: Path, password: str) -> None:
+    add_login(None, password, "https://example.com", "alice", "api_key")
+    listed = list_logins(None, password)
+    assert listed == [
+        {
+            "url": "https://example.com",
+            "username": "alice",
+            "secret_name": "api_key",
+        }
+    ]
+    with pytest.raises(LoginError, match="already exists"):
+        add_login(None, password, "https://example.com", "alice", "api_key")
+    with pytest.raises(LoginError, match="unknown secret"):
+        add_login(None, password, "https://example.com", "bob", "missing")
+    remove_login(None, password, "https://example.com", "alice")
+    assert list_logins(None, password) == []
+    with pytest.raises(LoginError, match="no login"):
+        remove_login(None, password, "https://example.com", "alice")

--- a/tests/test_phase0_seams.py
+++ b/tests/test_phase0_seams.py
@@ -1,0 +1,65 @@
+"""Phase 0 prompt + CLI seam smoke tests."""
+
+from __future__ import annotations
+
+import json
+
+from key_amnesia.cli import main
+from key_amnesia.prompt_route import PromptRequest, require_browser_fill_approval
+
+
+def test_browser_fill_approve_inline_yes() -> None:
+    req = PromptRequest(
+        action="browser-fill-approve",
+        secret_names=["api_key"],
+        detail=json.dumps(
+            {
+                "url": "https://example.com",
+                "usernames": ["alice"],
+                "secret_names": ["api_key"],
+            }
+        ),
+    )
+    outcome = require_browser_fill_approval(
+        req,
+        isatty_fn=lambda: True,
+        approve_provider=lambda: True,
+    )
+    assert outcome.ok is True
+    assert outcome.password is None
+    assert outcome.status_only and outcome.status_only.get("approved") is True
+
+
+def test_browser_fill_approve_inline_no() -> None:
+    req = PromptRequest(action="browser-fill-approve", detail='{"url":"https://x"}')
+    outcome = require_browser_fill_approval(
+        req,
+        isatty_fn=lambda: True,
+        approve_provider=lambda: False,
+    )
+    assert outcome.ok is False
+    assert outcome.password is None
+    assert outcome.status_only and outcome.status_only.get("approved") is False
+
+
+def test_login_cli_stub(capsys) -> None:
+    rc = main(["login", "list"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not implemented" in err.lower() or "Phase 0" in err
+
+
+def test_browser_fill_cli_stub(capsys) -> None:
+    rc = main(["browser-fill", "status"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not implemented" in err.lower() or "Phase 0" in err
+
+
+def test_native_host_stub(capsys) -> None:
+    from key_amnesia.native_host import main as host_main
+
+    rc = host_main([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not implemented" in err.lower()


### PR DESCRIPTION
## Summary
- Additive vault schema (`logins`, `browser_associations`, `database_id`) via load/save defaults — no AEAD/HEADER/crypto changes
- `logins.py` CRUD + subdomain-suffix URL matching; browser-fill IPC co-hosted as second Listener in the guard child (`browser_fill.lock` dies with `ka lock`/expiry)
- CLI seams (`ka login`, `ka browser-fill`), `browser-fill-approve` yes/no prompt path, and `key-amnesia-browser-host` entry stub for later workstreams

## Test plan
- [x] `pytest` green (67 passed, 1 skipped)
- [x] Lock clears `browser_fill.lock` / fill IPC unreachable after unlock→lock
- [ ] Spot-check `ka login --help` / `ka browser-fill --help` dispatch to stubs
- [ ] Confirm no change to existing guard verbs or crypto layout