### PR TITLE
WS-A: KeePassXC-Browser Native Messaging protocol

### DIFF
--- a/src/key_amnesia/keepass_protocol.py
+++ b/src/key_amnesia/keepass_protocol.py
@@ -1,0 +1,505 @@
+"""KeePassXC-Browser Native Messaging wire protocol.
+
+Framing: uint32 little-endian length + UTF-8 JSON on stdin/stdout.
+Session crypto: NaCl box (PyNaCl) with the extension — not vault AEAD.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import struct
+from typing import Any, BinaryIO, Callable, Mapping
+
+from nacl.public import Box, PrivateKey, PublicKey
+
+from key_amnesia import __version__
+
+# Native Messaging payload cap (KeePassXC NATIVEMSG_MAX_LENGTH).
+NATIVEMSG_MAX_LENGTH = 1024 * 1024
+
+# Association id returned to the extension (matches vault schema example).
+ASSOCIATION_ID = "key-amnesia"
+
+# Protocol version string shown to the extension (feature gating is loose).
+PROTOCOL_VERSION = __version__
+
+TRUE_STR = "true"
+
+# KeePassXC error codes (BrowserMessageBuilder.h).
+ERROR_DATABASE_NOT_OPENED = 1
+ERROR_DATABASE_HASH_NOT_RECEIVED = 2
+ERROR_CLIENT_PUBLIC_KEY_NOT_RECEIVED = 3
+ERROR_CANNOT_DECRYPT_MESSAGE = 4
+ERROR_TIMEOUT_OR_NOT_CONNECTED = 5
+ERROR_ACTION_CANCELLED_OR_DENIED = 6
+ERROR_CANNOT_ENCRYPT_MESSAGE = 7
+ERROR_ASSOCIATION_FAILED = 8
+ERROR_ENCRYPTION_KEY_UNRECOGNIZED = 10
+ERROR_INCORRECT_ACTION = 12
+ERROR_EMPTY_MESSAGE_RECEIVED = 13
+ERROR_NO_URL_PROVIDED = 14
+ERROR_NO_LOGINS_FOUND = 15
+
+ERROR_MESSAGES: dict[int, str] = {
+    ERROR_DATABASE_NOT_OPENED: "Database not opened",
+    ERROR_DATABASE_HASH_NOT_RECEIVED: "Database hash not available",
+    ERROR_CLIENT_PUBLIC_KEY_NOT_RECEIVED: "Client public key not received",
+    ERROR_CANNOT_DECRYPT_MESSAGE: "Cannot decrypt message",
+    ERROR_TIMEOUT_OR_NOT_CONNECTED: "Timeout or not connected to KeePassXC",
+    ERROR_ACTION_CANCELLED_OR_DENIED: "Action cancelled or denied",
+    ERROR_CANNOT_ENCRYPT_MESSAGE: "Message encryption failed.",
+    ERROR_ASSOCIATION_FAILED: "KeePassXC association failed, try again",
+    ERROR_ENCRYPTION_KEY_UNRECOGNIZED: "Encryption key is not recognized",
+    ERROR_INCORRECT_ACTION: "Incorrect action",
+    ERROR_EMPTY_MESSAGE_RECEIVED: "Empty message received",
+    ERROR_NO_URL_PROVIDED: "No URL provided",
+    ERROR_NO_LOGINS_FOUND: "No logins found",
+}
+
+SUPPORTED_ACTIONS = frozenset(
+    {
+        "change-public-keys",
+        "get-databasehash",
+        "associate",
+        "test-associate",
+        "get-logins",
+    }
+)
+
+STUBBED_ACTIONS = frozenset(
+    {
+        "set-login",
+        "generate-password",
+        "create-new-group",
+        "get-database-groups",
+        "get-totp",
+        "lock-database",
+        "request-autotype",
+        "passkeys-get",
+        "passkeys-register",
+        "delete-entry",
+        "get-database-entries",
+        "get-logins-count",
+    }
+)
+
+FillRequestFn = Callable[..., dict[str, Any] | None]
+
+
+def b64encode(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def b64decode(data: str) -> bytes:
+    return base64.b64decode(data.encode("ascii"))
+
+
+def increment_nonce(nonce: bytes) -> bytes:
+    """sodium_increment — little-endian byte-wise increment."""
+    n = bytearray(nonce)
+    for i in range(len(n)):
+        n[i] = (n[i] + 1) & 0xFF
+        if n[i] != 0:
+            break
+    return bytes(n)
+
+
+def increment_nonce_b64(nonce_b64: str) -> str:
+    return b64encode(increment_nonce(b64decode(nonce_b64)))
+
+
+def error_reply(
+    action: str,
+    error_code: int,
+    *,
+    error: str | None = None,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    reply: dict[str, Any] = {
+        "action": action,
+        "errorCode": str(error_code),
+        "error": error
+        if error is not None
+        else ERROR_MESSAGES.get(error_code, "Unknown error"),
+    }
+    if request_id:
+        reply["requestID"] = request_id
+    return reply
+
+
+def read_native_message(stream: BinaryIO) -> dict[str, Any] | None:
+    """Read one Native Messaging frame. Returns None on clean EOF."""
+    header = stream.read(4)
+    if not header:
+        return None
+    if len(header) < 4:
+        raise ValueError("truncated Native Messaging length header")
+    (length,) = struct.unpack("<I", header)
+    if length == 0:
+        raise ValueError("empty Native Messaging payload")
+    if length > NATIVEMSG_MAX_LENGTH:
+        raise ValueError("Native Messaging payload too large")
+    raw = stream.read(length)
+    if len(raw) < length:
+        raise ValueError("truncated Native Messaging payload")
+    msg = json.loads(raw.decode("utf-8"))
+    if not isinstance(msg, dict):
+        raise TypeError("Native Messaging JSON must be an object")
+    return msg
+
+
+def write_native_message(stream: BinaryIO, message: Mapping[str, Any]) -> None:
+    """Write one Native Messaging frame."""
+    raw = json.dumps(message, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+    if len(raw) > NATIVEMSG_MAX_LENGTH:
+        raise ValueError("Native Messaging response too large")
+    stream.write(struct.pack("<I", len(raw)))
+    stream.write(raw)
+    stream.flush()
+
+
+class KeePassProtocol:
+    """Stateful KeePassXC-Browser session for one native-host connection."""
+
+    def __init__(
+        self,
+        *,
+        fill_request: FillRequestFn | None = None,
+        version: str = PROTOCOL_VERSION,
+        association_id: str = ASSOCIATION_ID,
+        fill_timeout: float = 120.0,
+    ) -> None:
+        self._fill_request = fill_request
+        self.version = version
+        self.association_id = association_id
+        self.fill_timeout = fill_timeout
+        self.client_public_key: PublicKey | None = None
+        self.host_private_key: PrivateKey | None = None
+        self.associated = False
+
+    def _fill(self, msg: dict[str, Any]) -> dict[str, Any] | None:
+        fn = self._fill_request
+        if fn is None:
+            from key_amnesia.browser_fill import browser_fill_request
+
+            fn = browser_fill_request
+            self._fill_request = fn
+        return fn(msg, timeout=self.fill_timeout)
+
+    def _box(self) -> Box | None:
+        if self.client_public_key is None or self.host_private_key is None:
+            return None
+        return Box(self.host_private_key, self.client_public_key)
+
+    def _encrypt(self, plaintext: Mapping[str, Any], nonce_b64: str) -> str | None:
+        box = self._box()
+        if box is None:
+            return None
+        try:
+            nonce = b64decode(nonce_b64)
+            raw = json.dumps(
+                plaintext, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8")
+            encrypted = box.encrypt(raw, nonce)
+            return b64encode(encrypted.ciphertext)
+        except Exception:
+            return None
+
+    def _decrypt(self, message_b64: str, nonce_b64: str) -> dict[str, Any] | None:
+        box = self._box()
+        if box is None:
+            return None
+        try:
+            nonce = b64decode(nonce_b64)
+            ciphertext = b64decode(message_b64)
+            plain = box.decrypt(ciphertext, nonce)
+            data = json.loads(plain.decode("utf-8"))
+            if not isinstance(data, dict):
+                return None
+            return data
+        except Exception:
+            return None
+
+    def _encrypted_response(
+        self,
+        action: str,
+        request_nonce_b64: str,
+        params: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        resp_nonce = increment_nonce_b64(request_nonce_b64)
+        inner: dict[str, Any] = {
+            "version": self.version,
+            "success": TRUE_STR,
+            "nonce": resp_nonce,
+        }
+        inner.update(params)
+        encrypted = self._encrypt(inner, resp_nonce)
+        if encrypted is None:
+            return error_reply(action, ERROR_CANNOT_ENCRYPT_MESSAGE)
+        return {
+            "action": action,
+            "message": encrypted,
+            "nonce": resp_nonce,
+        }
+
+    def _require_keys(self, action: str) -> dict[str, Any] | None:
+        if self.client_public_key is None or self.host_private_key is None:
+            return error_reply(action, ERROR_CLIENT_PUBLIC_KEY_NOT_RECEIVED)
+        return None
+
+    def _require_fill_session(
+        self, action: str
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        """Return (error_reply, status) — error if unlock/fill session absent."""
+        status = self._fill({"verb": "status"})
+        if status is None or not status.get("ok"):
+            return error_reply(action, ERROR_DATABASE_NOT_OPENED), None
+        if status.get("expired"):
+            return error_reply(action, ERROR_DATABASE_NOT_OPENED), None
+        return None, status
+
+    def process(self, request: Mapping[str, Any] | None) -> dict[str, Any]:
+        if not request:
+            return error_reply("", ERROR_EMPTY_MESSAGE_RECEIVED)
+
+        action = str(request.get("action") or "")
+        if not action:
+            return error_reply("", ERROR_INCORRECT_ACTION)
+
+        if action == "change-public-keys":
+            return self._handle_change_public_keys(request)
+
+        if action in STUBBED_ACTIONS:
+            return self._handle_stubbed(action, request)
+
+        if action not in SUPPORTED_ACTIONS:
+            return error_reply(action, ERROR_INCORRECT_ACTION)
+
+        # Remaining actions need a live fill session (ka unlock). Never spawn
+        # a master-password console from the native host.
+        err, status = self._require_fill_session(action)
+        if err is not None:
+            return err
+
+        if action == "get-databasehash":
+            return self._handle_get_databasehash(request, status or {})
+        if action == "associate":
+            return self._handle_associate(request, status or {})
+        if action == "test-associate":
+            return self._handle_test_associate(request, status or {})
+        if action == "get-logins":
+            return self._handle_get_logins(request, status or {})
+
+        return error_reply(action, ERROR_INCORRECT_ACTION)
+
+    def _handle_stubbed(
+        self, action: str, request: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        request_id = request.get("requestID")
+        if action == "set-login":
+            msg = (
+                "set-login is not supported; use `ka login add` "
+                "(fresh auth) to create logins"
+            )
+        else:
+            msg = f"{action} is not supported by key-amnesia v2"
+        return error_reply(
+            action,
+            ERROR_INCORRECT_ACTION,
+            error=msg,
+            request_id=str(request_id) if request_id else None,
+        )
+
+    def _handle_change_public_keys(self, request: Mapping[str, Any]) -> dict[str, Any]:
+        action = "change-public-keys"
+        client_pk_b64 = str(request.get("publicKey") or "")
+        nonce_b64 = str(request.get("nonce") or "")
+        if not client_pk_b64 or not nonce_b64:
+            return error_reply(action, ERROR_CLIENT_PUBLIC_KEY_NOT_RECEIVED)
+        try:
+            client_pk = PublicKey(b64decode(client_pk_b64))
+        except Exception:
+            return error_reply(action, ERROR_CLIENT_PUBLIC_KEY_NOT_RECEIVED)
+
+        host_sk = PrivateKey.generate()
+        self.client_public_key = client_pk
+        self.host_private_key = host_sk
+        self.associated = False
+
+        resp_nonce = increment_nonce_b64(nonce_b64)
+        return {
+            "action": action,
+            "version": self.version,
+            "publicKey": b64encode(bytes(host_sk.public_key)),
+            "success": TRUE_STR,
+            "nonce": resp_nonce,
+        }
+
+    def _decode_request(
+        self, request: Mapping[str, Any], action: str
+    ) -> tuple[dict[str, Any] | None, str | None, dict[str, Any] | None]:
+        key_err = self._require_keys(action)
+        if key_err is not None:
+            return key_err, None, None
+        message_b64 = str(request.get("message") or "")
+        nonce_b64 = str(request.get("nonce") or "")
+        if not message_b64 or not nonce_b64:
+            return error_reply(action, ERROR_CANNOT_DECRYPT_MESSAGE), None, None
+        decrypted = self._decrypt(message_b64, nonce_b64)
+        if decrypted is None:
+            return error_reply(action, ERROR_CANNOT_DECRYPT_MESSAGE), None, None
+        return None, increment_nonce_b64(nonce_b64), decrypted
+
+    def _handle_get_databasehash(
+        self, request: Mapping[str, Any], status: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        action = "get-databasehash"
+        err, _resp_nonce, decrypted = self._decode_request(request, action)
+        if err is not None:
+            return err
+        assert decrypted is not None
+        db_hash = str(status.get("database_id") or "")
+        if not db_hash:
+            return error_reply(action, ERROR_DATABASE_HASH_NOT_RECEIVED)
+        return self._encrypted_response(
+            action,
+            str(request.get("nonce") or ""),
+            {"action": "hash", "hash": db_hash},
+        )
+
+    def _handle_associate(
+        self, request: Mapping[str, Any], status: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        action = "associate"
+        err, _resp_nonce, decrypted = self._decode_request(request, action)
+        if err is not None:
+            return err
+        assert decrypted is not None
+
+        key_b64 = str(decrypted.get("key") or "")
+        id_key_b64 = str(decrypted.get("idKey") or "") or key_b64
+        if not key_b64:
+            return error_reply(action, ERROR_ASSOCIATION_FAILED)
+
+        if self.client_public_key is None:
+            return error_reply(action, ERROR_CLIENT_PUBLIC_KEY_NOT_RECEIVED)
+        try:
+            if b64decode(key_b64) != bytes(self.client_public_key):
+                return error_reply(action, ERROR_ASSOCIATION_FAILED)
+        except Exception:
+            return error_reply(action, ERROR_ASSOCIATION_FAILED)
+
+        store = self._fill(
+            {
+                "verb": "associate-store",
+                "id": self.association_id,
+                "id_key_b64": id_key_b64,
+            }
+        )
+        if store is None or not store.get("ok"):
+            return error_reply(action, ERROR_ACTION_CANCELLED_OR_DENIED)
+
+        self.associated = True
+        db_hash = str(status.get("database_id") or "")
+        return self._encrypted_response(
+            action,
+            str(request.get("nonce") or ""),
+            {"hash": db_hash, "id": self.association_id},
+        )
+
+    def _handle_test_associate(
+        self, request: Mapping[str, Any], status: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        action = "test-associate"
+        err, _resp_nonce, decrypted = self._decode_request(request, action)
+        if err is not None:
+            return err
+        assert decrypted is not None
+
+        assoc_id = str(decrypted.get("id") or "")
+        key_b64 = str(decrypted.get("key") or "")
+        if not assoc_id or not key_b64:
+            return error_reply(action, ERROR_DATABASE_NOT_OPENED)
+
+        result = self._fill({"verb": "test-associate", "id": assoc_id})
+        if result is None or not result.get("ok") or not result.get("associated"):
+            return error_reply(action, ERROR_ASSOCIATION_FAILED)
+
+        self.associated = True
+        db_hash = str(status.get("database_id") or "")
+        return self._encrypted_response(
+            action,
+            str(request.get("nonce") or ""),
+            {"hash": db_hash, "id": assoc_id},
+        )
+
+    def _handle_get_logins(
+        self, request: Mapping[str, Any], status: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        action = "get-logins"
+        if not self.associated:
+            return error_reply(action, ERROR_ASSOCIATION_FAILED)
+
+        err, _resp_nonce, decrypted = self._decode_request(request, action)
+        if err is not None:
+            return err
+        assert decrypted is not None
+
+        url = str(decrypted.get("url") or "")
+        if not url:
+            return error_reply(action, ERROR_NO_URL_PROVIDED)
+
+        submit_url = decrypted.get("submitUrl")
+        fill_msg: dict[str, Any] = {
+            "verb": "get-logins-for-url",
+            "url": url,
+        }
+        if submit_url:
+            fill_msg["submit_url"] = str(submit_url)
+
+        # Hold the Native Messaging request open for approval + fill IPC RTT.
+        result = self._fill(fill_msg)
+        if result is None:
+            return error_reply(action, ERROR_DATABASE_NOT_OPENED)
+        if not result.get("ok"):
+            reason = str(result.get("reason") or "")
+            lowered = reason.lower()
+            if reason in ("denied", "timeout") or "denied" in lowered or "timeout" in lowered:
+                return error_reply(action, ERROR_ACTION_CANCELLED_OR_DENIED)
+            return error_reply(action, ERROR_NO_LOGINS_FOUND)
+
+        entries = result.get("entries") or []
+        if not isinstance(entries, list) or not entries:
+            return error_reply(action, ERROR_NO_LOGINS_FOUND)
+
+        out_entries: list[dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            item: dict[str, Any] = {
+                "login": str(entry.get("login") or ""),
+                "name": str(entry.get("name") or ""),
+                "password": str(entry.get("password") or ""),
+            }
+            if entry.get("uuid") is not None:
+                item["uuid"] = str(entry.get("uuid"))
+            out_entries.append(item)
+
+        if not out_entries:
+            return error_reply(action, ERROR_NO_LOGINS_FOUND)
+
+        db_hash = str(status.get("database_id") or "")
+        assoc_id = str(decrypted.get("id") or self.association_id)
+        return self._encrypted_response(
+            action,
+            str(request.get("nonce") or ""),
+            {
+                "count": str(len(out_entries)),
+                "entries": out_entries,
+                "hash": db_hash,
+                "id": assoc_id,
+            },
+        )

--- a/src/key_amnesia/native_host.py
+++ b/src/key_amnesia/native_host.py
@@ -1,20 +1,75 @@
 """KeePassXC-Browser Native Messaging host entry point.
 
-Phase 0 stub — protocol implementation lands in workstream A.
+Console script: `key-amnesia-browser-host`
+Bare argv only — no secrets on the command line.
+Requires a live `ka unlock` fill session; never spawns a password prompt.
 """
 
 from __future__ import annotations
 
+import os
 import sys
+from typing import BinaryIO, TextIO
+
+from key_amnesia.keepass_protocol import (
+    KeePassProtocol,
+    read_native_message,
+    write_native_message,
+)
+
+
+def _ensure_binary_stdio() -> tuple[BinaryIO, BinaryIO]:
+    """Native Messaging requires binary length-prefixed frames."""
+    if sys.platform == "win32":
+        import msvcrt
+
+        msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
+        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+    return sys.stdin.buffer, sys.stdout.buffer
+
+
+def run_host(
+    *,
+    stdin: BinaryIO | None = None,
+    stdout: BinaryIO | None = None,
+    protocol: KeePassProtocol | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Process Native Messaging requests until stdin EOF.
+
+    Does not write passwords (or any secret values) to stderr or audit.log.
+    """
+    err = stderr if stderr is not None else sys.stderr
+    if stdin is None or stdout is None:
+        bin_in, bin_out = _ensure_binary_stdio()
+        stdin = stdin or bin_in
+        stdout = stdout or bin_out
+
+    session = protocol or KeePassProtocol()
+
+    while True:
+        try:
+            request = read_native_message(stdin)
+        except Exception as exc:  # noqa: BLE001 — protocol boundary
+            err.write(f"key-amnesia-browser-host: bad frame: {type(exc).__name__}\n")
+            return 1
+        if request is None:
+            return 0
+        try:
+            response = session.process(request)
+            write_native_message(stdout, response)
+        except Exception as exc:  # noqa: BLE001
+            err.write(
+                f"key-amnesia-browser-host: handler error: {type(exc).__name__}\n"
+            )
+            return 1
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Console script `key-amnesia-browser-host` — not implemented until WS-A."""
-    sys.stderr.write(
-        "key-amnesia-browser-host: not implemented yet "
-        "(Phase 0 stub; see workstream A).\n"
-    )
-    return 1
+    """Console script `key-amnesia-browser-host`."""
+    # Intentionally ignore argv content — host is bare; no secrets on argv.
+    _ = argv if argv is not None else sys.argv[1:]
+    return run_host()
 
 
 if __name__ == "__main__":

--- a/tests/test_keepass_protocol.py
+++ b/tests/test_keepass_protocol.py
@@ -1,0 +1,419 @@
+"""Unit tests for KeePassXC-Browser wire protocol helpers."""
+
+from __future__ import annotations
+
+import io
+import json
+import struct
+from typing import Any
+
+import pytest
+from nacl.public import Box, PrivateKey, PublicKey
+
+from key_amnesia.keepass_protocol import (
+    ASSOCIATION_ID,
+    ERROR_ACTION_CANCELLED_OR_DENIED,
+    ERROR_ASSOCIATION_FAILED,
+    ERROR_DATABASE_NOT_OPENED,
+    ERROR_INCORRECT_ACTION,
+    ERROR_NO_LOGINS_FOUND,
+    KeePassProtocol,
+    b64decode,
+    b64encode,
+    increment_nonce,
+    increment_nonce_b64,
+    read_native_message,
+    write_native_message,
+)
+
+
+def _nonce() -> bytes:
+    return b"\x01" * 24
+
+
+def _client_keys() -> tuple[PrivateKey, str]:
+    sk = PrivateKey.generate()
+    return sk, b64encode(bytes(sk.public_key))
+
+
+class FakeFill:
+    """In-memory fill IPC stand-in for protocol unit tests."""
+
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        database_id: str = "dbhashabc",
+        associations: list[dict[str, str]] | None = None,
+        entries: list[dict[str, str]] | None = None,
+        approve: bool = True,
+        deny_reason: str = "denied",
+    ) -> None:
+        self.available = available
+        self.database_id = database_id
+        self.associations = list(associations or [])
+        self.entries = list(entries or [])
+        self.approve = approve
+        self.deny_reason = deny_reason
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self, msg: dict[str, Any], timeout: float = 120.0
+    ) -> dict[str, Any] | None:
+        self.calls.append(dict(msg))
+        if not self.available:
+            return None
+        verb = msg.get("verb")
+        if verb == "status":
+            return {
+                "ok": True,
+                "database_id": self.database_id,
+                "login_count": len(self.entries),
+                "associated": bool(self.associations),
+                "expired": False,
+            }
+        if verb == "associate-store":
+            aid = str(msg.get("id") or "")
+            key = str(msg.get("id_key_b64") or "")
+            self.associations = [e for e in self.associations if e.get("id") != aid]
+            self.associations.append({"id": aid, "id_key_b64": key})
+            return {"ok": True, "associated": True, "id": aid}
+        if verb == "test-associate":
+            aid = str(msg.get("id") or "")
+            for e in self.associations:
+                if e.get("id") == aid:
+                    return {"ok": True, "associated": True, "id": aid}
+            return {"ok": False, "associated": False, "reason": "not associated"}
+        if verb == "get-logins-for-url":
+            if not self.approve:
+                return {"ok": False, "reason": self.deny_reason}
+            if not self.entries:
+                return {"ok": False, "reason": "no matching logins"}
+            return {"ok": True, "entries": list(self.entries)}
+        return {"ok": False, "reason": f"unknown verb: {verb}"}
+
+
+def _handshake(proto: KeePassProtocol, client_sk: PrivateKey) -> str:
+    nonce = b64encode(_nonce())
+    resp = proto.process(
+        {
+            "action": "change-public-keys",
+            "publicKey": b64encode(bytes(client_sk.public_key)),
+            "nonce": nonce,
+            "clientID": "test-client",
+        }
+    )
+    assert resp.get("success") == "true"
+    assert "publicKey" in resp
+    return str(resp["publicKey"])
+
+
+def _encrypt_to_host(
+    client_sk: PrivateKey,
+    host_pk_b64: str,
+    nonce_b64: str,
+    payload: dict[str, Any],
+) -> str:
+    box = Box(client_sk, PublicKey(b64decode(host_pk_b64)))
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return b64encode(box.encrypt(raw, b64decode(nonce_b64)).ciphertext)
+
+
+def _decrypt_from_host(
+    client_sk: PrivateKey,
+    host_pk_b64: str,
+    nonce_b64: str,
+    message_b64: str,
+) -> dict[str, Any]:
+    box = Box(client_sk, PublicKey(b64decode(host_pk_b64)))
+    plain = box.decrypt(b64decode(message_b64), b64decode(nonce_b64))
+    data = json.loads(plain.decode("utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _encrypted_action(
+    proto: KeePassProtocol,
+    client_sk: PrivateKey,
+    host_pk_b64: str,
+    action: str,
+    inner: dict[str, Any],
+    nonce: bytes | None = None,
+) -> dict[str, Any]:
+    n = nonce or _nonce()
+    nonce_b64 = b64encode(n)
+    inner = {**inner, "action": action}
+    msg = _encrypt_to_host(client_sk, host_pk_b64, nonce_b64, inner)
+    return proto.process(
+        {
+            "action": action,
+            "message": msg,
+            "nonce": nonce_b64,
+            "clientID": "test-client",
+        }
+    )
+
+
+def test_increment_nonce_little_endian() -> None:
+    n = bytes([255, 0, 0]) + bytes(21)
+    assert increment_nonce(n)[0] == 0
+    assert increment_nonce(n)[1] == 1
+    assert increment_nonce_b64(b64encode(bytes(24))) == b64encode(
+        b"\x01" + bytes(23)
+    )
+
+
+def test_native_message_framing_roundtrip() -> None:
+    buf = io.BytesIO()
+    payload = {"action": "change-public-keys", "nonce": "abc"}
+    write_native_message(buf, payload)
+    raw = buf.getvalue()
+    (length,) = struct.unpack("<I", raw[:4])
+    assert length == len(raw) - 4
+    buf.seek(0)
+    assert read_native_message(buf) == payload
+    assert read_native_message(buf) is None
+
+
+def test_change_public_keys_and_get_databasehash() -> None:
+    fill = FakeFill(database_id="hash123")
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, _ = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "get-databasehash",
+        {"action": "get-databasehash"},
+    )
+    assert "message" in resp
+    inner = _decrypt_from_host(
+        client_sk, host_pk, str(resp["nonce"]), str(resp["message"])
+    )
+    assert inner["success"] == "true"
+    assert inner["hash"] == "hash123"
+    assert inner["action"] == "hash"
+
+
+def test_no_session_returns_database_not_opened() -> None:
+    fill = FakeFill(available=False)
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, _ = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "get-databasehash",
+        {"action": "get-databasehash"},
+    )
+    assert resp.get("errorCode") == str(ERROR_DATABASE_NOT_OPENED)
+    assert "Database not opened" in str(resp.get("error"))
+
+
+def test_associate_and_test_associate() -> None:
+    fill = FakeFill()
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, client_pk_b64 = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+
+    id_key = PrivateKey.generate()
+    id_key_b64 = b64encode(bytes(id_key.public_key))
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "associate",
+        {
+            "action": "associate",
+            "key": client_pk_b64,
+            "idKey": id_key_b64,
+        },
+        nonce=_nonce(),
+    )
+    assert "message" in resp
+    inner = _decrypt_from_host(
+        client_sk, host_pk, str(resp["nonce"]), str(resp["message"])
+    )
+    assert inner["id"] == ASSOCIATION_ID
+    assert proto.associated is True
+    assert fill.associations[0]["id_key_b64"] == id_key_b64
+
+    proto2 = KeePassProtocol(fill_request=fill)
+    host_pk2 = _handshake(proto2, client_sk)
+    resp2 = _encrypted_action(
+        proto2,
+        client_sk,
+        host_pk2,
+        "test-associate",
+        {"action": "test-associate", "id": ASSOCIATION_ID, "key": id_key_b64},
+        nonce=increment_nonce(_nonce()),
+    )
+    assert "message" in resp2
+    inner2 = _decrypt_from_host(
+        client_sk, host_pk2, str(resp2["nonce"]), str(resp2["message"])
+    )
+    assert inner2["success"] == "true"
+    assert inner2["id"] == ASSOCIATION_ID
+
+
+def test_associate_rejects_mismatched_session_key() -> None:
+    fill = FakeFill()
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, _ = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+    other_pk = b64encode(bytes(PrivateKey.generate().public_key))
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "associate",
+        {"action": "associate", "key": other_pk, "idKey": other_pk},
+    )
+    assert resp.get("errorCode") == str(ERROR_ASSOCIATION_FAILED)
+
+
+def test_get_logins_returns_entries() -> None:
+    fill = FakeFill(
+        entries=[
+            {
+                "login": "alice",
+                "name": "api_key",
+                "password": "super-secret-value-123",
+                "uuid": "api_key",
+            }
+        ]
+    )
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, client_pk_b64 = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+    _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "associate",
+        {
+            "action": "associate",
+            "key": client_pk_b64,
+            "idKey": client_pk_b64,
+        },
+    )
+
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "get-logins",
+        {
+            "action": "get-logins",
+            "url": "https://example.com/login",
+            "keys": [{"id": ASSOCIATION_ID, "key": client_pk_b64}],
+        },
+        nonce=increment_nonce(increment_nonce(_nonce())),
+    )
+    assert "message" in resp
+    inner = _decrypt_from_host(
+        client_sk, host_pk, str(resp["nonce"]), str(resp["message"])
+    )
+    assert inner["count"] == "1"
+    assert inner["entries"][0]["password"] == "super-secret-value-123"
+    assert inner["entries"][0]["login"] == "alice"
+    assert any(c.get("verb") == "get-logins-for-url" for c in fill.calls)
+
+
+def test_get_logins_requires_association() -> None:
+    fill = FakeFill(
+        entries=[{"login": "a", "name": "n", "password": "p"}],
+    )
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, _ = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "get-logins",
+        {"action": "get-logins", "url": "https://example.com"},
+    )
+    assert resp.get("errorCode") == str(ERROR_ASSOCIATION_FAILED)
+
+
+def test_get_logins_denied_maps_to_cancelled() -> None:
+    fill = FakeFill(
+        entries=[{"login": "a", "name": "n", "password": "p"}],
+        approve=False,
+    )
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, client_pk_b64 = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+    _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "associate",
+        {"action": "associate", "key": client_pk_b64, "idKey": client_pk_b64},
+    )
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "get-logins",
+        {"action": "get-logins", "url": "https://example.com"},
+        nonce=increment_nonce(_nonce()),
+    )
+    assert resp.get("errorCode") == str(ERROR_ACTION_CANCELLED_OR_DENIED)
+
+
+def test_get_logins_empty_maps_to_no_logins() -> None:
+    fill = FakeFill(entries=[], approve=True)
+    proto = KeePassProtocol(fill_request=fill)
+    client_sk, client_pk_b64 = _client_keys()
+    host_pk = _handshake(proto, client_sk)
+    _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "associate",
+        {"action": "associate", "key": client_pk_b64, "idKey": client_pk_b64},
+    )
+    fill.entries = []
+    resp = _encrypted_action(
+        proto,
+        client_sk,
+        host_pk,
+        "get-logins",
+        {"action": "get-logins", "url": "https://example.com"},
+        nonce=increment_nonce(_nonce()),
+    )
+    assert resp.get("errorCode") == str(ERROR_NO_LOGINS_FOUND)
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        "set-login",
+        "generate-password",
+        "get-totp",
+        "passkeys-get",
+        "create-new-group",
+    ],
+)
+def test_stubbed_actions_return_clear_error(action: str) -> None:
+    proto = KeePassProtocol(fill_request=FakeFill())
+    resp = proto.process({"action": action, "nonce": b64encode(_nonce())})
+    assert resp.get("errorCode") == str(ERROR_INCORRECT_ACTION)
+    assert "not supported" in str(resp.get("error")).lower()
+    if action == "set-login":
+        assert "ka login add" in str(resp.get("error"))
+
+
+def test_set_login_stub_does_not_need_fill_session() -> None:
+    """Stubbed actions must not require unlock (no password spawn path)."""
+    fill = FakeFill(available=False)
+    proto = KeePassProtocol(fill_request=fill)
+    resp = proto.process({"action": "set-login", "nonce": b64encode(_nonce())})
+    assert resp.get("errorCode") == str(ERROR_INCORRECT_ACTION)
+    assert fill.calls == []

--- a/tests/test_native_host_e2e.py
+++ b/tests/test_native_host_e2e.py
@@ -1,0 +1,274 @@
+"""End-to-end Native Messaging host tests (fake extension over pipes)."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from nacl.public import Box, PrivateKey, PublicKey
+
+from key_amnesia.keepass_protocol import (
+    ASSOCIATION_ID,
+    ERROR_DATABASE_NOT_OPENED,
+    ERROR_INCORRECT_ACTION,
+    KeePassProtocol,
+    b64decode,
+    b64encode,
+    read_native_message,
+    write_native_message,
+)
+from key_amnesia.native_host import run_host
+from key_amnesia.paths import audit_log_path
+
+
+def _nonce_at(n: int) -> bytes:
+    base = bytearray(24)
+    for _ in range(n):
+        for i in range(len(base)):
+            base[i] = (base[i] + 1) & 0xFF
+            if base[i] != 0:
+                break
+    return bytes(base)
+
+
+class FakeFill:
+    def __init__(self) -> None:
+        self.database_id = "e2e-database-hash"
+        self.associations: list[dict[str, str]] = []
+        self.password = "protocol-only-password-xyz"
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self, msg: dict[str, Any], timeout: float = 120.0
+    ) -> dict[str, Any] | None:
+        self.calls.append(dict(msg))
+        verb = msg.get("verb")
+        if verb == "status":
+            return {
+                "ok": True,
+                "database_id": self.database_id,
+                "login_count": 1,
+                "associated": bool(self.associations),
+                "expired": False,
+            }
+        if verb == "associate-store":
+            self.associations.append(
+                {
+                    "id": str(msg.get("id") or ""),
+                    "id_key_b64": str(msg.get("id_key_b64") or ""),
+                }
+            )
+            return {"ok": True, "associated": True, "id": msg.get("id")}
+        if verb == "test-associate":
+            aid = str(msg.get("id") or "")
+            for e in self.associations:
+                if e.get("id") == aid:
+                    return {"ok": True, "associated": True, "id": aid}
+            return {"ok": False, "associated": False}
+        if verb == "get-logins-for-url":
+            return {
+                "ok": True,
+                "entries": [
+                    {
+                        "login": "alice",
+                        "name": "api_key",
+                        "password": self.password,
+                        "uuid": "api_key",
+                    }
+                ],
+            }
+        return {"ok": False, "reason": "unknown"}
+
+
+def _encrypt(
+    client_sk: PrivateKey, host_pk_b64: str, nonce: bytes, payload: dict[str, Any]
+) -> str:
+    box = Box(client_sk, PublicKey(b64decode(host_pk_b64)))
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return b64encode(box.encrypt(raw, nonce).ciphertext)
+
+
+def _decrypt(
+    client_sk: PrivateKey, host_pk_b64: str, nonce_b64: str, message_b64: str
+) -> dict[str, Any]:
+    box = Box(client_sk, PublicKey(b64decode(host_pk_b64)))
+    plain = box.decrypt(b64decode(message_b64), b64decode(nonce_b64))
+    data = json.loads(plain.decode("utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _run_scripted_session(
+    requests: list[dict[str, Any]],
+    *,
+    protocol: KeePassProtocol,
+) -> list[dict[str, Any]]:
+    """Feed NM requests through run_host; collect framed responses."""
+    stdin = io.BytesIO()
+    for req in requests:
+        write_native_message(stdin, req)
+    stdin.seek(0)
+    stdout = io.BytesIO()
+    rc = run_host(
+        stdin=stdin,
+        stdout=stdout,
+        protocol=protocol,
+        stderr=io.StringIO(),
+    )
+    assert rc == 0
+    stdout.seek(0)
+    responses: list[dict[str, Any]] = []
+    while True:
+        msg = read_native_message(stdout)
+        if msg is None:
+            break
+        responses.append(msg)
+    return responses
+
+
+def test_e2e_handshake_associate_get_logins(ka_home: Path) -> None:
+    """Password appears in encrypted protocol response; never in audit.log."""
+    fill = FakeFill()
+    client_sk = PrivateKey.generate()
+    client_pk = b64encode(bytes(client_sk.public_key))
+    proto = KeePassProtocol(fill_request=fill)
+
+    n0 = _nonce_at(0)
+    hs = proto.process(
+        {
+            "action": "change-public-keys",
+            "publicKey": client_pk,
+            "nonce": b64encode(n0),
+            "clientID": "e2e",
+        }
+    )
+    assert hs.get("success") == "true"
+    host_pk = str(hs["publicKey"])
+
+    # Distinct nonces for each encrypted request (avoid NaCl nonce reuse).
+    n1 = _nonce_at(10)
+    n2 = _nonce_at(20)
+    requests = [
+        {
+            "action": "associate",
+            "message": _encrypt(
+                client_sk,
+                host_pk,
+                n1,
+                {"action": "associate", "key": client_pk, "idKey": client_pk},
+            ),
+            "nonce": b64encode(n1),
+            "clientID": "e2e",
+        },
+        {
+            "action": "get-logins",
+            "message": _encrypt(
+                client_sk,
+                host_pk,
+                n2,
+                {
+                    "action": "get-logins",
+                    "url": "https://example.com",
+                    "keys": [{"id": ASSOCIATION_ID, "key": client_pk}],
+                },
+            ),
+            "nonce": b64encode(n2),
+            "clientID": "e2e",
+        },
+    ]
+    responses = _run_scripted_session(requests, protocol=proto)
+    assert len(responses) == 2
+    assert responses[0]["action"] == "associate"
+    assert responses[1]["action"] == "get-logins"
+
+    assoc_inner = _decrypt(
+        client_sk, host_pk, str(responses[0]["nonce"]), str(responses[0]["message"])
+    )
+    assert assoc_inner["id"] == ASSOCIATION_ID
+
+    logins_inner = _decrypt(
+        client_sk, host_pk, str(responses[1]["nonce"]), str(responses[1]["message"])
+    )
+    assert logins_inner["entries"][0]["password"] == fill.password
+    assert logins_inner["entries"][0]["login"] == "alice"
+
+    audit = audit_log_path()
+    if audit.exists():
+        assert fill.password not in audit.read_text(encoding="utf-8")
+    # Outer NM JSON keeps the password inside the NaCl box only.
+    assert fill.password not in json.dumps(responses[1])
+
+
+def test_e2e_no_session_database_locked(ka_home: Path) -> None:
+    client_sk = PrivateKey.generate()
+    client_pk = b64encode(bytes(client_sk.public_key))
+    proto = KeePassProtocol(fill_request=lambda msg, timeout=120.0: None)
+
+    n0 = _nonce_at(0)
+    hs = proto.process(
+        {
+            "action": "change-public-keys",
+            "publicKey": client_pk,
+            "nonce": b64encode(n0),
+            "clientID": "e2e",
+        }
+    )
+    host_pk = str(hs["publicKey"])
+    n1 = _nonce_at(10)
+    responses = _run_scripted_session(
+        [
+            {
+                "action": "get-databasehash",
+                "message": _encrypt(
+                    client_sk,
+                    host_pk,
+                    n1,
+                    {"action": "get-databasehash"},
+                ),
+                "nonce": b64encode(n1),
+                "clientID": "e2e",
+            }
+        ],
+        protocol=proto,
+    )
+    assert len(responses) == 1
+    assert responses[0].get("errorCode") == str(ERROR_DATABASE_NOT_OPENED)
+
+
+def test_e2e_set_login_stub(ka_home: Path) -> None:
+    responses = _run_scripted_session(
+        [{"action": "set-login", "nonce": b64encode(_nonce_at(0)), "clientID": "e2e"}],
+        protocol=KeePassProtocol(fill_request=FakeFill()),
+    )
+    assert len(responses) == 1
+    assert responses[0].get("errorCode") == str(ERROR_INCORRECT_ACTION)
+    assert "ka login add" in str(responses[0].get("error"))
+
+
+def test_e2e_full_framing_including_handshake(ka_home: Path) -> None:
+    """Single host session: change-public-keys + associate framed on stdin."""
+    fill = FakeFill()
+    client_sk = PrivateKey.generate()
+    client_pk = b64encode(bytes(client_sk.public_key))
+    # Pre-generate host keypair by doing handshake on a throwaway, then rebuild
+    # requests for a fresh protocol inside run_host — use two-pass:
+    # Pass 1 learns nothing useful across processes; instead encrypt after
+    # injecting a protocol that we handshake first, then only frame post-handshake
+    # actions (covered above). Here verify change-public-keys framing alone.
+    responses = _run_scripted_session(
+        [
+            {
+                "action": "change-public-keys",
+                "publicKey": client_pk,
+                "nonce": b64encode(_nonce_at(0)),
+                "clientID": "e2e",
+            }
+        ],
+        protocol=KeePassProtocol(fill_request=fill),
+    )
+    assert len(responses) == 1
+    assert responses[0]["action"] == "change-public-keys"
+    assert responses[0].get("success") == "true"
+    assert "publicKey" in responses[0]


### PR DESCRIPTION
## Summary
- Implement Native Messaging framing (uint32 LE + JSON) and NaCl `box` session crypto in `keepass_protocol.py`.
- Wire `key-amnesia-browser-host` for `change-public-keys`, `get-databasehash`, `associate`, `test-associate`, and `get-logins` via live fill IPC (`ka unlock` required; no password spawn from host).
- Stub `set-login` and other extras with clear protocol errors; hold NM request open during fill approval; password stays in protocol ciphertext only (never audit.log).

## Test plan
- [x] `pytest tests/test_keepass_protocol.py tests/test_native_host_e2e.py -v` (20 passed)
- [ ] Note: `tests/test_phase0_seams.py::test_native_host_stub` will need integrator update (stub replaced)
- [ ] Manual: unlock session + KeePassXC-Browser extension handshake smoke (optional)