### PR TITLE
WS-E: Linux /dev/tty emulator install offer

### DIFF
--- a/src/key_amnesia/platform.py
+++ b/src/key_amnesia/platform.py
@@ -7,7 +7,9 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import Any, Callable
+from typing import Any, Callable, TextIO
+
+from key_amnesia import theme
 
 # Linux X11/Wayland terminal emulators, tried in order (first on PATH wins).
 _LINUX_EMULATORS: tuple[str, ...] = (
@@ -15,6 +17,23 @@ _LINUX_EMULATORS: tuple[str, ...] = (
     "gnome-terminal",
     "konsole",
     "xterm",
+)
+
+_LINUX_EMULATOR_DESCRIPTIONS: dict[str, str] = {
+    "x-terminal-emulator": "uses your distro's configured default terminal",
+    "gnome-terminal": "full-featured, best if you're on GNOME",
+    "konsole": "full-featured, best if you're on KDE",
+    "xterm": "lightest and fastest, no desktop-environment dependencies",
+}
+
+# Package-manager detection order (first on PATH wins).
+_PKG_MANAGERS: tuple[tuple[str, str], ...] = (
+    ("apt-get", "sudo apt-get install {pkg}"),
+    ("apt", "sudo apt install {pkg}"),
+    ("dnf", "sudo dnf install {pkg}"),
+    ("pacman", "sudo pacman -S {pkg}"),
+    ("apk", "sudo apk add {pkg}"),
+    ("zypper", "sudo zypper install {pkg}"),
 )
 
 # Brief pause after spawn to catch an emulator that launches then exits right
@@ -52,18 +71,42 @@ def _process_alive(proc: Any) -> bool:
         return True
 
 
-def _spawn_linux(
+def _no_emulator_oserror() -> OSError:
+    return OSError(
+        "No suitable terminal emulator found "
+        f"(tried {', '.join(_LINUX_EMULATORS)}). Fail closed."
+    )
+
+
+def _open_controlling_tty() -> TextIO | None:
+    """Open the controlling terminal, or None if unavailable."""
+    try:
+        return open("/dev/tty", "r+", encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _tty_readline(tty: TextIO, prompt: str) -> str:
+    tty.write(prompt)
+    tty.flush()
+    return tty.readline().strip()
+
+
+def _pkg_install_command(package: str) -> str | None:
+    """Return a one-line install command for *package*, or None if unknown pm."""
+    for binary, template in _PKG_MANAGERS:
+        if shutil.which(binary):
+            return template.format(pkg=package)
+    return None
+
+
+def _try_spawn_linux_emulators(
     argv: list[str],
     env: dict[str, str],
     *,
     popen_fn: Callable[..., Any],
-) -> Any:
-    if not _has_interactive_display():
-        raise OSError(
-            "No interactive display available (DISPLAY/WAYLAND_DISPLAY unset); "
-            "cannot spawn isolated console. Fail closed."
-        )
-
+) -> tuple[Any | None, list[str]]:
+    """Try each known emulator on PATH. Return (proc_or_None, names_tried)."""
     tried: list[str] = []
     for name in _LINUX_EMULATORS:
         path = shutil.which(name)
@@ -79,20 +122,113 @@ def _spawn_linux(
         if _POLL_DELAY_S:
             time.sleep(_POLL_DELAY_S)
         if _process_alive(proc):
-            return proc
+            return proc, tried
         # Launched but exited immediately (bad invocation, broken alias) —
         # don't report false success; try the next emulator instead.
         continue
+    return None, tried
+
+
+def _offer_linux_emulator_install(
+    argv: list[str],
+    env: dict[str, str],
+    *,
+    popen_fn: Callable[..., Any],
+) -> Any | None:
+    """Interactive /dev/tty recovery when no emulator is on PATH.
+
+    Returns a live process if the user installs and retry succeeds; otherwise
+    None (caller raises the existing OSError). Never prompts on the headless
+    branch — that path never reaches here. Never asks for a password.
+    """
+    tty = _open_controlling_tty()
+    if tty is None:
+        return None
+
+    err = _no_emulator_oserror()
+    try:
+        theme.warn(str(err), file=tty)
+        answer = _tty_readline(tty, "Install one now? [y/N] ").strip().lower()
+        if answer not in ("y", "yes"):
+            return None
+
+        theme.info("Choose a terminal emulator to install:", file=tty)
+        for i, name in enumerate(_LINUX_EMULATORS, start=1):
+            desc = _LINUX_EMULATOR_DESCRIPTIONS.get(name, "")
+            theme.info(f"  {i}) {name} — {desc}", file=tty)
+        skip_n = len(_LINUX_EMULATORS) + 1
+        theme.info(f"  {skip_n}) skip, don't install anything", file=tty)
+
+        choice_raw = _tty_readline(tty, "Choice: ").strip()
+        try:
+            choice = int(choice_raw)
+        except ValueError:
+            return None
+        if choice == skip_n or choice < 1 or choice > skip_n:
+            return None
+
+        package = _LINUX_EMULATORS[choice - 1]
+        cmd = _pkg_install_command(package)
+        if cmd is not None:
+            theme.info("Run this in another shell (not executed by key-amnesia):", file=tty)
+            theme.out(f"  {cmd}", file=tty)
+        else:
+            theme.info(
+                f"Install package '{package}' with your distro's package manager "
+                "(no known package manager found on PATH).",
+                file=tty,
+            )
+        _tty_readline(tty, "Press Enter after installing… ")
+
+        retry = _tty_readline(tty, "Installed it? Retry now? [y/N] ").strip().lower()
+        if retry not in ("y", "yes"):
+            return None
+
+        proc, tried = _try_spawn_linux_emulators(argv, env, popen_fn=popen_fn)
+        if proc is not None:
+            return proc
+        if tried:
+            # Found but none stayed running — surface the same message as the
+            # normal path rather than the "none on PATH" OSError.
+            raise OSError(
+                f"Terminal emulator(s) found ({', '.join(tried)}) but none stayed "
+                "running (bad invocation or immediate exit). Fail closed."
+            )
+        return None
+    finally:
+        try:
+            tty.close()
+        except Exception:
+            pass
+
+
+def _spawn_linux(
+    argv: list[str],
+    env: dict[str, str],
+    *,
+    popen_fn: Callable[..., Any],
+) -> Any:
+    if not _has_interactive_display():
+        raise OSError(
+            "No interactive display available (DISPLAY/WAYLAND_DISPLAY unset); "
+            "cannot spawn isolated console. Fail closed."
+        )
+
+    proc, tried = _try_spawn_linux_emulators(argv, env, popen_fn=popen_fn)
+    if proc is not None:
+        return proc
 
     if tried:
         raise OSError(
             f"Terminal emulator(s) found ({', '.join(tried)}) but none stayed "
             "running (bad invocation or immediate exit). Fail closed."
         )
-    raise OSError(
-        "No suitable terminal emulator found "
-        f"(tried {', '.join(_LINUX_EMULATORS)}). Fail closed."
-    )
+
+    # Display present, nothing on PATH — one interactive install offer via /dev/tty.
+    offered = _offer_linux_emulator_install(argv, env, popen_fn=popen_fn)
+    if offered is not None:
+        return offered
+    raise _no_emulator_oserror()
 
 
 def spawn_isolated_console(

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import io
 import sys
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
-from key_amnesia.platform import spawn_isolated_console
+from key_amnesia.platform import (
+    _LINUX_EMULATORS,
+    _pkg_install_command,
+    spawn_isolated_console,
+)
 
 
 HELPER_ARGV = [sys.executable, "-m", "key_amnesia", "_prompt-helper"]
@@ -26,6 +31,35 @@ def _fake_which(available: dict[str, str]):
         return available.get(name)
 
     return which
+
+
+class _FakeTTY(io.StringIO):
+    """Controlling-tty double: scripted readline answers + captured writes."""
+
+    def __init__(self, answers: list[str]):
+        super().__init__()
+        self._answers = list(answers)
+        self.writes: list[str] = []
+
+    def write(self, s: str) -> int:
+        self.writes.append(s)
+        return super().write(s)
+
+    def readline(self, *args: Any, **kwargs: Any) -> str:  # noqa: ARG002
+        if not self._answers:
+            return "\n"
+        return self._answers.pop(0) + "\n"
+
+    def isatty(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        # Leave buffer readable for assertions after the offer closes the tty.
+        pass
+
+    @property
+    def text(self) -> str:
+        return "".join(self.writes)
 
 
 @pytest.fixture(autouse=True)
@@ -187,16 +221,131 @@ def test_linux_headless_fail_closed(monkeypatch) -> None:
         spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
 
 
-def test_linux_no_emulator_fail_closed(monkeypatch) -> None:
+def test_linux_no_emulator_tty_unavailable_fail_closed(monkeypatch) -> None:
+    """No emulator + no /dev/tty → identical fail-closed (no offer attempted)."""
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.setattr(
         "key_amnesia.platform.shutil.which",
         _fake_which({}),
     )
+    monkeypatch.setattr("key_amnesia.platform._open_controlling_tty", lambda: None)
 
     with pytest.raises(OSError, match="terminal emulator|Fail closed"):
         spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
+
+
+def test_linux_no_emulator_decline_install_fail_closed(monkeypatch) -> None:
+    """User declines Install one now? → same OSError as today."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which({}),
+    )
+    tty = _FakeTTY(answers=["n"])
+    monkeypatch.setattr("key_amnesia.platform._open_controlling_tty", lambda: tty)
+
+    with pytest.raises(OSError, match="terminal emulator|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
+
+    assert "Install one now?" in tty.text
+    assert "No suitable terminal emulator found" in tty.text
+
+
+def test_linux_no_emulator_retry_still_empty_fail_closed(monkeypatch) -> None:
+    """Accept offer + menu + retry, second scan still empty → OSError (one offer only)."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which({"apt": "/usr/bin/apt"}),
+    )
+    # y → pick xterm (4) → Enter after install → y retry; which never finds emulators
+    tty = _FakeTTY(answers=["y", "4", "", "y"])
+    monkeypatch.setattr("key_amnesia.platform._open_controlling_tty", lambda: tty)
+
+    with pytest.raises(OSError, match="terminal emulator|Fail closed"):
+        spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=MagicMock())
+
+    text = tty.text
+    assert "Install one now?" in text
+    assert "xterm" in text
+    assert "sudo apt install xterm" in text
+    assert "Installed it? Retry now?" in text
+    # Menu shown once — no second Install offer.
+    assert text.count("Install one now?") == 1
+
+
+def test_linux_no_emulator_retry_success(monkeypatch) -> None:
+    """Accept offer; second which scan finds an emulator → spawn succeeds."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+
+    calls = {"n": 0}
+
+    def which(name: str) -> str | None:
+        # First pass (and pkg-mgr probes during offer): no emulators.
+        # After retry confirmation, xterm appears.
+        if name in _LINUX_EMULATORS:
+            calls["n"] += 1
+            # Emulator which is consulted once per name per scan. First scan:
+            # 4 misses. Offer path may re-probe pkg managers. Second scan after
+            # retry: return xterm.
+            if calls["n"] > len(_LINUX_EMULATORS) and name == "xterm":
+                return "/usr/bin/xterm"
+            return None
+        if name == "apt":
+            return "/usr/bin/apt"
+        return None
+
+    monkeypatch.setattr("key_amnesia.platform.shutil.which", which)
+    tty = _FakeTTY(answers=["y", "4", "", "y"])
+    monkeypatch.setattr("key_amnesia.platform._open_controlling_tty", lambda: tty)
+
+    captured: dict[str, Any] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        proc = MagicMock()
+        proc.poll.return_value = None
+        return proc
+
+    result = spawn_isolated_console(HELPER_ARGV, dict(SENSITIVE_ENV), popen_fn=fake_popen)
+
+    assert result.poll() is None
+    assert captured["cmd"] == ["/usr/bin/xterm", "-e", *HELPER_ARGV]
+    assert "sudo apt install xterm" in tty.text
+
+
+def test_pkg_manager_detection_order(monkeypatch) -> None:
+    """apt-get/apt, dnf, pacman, apk, zypper — first on PATH wins."""
+    order = ["apt-get", "apt", "dnf", "pacman", "apk", "zypper"]
+    expected = {
+        "apt-get": "sudo apt-get install xterm",
+        "apt": "sudo apt install xterm",
+        "dnf": "sudo dnf install xterm",
+        "pacman": "sudo pacman -S xterm",
+        "apk": "sudo apk add xterm",
+        "zypper": "sudo zypper install xterm",
+    }
+    for name in order:
+        available = {name: f"/usr/bin/{name}"}
+        monkeypatch.setattr(
+            "key_amnesia.platform.shutil.which",
+            _fake_which(available),
+        )
+        assert _pkg_install_command("xterm") == expected[name]
+
+    monkeypatch.setattr("key_amnesia.platform.shutil.which", _fake_which({}))
+    assert _pkg_install_command("xterm") is None
+
+    # Precedence: apt-get before apt when both present.
+    monkeypatch.setattr(
+        "key_amnesia.platform.shutil.which",
+        _fake_which({"apt-get": "/usr/bin/apt-get", "apt": "/usr/bin/apt"}),
+    )
+    assert _pkg_install_command("xterm") == "sudo apt-get install xterm"
 
 
 def test_darwin_fail_closed(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- When DISPLAY/WAYLAND is set but no `_LINUX_EMULATORS` entry is on PATH, open `/dev/tty` and offer a one-shot install flow (y/N → numbered menu → print pkg-manager command without executing → one retry).
- Headless path unchanged; tty unavailable or decline still raises the existing fail-closed `OSError`.
- Adds `test_posix` coverage for tty unavailable, decline, retry-empty, retry-success, and package-manager precedence.

## Test plan
- [x] `pytest tests/test_posix.py -v` (13 passed)
- [ ] Manual Linux smoke: display set, no emulators on PATH, confirm offer prints install cmd and does not execute it