### PR TITLE
Implement ka login CRUD CLI with fresh auth

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -159,7 +159,7 @@ Master password never appears on this channel in any form. Master password is ne
 - **per-call (default):** no persistent guard; each privileged op goes through password routing; discard after use.
 - **cached:** `unlock` starts guard holding decrypted vault; timeout from unlock; ~2 min before expiry prompt extend on guard’s TTY if still interactive; `lock` tears down. Live guard → `run`/`list` skip prompt.
 
-Always fresh master-password routing (never guard shortcut) for `reveal`, `copy`, `remove`, `config set`, and **`set`**.
+Always fresh master-password routing (never guard shortcut) for `reveal`, `copy`, `remove`, `config set`, **`set`**, and **`login add` / `login list` / `login remove`**.
 
 ---
 
@@ -171,6 +171,10 @@ Always fresh master-password routing (never guard shortcut) for `reveal`, `copy`
 - `list` — read names sidecar (no prompt); never values
 - `unlock` / `lock` — cached session control
 - `reveal` / `copy` — always fresh auth; display location follows TTY vs helper rule
+- `login add <url> <username> <secret-name>` — fresh auth; associate an existing secret with a site/username (secret must already exist)
+- `login list` — fresh auth; print url/username/secret_name only (never password values); no prompt-free sidecar
+- `login remove <url> <username>` — fresh auth; drop that association
+- Extension `set-login` is stubbed in v2 — CLI `login add` is the only create path
 - `config set session-mode|session-timeout-minutes` — always fresh auth
 - `_prompt-helper` — internal; bare argv + env handoff; omitted from top-level summary, still supports `--help`
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,25 @@ Before a session expires, the guard asks *in its own window* whether to extend. 
 | `ka unlock` / `ka lock` | Start / end a cached session |
 | `ka reveal NAME` | Show a value to *you* (password required every time, even mid-session) |
 | `ka copy NAME` | Copy a value to your clipboard instead of showing it (same rule) |
+| `ka login …` | Manage URL/username ↔ secret associations for browser fill — see [Managing logins](#managing-logins) |
 | `ka config show` / `ka config set KEY VALUE` | View / change settings (changes require your password) |
 | `ka status` | Is a session active, and until when |
 
 Every command supports `--help`.
 
 `reveal` and `copy` deserve a special note: even if an agent invokes them, the value appears **only in the pop-up window on your screen** (or your clipboard) — the agent's own process receives nothing but a status flag. And they *always* require a fresh password, session or no session — so an agent can never ride an open session into actually reading a value.
+
+### Managing logins
+
+Browser fill looks up which vault secret to use for a site via **login associations** — a URL, username, and existing secret name. Create and manage them only from the CLI (the extension's `set-login` path is stubbed in v2; the CLI is the only create path):
+
+```text
+ka login add <url> <username> <secret-name>
+ka login list
+ka login remove <url> <username>
+```
+
+Each of these always asks for your master password (fresh auth — never a cached session shortcut). `list` prints `url`, `username`, and `secret_name` only — never password values. The named secret must already exist (`ka set` it first) before you can `login add` it.
 
 ## Under the hood
 

--- a/src/key_amnesia/login_cli.py
+++ b/src/key_amnesia/login_cli.py
@@ -1,4 +1,4 @@
-"""Login CLI stubs — handlers filled by workstream C."""
+"""Login CLI — manage URL/username ↔ secret associations (browser fill)."""
 
 from __future__ import annotations
 
@@ -6,6 +6,11 @@ import argparse
 from typing import Any
 
 from key_amnesia import theme
+from key_amnesia.audit import audit_event
+from key_amnesia.logins import LoginError, add_login, list_logins, remove_login
+from key_amnesia.paths import vault_path
+from key_amnesia.prompt_route import AuthOutcome, PromptRequest, require_human_auth
+from key_amnesia.vault import VaultError
 
 
 def build_login_parser(sub: Any) -> argparse.ArgumentParser:
@@ -26,9 +31,154 @@ def build_login_parser(sub: Any) -> argparse.ArgumentParser:
     return p
 
 
-def main(args: argparse.Namespace) -> int:
-    """Phase 0 stub — real handlers land in WS-C."""
-    theme.error(
-        "ka login is not implemented yet (Phase 0 stub; see workstream C).",
+def _auth(request: PromptRequest) -> tuple[bool, str | None, AuthOutcome]:
+    outcome = require_human_auth(request)
+    if not outcome.ok:
+        return False, None, outcome
+    return True, outcome.password, outcome
+
+
+def _cmd_add(args: argparse.Namespace) -> int:
+    url = args.url
+    username = args.username
+    secret_name = args.secret_name
+    if not vault_path().exists():
+        theme.error("Vault not initialized. Run 'ka init' first.")
+        return 1
+
+    request = PromptRequest(
+        action="login-add",
+        secret_names=[secret_name],
+        detail=f"{username} @ {url} → {secret_name}",
     )
+    ok, password, outcome = _auth(request)
+    if not ok:
+        theme.error(f"Denied: {outcome.reason}")
+        return 1
+
+    if password is not None:
+        try:
+            add_login(None, password, url, username, secret_name)
+        except (LoginError, VaultError) as e:
+            theme.error(f"Error: {e}")
+            audit_event(
+                "login-add",
+                secret_names=[secret_name],
+                route=outcome.route,
+                result="denied",
+                reason=str(e),
+            )
+            return 1
+        audit_event(
+            "login-add",
+            secret_names=[secret_name],
+            route=outcome.route,
+            result="allowed",
+        )
+        theme.success(f"Added login {username} @ {url} → {secret_name}.")
+        return 0
+
+    if outcome.status_only and outcome.status_only.get("action") == "login-add":
+        theme.success(f"Added login {username} @ {url} → {secret_name}.")
+        return 0
+    theme.error(f"Denied: {outcome.reason or 'login-add failed'}")
     return 1
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    if not vault_path().exists():
+        theme.error("Vault not initialized. Run 'ka init' first.")
+        return 1
+
+    request = PromptRequest(action="login-list")
+    ok, password, outcome = _auth(request)
+    if not ok:
+        theme.error(f"Denied: {outcome.reason}")
+        return 1
+
+    if password is not None:
+        try:
+            entries = list_logins(None, password)
+        except VaultError as e:
+            theme.error(f"Error: {e}")
+            audit_event(
+                "login-list",
+                route=outcome.route,
+                result="denied",
+                reason=str(e),
+            )
+            return 1
+        audit_event(
+            "login-list",
+            route=outcome.route,
+            result="allowed",
+        )
+        if not entries:
+            theme.info("No login associations.")
+            return 0
+        for entry in entries:
+            theme.out(
+                f"{entry['url']}\t{entry['username']}\t{entry['secret_name']}"
+            )
+        return 0
+
+    if outcome.status_only and outcome.status_only.get("action") == "login-list":
+        # Spawned helper already displayed the list.
+        return 0
+    theme.error(f"Denied: {outcome.reason or 'login-list failed'}")
+    return 1
+
+
+def _cmd_remove(args: argparse.Namespace) -> int:
+    url = args.url
+    username = args.username
+    if not vault_path().exists():
+        theme.error("Vault not initialized. Run 'ka init' first.")
+        return 1
+
+    request = PromptRequest(
+        action="login-remove",
+        detail=f"{username} @ {url}",
+    )
+    ok, password, outcome = _auth(request)
+    if not ok:
+        theme.error(f"Denied: {outcome.reason}")
+        return 1
+
+    if password is not None:
+        try:
+            remove_login(None, password, url, username)
+        except (LoginError, VaultError) as e:
+            theme.error(f"Error: {e}")
+            audit_event(
+                "login-remove",
+                route=outcome.route,
+                result="denied",
+                reason=str(e),
+            )
+            return 1
+        audit_event(
+            "login-remove",
+            route=outcome.route,
+            result="allowed",
+        )
+        theme.success(f"Removed login {username} @ {url}.")
+        return 0
+
+    if outcome.status_only and outcome.status_only.get("action") == "login-remove":
+        theme.success(f"Removed login {username} @ {url}.")
+        return 0
+    theme.error(f"Denied: {outcome.reason or 'login-remove failed'}")
+    return 1
+
+
+def main(args: argparse.Namespace) -> int:
+    cmd = getattr(args, "login_command", None)
+    if cmd == "add":
+        return _cmd_add(args)
+    if cmd == "list":
+        return _cmd_list(args)
+    if cmd == "remove":
+        return _cmd_remove(args)
+    theme.error("Usage: key-amnesia login {add|list|remove} ...")
+    return 2

--- a/tests/test_login_cli.py
+++ b/tests/test_login_cli.py
@@ -1,0 +1,158 @@
+"""CLI tests for ka login add|list|remove."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from key_amnesia.cli import main
+from key_amnesia.logins import list_logins
+from key_amnesia.prompt_route import AuthOutcome, PromptRequest
+
+
+def _auth_ok(password: str):
+    def fake(request: PromptRequest, *a, **k) -> AuthOutcome:
+        return AuthOutcome(ok=True, route="inline", password=password)
+
+    return fake
+
+
+def _auth_deny(request: PromptRequest, *a, **k) -> AuthOutcome:
+    return AuthOutcome(ok=False, route="inline", reason="cancelled")
+
+
+def test_login_help() -> None:
+    with pytest.raises(SystemExit) as ei:
+        main(["login", "--help"])
+    assert ei.value.code == 0
+
+
+def test_login_add_help() -> None:
+    with pytest.raises(SystemExit) as ei:
+        main(["login", "add", "--help"])
+    assert ei.value.code == 0
+
+
+def test_login_list_help() -> None:
+    with pytest.raises(SystemExit) as ei:
+        main(["login", "list", "--help"])
+    assert ei.value.code == 0
+
+
+def test_login_remove_help() -> None:
+    with pytest.raises(SystemExit) as ei:
+        main(["login", "remove", "--help"])
+    assert ei.value.code == 0
+
+
+def test_login_without_subcommand() -> None:
+    rc = main(["login"])
+    assert rc == 2
+
+
+def test_login_add_list_remove_roundtrip(
+    seeded_vault: Path, password: str, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        "key_amnesia.login_cli.require_human_auth",
+        _auth_ok(password),
+    )
+    rc = main(
+        ["login", "add", "https://example.com", "alice", "api_key"]
+    )
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "alice" in out.err or "alice" in out.out
+
+    rc = main(["login", "list"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    text = captured.out + captured.err
+    assert "https://example.com\talice\tapi_key" in text
+    assert "super-secret-value-123" not in text
+
+    entries = list_logins(None, password)
+    assert len(entries) == 1
+    assert entries[0]["secret_name"] == "api_key"
+
+    rc = main(["login", "remove", "https://example.com", "alice"])
+    assert rc == 0
+    assert list_logins(None, password) == []
+
+
+def test_login_add_unknown_secret(
+    seeded_vault: Path, password: str, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        "key_amnesia.login_cli.require_human_auth",
+        _auth_ok(password),
+    )
+    rc = main(
+        ["login", "add", "https://example.com", "alice", "no_such_secret"]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unknown secret" in err.lower()
+
+
+def test_login_fresh_auth_ignores_live_guard(
+    seeded_vault: Path, password: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from key_amnesia import guard as guard_mod
+
+    monkeypatch.setattr(guard_mod, "guard_is_alive", lambda *a, **k: True)
+    calls = {"guard_request": 0}
+
+    def fake_req(*a, **k):
+        calls["guard_request"] += 1
+        return {"ok": True}
+
+    monkeypatch.setattr(guard_mod, "guard_request", fake_req)
+    monkeypatch.setattr(
+        "key_amnesia.login_cli.require_human_auth",
+        _auth_ok(password),
+    )
+
+    assert main(["login", "list"]) == 0
+    assert (
+        main(
+            ["login", "add", "https://example.com", "bob", "db_pass"]
+        )
+        == 0
+    )
+    assert main(["login", "remove", "https://example.com", "bob"]) == 0
+    assert calls["guard_request"] == 0
+
+
+def test_login_denied_without_auth(
+    seeded_vault: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        "key_amnesia.login_cli.require_human_auth",
+        _auth_deny,
+    )
+    assert main(["login", "list"]) == 1
+    assert (
+        main(
+            ["login", "add", "https://example.com", "alice", "api_key"]
+        )
+        == 1
+    )
+    assert main(["login", "remove", "https://example.com", "alice"]) == 1
+    err = capsys.readouterr().err
+    assert "Denied" in err
+
+
+def test_login_list_empty(
+    seeded_vault: Path, password: str, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        "key_amnesia.login_cli.require_human_auth",
+        _auth_ok(password),
+    )
+    rc = main(["login", "list"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    text = captured.out + captured.err
+    assert "No login associations." in text

--- a/tests/test_phase0_seams.py
+++ b/tests/test_phase0_seams.py
@@ -42,11 +42,18 @@ def test_browser_fill_approve_inline_no() -> None:
     assert outcome.status_only and outcome.status_only.get("approved") is False
 
 
-def test_login_cli_stub(capsys) -> None:
+def test_login_cli_wired(monkeypatch, password, seeded_vault, capsys) -> None:
+    """login is implemented (WS-C); still requires fresh auth."""
+    from key_amnesia.prompt_route import AuthOutcome
+
+    monkeypatch.setattr(
+        "key_amnesia.login_cli.require_human_auth",
+        lambda *a, **k: AuthOutcome(ok=True, route="inline", password=password),
+    )
     rc = main(["login", "list"])
-    assert rc == 1
-    err = capsys.readouterr().err
-    assert "not implemented" in err.lower() or "Phase 0" in err
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "No login associations." in (captured.out + captured.err)
 
 
 def test_browser_fill_cli_stub(capsys) -> None:


### PR DESCRIPTION
## Summary
- Implement `ka login add|list|remove` with always-fresh master-password auth (same class as `set`/`remove`); never prints password values
- Document Managing logins in README and DESIGN (CLI-only create path; extension `set-login` stubbed in v2)
- Add `tests/test_login_cli.py` and update Phase 0 seam test so login is no longer treated as a stub

## Test plan
- [x] `python -m pytest tests/test_login_cli.py tests/test_phase0_seams.py -q --tb=short` (15 passed)
- [ ] Manual: `ka login --help` / `add|list|remove --help`
- [ ] Manual: add → list (tab-separated, no secrets) → remove roundtrip against a real vault
- [ ] Confirm a live guard session does not skip the password prompt for login commands