### PR TITLE
v2 WS-B: Native Messaging host installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ Or from a local clone: `pip install .` — either way you get both the full `key
 
 > Windows and Linux supported; macOS still falls back to fail-closed (not yet implemented).
 
+### Browser fill — install
+
+key-amnesia can act as the Native Messaging host that the [KeePassXC-Browser](https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_setup_browser_integration) extension already talks to (`org.keepassxc.keepassxc_browser`). No separate extension is required.
+
+```bash
+# After pip install, register manifests for Chrome / Edge / Brave / Firefox:
+ka browser-fill install
+
+# Inspect what is registered (missing / ours / foreign):
+ka browser-fill status
+
+# Remove only key-amnesia's manifests:
+ka browser-fill uninstall
+```
+
+**`ka unlock` is required** before the extension can retrieve logins. Browser-fill runs only while a cached unlock session is live; there is no per-call password path from the native host.
+
+If a browser already has a host registered under that exact name (for example KeePassXC itself), install **warns and asks for confirmation** — or require `--force`. It never silently overwrites. Use `ka browser-fill status` to see `foreign(path=…)` entries before deciding.
+
+Windows and Linux only; macOS install fails closed with a clear message.
+
 ## Two modes: ask every time, or unlock a session
 
 | Mode | What it feels like |

--- a/src/key_amnesia/native_host_install.py
+++ b/src/key_amnesia/native_host_install.py
@@ -1,11 +1,526 @@
-"""Native Messaging host installer stubs — handlers filled by workstream B."""
+"""Install / status / uninstall Native Messaging manifests for browser-fill.
+
+Registers host name ``org.keepassxc.keepassxc_browser`` so the KeePassXC-Browser
+extension can find ``key-amnesia-browser-host``. Windows + Linux only; macOS
+fails closed.
+"""
 
 from __future__ import annotations
 
 import argparse
-from typing import Any
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal
 
 from key_amnesia import theme
+
+HOST_NAME = "org.keepassxc.keepassxc_browser"
+HOST_DESCRIPTION = "key-amnesia KeePassXC-Browser Native Messaging host"
+HOST_SCRIPT = "key-amnesia-browser-host"
+
+CHROMIUM_ALLOWED_ORIGINS = [
+    "chrome-extension://oboonakemofpalpdambfdlilmafhnnmo/",
+]
+FIREFOX_ALLOWED_EXTENSIONS = [
+    "keepassxc-browser@keepassxc.org",
+]
+
+BrowserFamily = Literal["chromium", "firefox"]
+InstallState = Literal["missing", "ours", "foreign", "invalid"]
+
+
+@dataclass(frozen=True)
+class BrowserTarget:
+    """One browser × OS install location."""
+
+    key: str
+    label: str
+    family: BrowserFamily
+    manifest_path: Path
+    # Windows HKCU relative key under Software\… (None = file-only)
+    registry_subkey: str | None = None
+
+
+ConfirmFn = Callable[[str], bool]
+WhichFn = Callable[[str], str | None]
+RegistryGetFn = Callable[[str], str | None]
+RegistrySetFn = Callable[[str, str], None]
+RegistryDeleteFn = Callable[[str], None]
+
+
+def _platform_name() -> str:
+    return sys.platform
+
+
+def _home() -> Path:
+    return Path.home()
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+def resolve_host_path(*, which_fn: WhichFn | None = None) -> Path | None:
+    """Absolute path to the ``key-amnesia-browser-host`` console script, if found."""
+    which = which_fn or shutil.which
+    found = which(HOST_SCRIPT)
+    if not found:
+        return None
+    return Path(found).resolve()
+
+
+def chromium_manifest(host_path: Path) -> dict[str, Any]:
+    return {
+        "name": HOST_NAME,
+        "description": HOST_DESCRIPTION,
+        "path": str(host_path),
+        "type": "stdio",
+        "allowed_origins": list(CHROMIUM_ALLOWED_ORIGINS),
+    }
+
+
+def firefox_manifest(host_path: Path) -> dict[str, Any]:
+    return {
+        "name": HOST_NAME,
+        "description": HOST_DESCRIPTION,
+        "path": str(host_path),
+        "type": "stdio",
+        "allowed_extensions": list(FIREFOX_ALLOWED_EXTENSIONS),
+    }
+
+
+def build_manifest(family: BrowserFamily, host_path: Path) -> dict[str, Any]:
+    if family == "firefox":
+        return firefox_manifest(host_path)
+    return chromium_manifest(host_path)
+
+
+def windows_targets(
+    *,
+    local_appdata: Path | None = None,
+    appdata: Path | None = None,
+) -> list[BrowserTarget]:
+    local = local_appdata or Path(
+        _env("LOCALAPPDATA") or str(_home() / "AppData" / "Local")
+    )
+    roaming = appdata or Path(
+        _env("APPDATA") or str(_home() / "AppData" / "Roaming")
+    )
+    name = f"{HOST_NAME}.json"
+    return [
+        BrowserTarget(
+            key="chrome",
+            label="Chrome",
+            family="chromium",
+            manifest_path=local
+            / "Google"
+            / "Chrome"
+            / "User Data"
+            / "NativeMessagingHosts"
+            / name,
+            registry_subkey=rf"Software\Google\Chrome\NativeMessagingHosts\{HOST_NAME}",
+        ),
+        BrowserTarget(
+            key="edge",
+            label="Edge",
+            family="chromium",
+            manifest_path=local
+            / "Microsoft"
+            / "Edge"
+            / "User Data"
+            / "NativeMessagingHosts"
+            / name,
+            registry_subkey=rf"Software\Microsoft\Edge\NativeMessagingHosts\{HOST_NAME}",
+        ),
+        BrowserTarget(
+            key="brave",
+            label="Brave",
+            family="chromium",
+            manifest_path=local
+            / "BraveSoftware"
+            / "Brave-Browser"
+            / "User Data"
+            / "NativeMessagingHosts"
+            / name,
+            registry_subkey=rf"Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\{HOST_NAME}",
+        ),
+        BrowserTarget(
+            key="firefox",
+            label="Firefox",
+            family="firefox",
+            manifest_path=roaming / "Mozilla" / "NativeMessagingHosts" / name,
+            registry_subkey=rf"Software\Mozilla\NativeMessagingHosts\{HOST_NAME}",
+        ),
+    ]
+
+
+def linux_targets(*, home: Path | None = None) -> list[BrowserTarget]:
+    h = home or _home()
+    name = f"{HOST_NAME}.json"
+    return [
+        BrowserTarget(
+            key="chrome",
+            label="Chrome",
+            family="chromium",
+            manifest_path=h
+            / ".config"
+            / "google-chrome"
+            / "NativeMessagingHosts"
+            / name,
+        ),
+        BrowserTarget(
+            key="chromium",
+            label="Chromium",
+            family="chromium",
+            manifest_path=h / ".config" / "chromium" / "NativeMessagingHosts" / name,
+        ),
+        BrowserTarget(
+            key="edge",
+            label="Edge",
+            family="chromium",
+            manifest_path=h
+            / ".config"
+            / "microsoft-edge"
+            / "NativeMessagingHosts"
+            / name,
+        ),
+        BrowserTarget(
+            key="brave",
+            label="Brave",
+            family="chromium",
+            manifest_path=h
+            / ".config"
+            / "BraveSoftware"
+            / "Brave-Browser"
+            / "NativeMessagingHosts"
+            / name,
+        ),
+        BrowserTarget(
+            key="firefox",
+            label="Firefox",
+            family="firefox",
+            manifest_path=h / ".mozilla" / "native-messaging-hosts" / name,
+        ),
+    ]
+
+
+def targets_for_platform(
+    platform: str | None = None,
+    *,
+    home: Path | None = None,
+    local_appdata: Path | None = None,
+    appdata: Path | None = None,
+) -> list[BrowserTarget]:
+    plat = platform if platform is not None else _platform_name()
+    if plat == "win32":
+        return windows_targets(local_appdata=local_appdata, appdata=appdata)
+    if plat.startswith("linux"):
+        return linux_targets(home=home)
+    return []
+
+
+def _normalize_path(value: str | Path) -> str:
+    try:
+        return str(Path(value).resolve())
+    except OSError:
+        return str(value)
+
+
+def is_our_manifest(data: dict[str, Any], host_path: Path) -> bool:
+    """True when manifest ``path`` already points at our host binary."""
+    raw = data.get("path")
+    if not isinstance(raw, str) or not raw:
+        return False
+    return _normalize_path(raw) == _normalize_path(host_path)
+
+
+def classify_manifest(
+    path: Path,
+    host_path: Path,
+) -> tuple[InstallState, str | None]:
+    """Return (state, foreign_path_or_None)."""
+    if not path.is_file():
+        return "missing", None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return "invalid", None
+    if not isinstance(data, dict):
+        return "invalid", None
+    raw = data.get("path")
+    if not isinstance(raw, str) or not raw:
+        return "invalid", None
+    if is_our_manifest(data, host_path):
+        return "ours", None
+    return "foreign", raw
+
+
+def _winreg_get(subkey: str) -> str | None:
+    import winreg
+
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, subkey) as key:
+            value, _ = winreg.QueryValueEx(key, "")
+            return str(value) if value else None
+    except OSError:
+        return None
+
+
+def _winreg_set(subkey: str, manifest_path: str) -> None:
+    import winreg
+
+    with winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, subkey) as key:
+        winreg.SetValueEx(key, "", 0, winreg.REG_SZ, manifest_path)
+
+
+def _winreg_delete(subkey: str) -> None:
+    import winreg
+
+    try:
+        winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+    except FileNotFoundError:
+        return
+    except OSError:
+        # Parent may still hold children; ignore best-effort uninstall noise.
+        return
+
+
+def default_confirm(prompt: str) -> bool:
+    try:
+        answer = input(f"{prompt} [y/N] ").strip().lower()
+    except EOFError:
+        return False
+    return answer in ("y", "yes")
+
+
+def write_manifest(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=False) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def remove_manifest(path: Path) -> bool:
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def _filter_targets(
+    targets: list[BrowserTarget],
+    browsers: list[str] | None,
+) -> list[BrowserTarget]:
+    if not browsers:
+        return list(targets)
+    wanted = {b.strip().lower() for b in browsers}
+    return [t for t in targets if t.key in wanted]
+
+
+def status_line(target: BrowserTarget, state: InstallState, foreign_path: str | None) -> str:
+    if state == "missing":
+        detail = "missing"
+    elif state == "ours":
+        detail = "ours"
+    elif state == "foreign":
+        detail = f"foreign(path={foreign_path})"
+    else:
+        detail = "invalid"
+    return f"{target.label}: {detail} ({target.manifest_path})"
+
+
+def cmd_status(
+    *,
+    host_path: Path | None = None,
+    targets: list[BrowserTarget] | None = None,
+    platform: str | None = None,
+    which_fn: WhichFn | None = None,
+) -> int:
+    plat = platform if platform is not None else _platform_name()
+    if plat == "darwin":
+        theme.error(
+            "Browser-fill Native Messaging install is not supported on macOS "
+            "(Windows and Linux only)."
+        )
+        return 1
+
+    host = host_path or resolve_host_path(which_fn=which_fn)
+    if host is None:
+        theme.warn(
+            f"Host binary {HOST_SCRIPT!r} not found on PATH; "
+            "status still reports manifest files."
+        )
+        # Use a sentinel so nothing classifies as "ours" without a real path.
+        host = Path("__key_amnesia_host_not_found__")
+
+    rows = targets if targets is not None else targets_for_platform(plat)
+    if not rows:
+        theme.error(f"No browser targets for platform {plat!r}.")
+        return 1
+
+    theme.info(f"Native Messaging host: {HOST_NAME}")
+    if host.name != "__key_amnesia_host_not_found__":
+        theme.info(f"Expected host path: {host}")
+    for target in rows:
+        state, foreign = classify_manifest(target.manifest_path, host)
+        line = status_line(target, state, foreign)
+        if state == "ours":
+            theme.success(line)
+        elif state in ("foreign", "invalid"):
+            theme.warn(line)
+        else:
+            theme.out(line)
+    return 0
+
+
+def cmd_install(
+    *,
+    force: bool = False,
+    browsers: list[str] | None = None,
+    host_path: Path | None = None,
+    targets: list[BrowserTarget] | None = None,
+    platform: str | None = None,
+    which_fn: WhichFn | None = None,
+    confirm_fn: ConfirmFn | None = None,
+    registry_get: RegistryGetFn | None = None,
+    registry_set: RegistrySetFn | None = None,
+) -> int:
+    plat = platform if platform is not None else _platform_name()
+    if plat == "darwin":
+        theme.error(
+            "Browser-fill Native Messaging install is not supported on macOS "
+            "(Windows and Linux only)."
+        )
+        return 1
+
+    host = host_path or resolve_host_path(which_fn=which_fn)
+    if host is None:
+        theme.error(
+            f"Could not find {HOST_SCRIPT!r} on PATH. "
+            "Install the package first (pip install .) then retry."
+        )
+        return 1
+
+    rows = _filter_targets(
+        targets if targets is not None else targets_for_platform(plat),
+        browsers,
+    )
+    if not rows:
+        theme.error("No matching browser targets.")
+        return 1
+
+    confirm = confirm_fn or default_confirm
+    reg_set = registry_set
+    if plat == "win32" and reg_set is None:
+        reg_set = _winreg_set
+
+    installed = 0
+    skipped = 0
+    for target in rows:
+        payload = build_manifest(target.family, host)
+        state, foreign = classify_manifest(target.manifest_path, host)
+
+        if state == "ours":
+            theme.info(f"{target.label}: already installed ({target.manifest_path})")
+            if plat == "win32" and target.registry_subkey and reg_set is not None:
+                reg_set(target.registry_subkey, str(target.manifest_path.resolve()))
+            installed += 1
+            continue
+
+        if state in ("foreign", "invalid"):
+            theme.warn(
+                f"{target.label}: existing Native Messaging host "
+                f"{HOST_NAME!r} at {target.manifest_path}"
+                + (f" (path={foreign})" if foreign else " (unreadable/invalid)")
+            )
+            theme.warn(
+                "Overwriting will replace KeePassXC (or another app) as the "
+                "Native Messaging host for this extension. Never done silently."
+            )
+            if not force:
+                if not confirm(f"Overwrite {target.label} manifest?"):
+                    theme.info(f"{target.label}: skipped (left untouched)")
+                    skipped += 1
+                    continue
+            else:
+                theme.warn(f"{target.label}: --force set; overwriting")
+
+        write_manifest(target.manifest_path, payload)
+        if plat == "win32" and target.registry_subkey and reg_set is not None:
+            reg_set(target.registry_subkey, str(target.manifest_path.resolve()))
+        theme.success(f"{target.label}: installed → {target.manifest_path}")
+        installed += 1
+
+    theme.info(
+        f"Done: {installed} installed/updated, {skipped} skipped. "
+        "Run `ka unlock` before the extension can retrieve logins."
+    )
+    return 0 if installed > 0 or skipped == 0 else 1
+
+
+def cmd_uninstall(
+    *,
+    browsers: list[str] | None = None,
+    host_path: Path | None = None,
+    targets: list[BrowserTarget] | None = None,
+    platform: str | None = None,
+    which_fn: WhichFn | None = None,
+    force: bool = False,
+    confirm_fn: ConfirmFn | None = None,
+    registry_delete: RegistryDeleteFn | None = None,
+) -> int:
+    plat = platform if platform is not None else _platform_name()
+    if plat == "darwin":
+        theme.error(
+            "Browser-fill Native Messaging install is not supported on macOS "
+            "(Windows and Linux only)."
+        )
+        return 1
+
+    host = host_path or resolve_host_path(which_fn=which_fn)
+    if host is None:
+        host = Path("__key_amnesia_host_not_found__")
+
+    rows = _filter_targets(
+        targets if targets is not None else targets_for_platform(plat),
+        browsers,
+    )
+    if not rows:
+        theme.error("No matching browser targets.")
+        return 1
+
+    confirm = confirm_fn or default_confirm
+    reg_del = registry_delete
+    if plat == "win32" and reg_del is None:
+        reg_del = _winreg_delete
+
+    removed = 0
+    for target in rows:
+        state, foreign = classify_manifest(target.manifest_path, host)
+        if state == "missing":
+            theme.out(f"{target.label}: nothing to remove")
+            continue
+        if state == "foreign" and not force:
+            theme.warn(
+                f"{target.label}: foreign host at {target.manifest_path} "
+                f"(path={foreign}); refusing to delete without --force"
+            )
+            continue
+        if state == "foreign" and force:
+            if not confirm(f"Delete foreign {target.label} manifest?"):
+                theme.info(f"{target.label}: skipped")
+                continue
+        remove_manifest(target.manifest_path)
+        if plat == "win32" and target.registry_subkey and reg_del is not None:
+            reg_del(target.registry_subkey)
+        theme.success(f"{target.label}: removed {target.manifest_path}")
+        removed += 1
+
+    theme.info(f"Uninstall complete ({removed} removed).")
+    return 0
 
 
 def build_browser_fill_parser(sub: Any) -> argparse.ArgumentParser:
@@ -15,15 +530,65 @@ def build_browser_fill_parser(sub: Any) -> argparse.ArgumentParser:
         help="Install or inspect KeePassXC-Browser Native Messaging host",
     )
     bf_sub = p.add_subparsers(dest="browser_fill_command")
-    bf_sub.add_parser("install", help="Install native messaging manifests")
+
+    install_p = bf_sub.add_parser(
+        "install",
+        help="Install native messaging manifests (Chrome/Edge/Brave/Firefox)",
+    )
+    install_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing foreign host manifest without prompting",
+    )
+    install_p.add_argument(
+        "--browser",
+        action="append",
+        dest="browsers",
+        metavar="NAME",
+        help=(
+            "Limit to one browser key (repeatable): "
+            "chrome, edge, brave, firefox[, chromium]"
+        ),
+    )
+
     bf_sub.add_parser("status", help="Show per-browser install status")
-    bf_sub.add_parser("uninstall", help="Remove key-amnesia native messaging manifests")
+
+    uninstall_p = bf_sub.add_parser(
+        "uninstall",
+        help="Remove key-amnesia native messaging manifests",
+    )
+    uninstall_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Also remove a foreign host manifest after confirmation",
+    )
+    uninstall_p.add_argument(
+        "--browser",
+        action="append",
+        dest="browsers",
+        metavar="NAME",
+        help="Limit to one browser key (repeatable)",
+    )
     return p
 
 
 def main(args: argparse.Namespace) -> int:
-    """Phase 0 stub — real handlers land in WS-B."""
-    theme.error(
-        "ka browser-fill is not implemented yet (Phase 0 stub; see workstream B).",
-    )
-    return 1
+    """Dispatch ``ka browser-fill`` subcommands."""
+    cmd = getattr(args, "browser_fill_command", None)
+    if cmd is None:
+        theme.error("Usage: ka browser-fill {install|status|uninstall} …")
+        return 2
+    if cmd == "status":
+        return cmd_status()
+    if cmd == "install":
+        return cmd_install(
+            force=bool(getattr(args, "force", False)),
+            browsers=getattr(args, "browsers", None),
+        )
+    if cmd == "uninstall":
+        return cmd_uninstall(
+            force=bool(getattr(args, "force", False)),
+            browsers=getattr(args, "browsers", None),
+        )
+    theme.error(f"Unknown browser-fill command: {cmd}")
+    return 2

--- a/tests/test_native_host_install.py
+++ b/tests/test_native_host_install.py
@@ -1,0 +1,386 @@
+"""Tests for Native Messaging host installer (workstream B)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from key_amnesia.cli import main as cli_main
+from key_amnesia.native_host_install import (
+    HOST_NAME,
+    build_manifest,
+    classify_manifest,
+    cmd_install,
+    cmd_status,
+    cmd_uninstall,
+    chromium_manifest,
+    firefox_manifest,
+    is_our_manifest,
+    linux_targets,
+    resolve_host_path,
+    windows_targets,
+)
+
+
+@pytest.fixture
+def host_bin(tmp_path: Path) -> Path:
+    path = tmp_path / "bin" / "key-amnesia-browser-host"
+    path.parent.mkdir(parents=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    return path.resolve()
+
+
+@pytest.fixture
+def win_roots(tmp_path: Path) -> tuple[Path, Path]:
+    local = tmp_path / "Local"
+    appdata = tmp_path / "Roaming"
+    local.mkdir()
+    appdata.mkdir()
+    return local, appdata
+
+
+@pytest.fixture
+def linux_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    return home
+
+
+def test_windows_manifest_paths(win_roots: tuple[Path, Path]) -> None:
+    local, appdata = win_roots
+    targets = windows_targets(local_appdata=local, appdata=appdata)
+    by_key = {t.key: t for t in targets}
+    assert set(by_key) == {"chrome", "edge", "brave", "firefox"}
+    assert by_key["chrome"].manifest_path == (
+        local
+        / "Google"
+        / "Chrome"
+        / "User Data"
+        / "NativeMessagingHosts"
+        / f"{HOST_NAME}.json"
+    )
+    assert by_key["edge"].manifest_path == (
+        local
+        / "Microsoft"
+        / "Edge"
+        / "User Data"
+        / "NativeMessagingHosts"
+        / f"{HOST_NAME}.json"
+    )
+    assert by_key["brave"].manifest_path == (
+        local
+        / "BraveSoftware"
+        / "Brave-Browser"
+        / "User Data"
+        / "NativeMessagingHosts"
+        / f"{HOST_NAME}.json"
+    )
+    assert by_key["firefox"].manifest_path == (
+        appdata / "Mozilla" / "NativeMessagingHosts" / f"{HOST_NAME}.json"
+    )
+    assert by_key["chrome"].family == "chromium"
+    assert by_key["firefox"].family == "firefox"
+    assert by_key["firefox"].registry_subkey is not None
+
+
+def test_linux_manifest_paths(linux_home: Path) -> None:
+    targets = linux_targets(home=linux_home)
+    by_key = {t.key: t for t in targets}
+    assert set(by_key) == {"chrome", "chromium", "edge", "brave", "firefox"}
+    assert by_key["chrome"].manifest_path == (
+        linux_home
+        / ".config"
+        / "google-chrome"
+        / "NativeMessagingHosts"
+        / f"{HOST_NAME}.json"
+    )
+    assert by_key["chromium"].manifest_path == (
+        linux_home / ".config" / "chromium" / "NativeMessagingHosts" / f"{HOST_NAME}.json"
+    )
+    assert by_key["edge"].manifest_path == (
+        linux_home
+        / ".config"
+        / "microsoft-edge"
+        / "NativeMessagingHosts"
+        / f"{HOST_NAME}.json"
+    )
+    assert by_key["brave"].manifest_path == (
+        linux_home
+        / ".config"
+        / "BraveSoftware"
+        / "Brave-Browser"
+        / "NativeMessagingHosts"
+        / f"{HOST_NAME}.json"
+    )
+    assert by_key["firefox"].manifest_path == (
+        linux_home / ".mozilla" / "native-messaging-hosts" / f"{HOST_NAME}.json"
+    )
+
+
+def test_manifest_json_shape(host_bin: Path) -> None:
+    chrome = chromium_manifest(host_bin)
+    assert chrome["name"] == HOST_NAME
+    assert chrome["type"] == "stdio"
+    assert chrome["path"] == str(host_bin)
+    assert chrome["allowed_origins"] == [
+        "chrome-extension://oboonakemofpalpdambfdlilmafhnnmo/"
+    ]
+    assert "allowed_extensions" not in chrome
+
+    ff = firefox_manifest(host_bin)
+    assert ff["name"] == HOST_NAME
+    assert ff["allowed_extensions"] == ["keepassxc-browser@keepassxc.org"]
+    assert "allowed_origins" not in ff
+
+
+def test_classify_missing_ours_foreign(tmp_path: Path, host_bin: Path) -> None:
+    path = tmp_path / f"{HOST_NAME}.json"
+    assert classify_manifest(path, host_bin) == ("missing", None)
+
+    write = build_manifest("chromium", host_bin)
+    path.write_text(json.dumps(write), encoding="utf-8")
+    assert classify_manifest(path, host_bin) == ("ours", None)
+    assert is_our_manifest(write, host_bin)
+
+    foreign_host = tmp_path / "keepassxc-proxy"
+    foreign_host.write_text("x", encoding="utf-8")
+    path.write_text(
+        json.dumps(build_manifest("chromium", foreign_host.resolve())),
+        encoding="utf-8",
+    )
+    state, foreign = classify_manifest(path, host_bin)
+    assert state == "foreign"
+    assert foreign is not None
+    assert "keepassxc-proxy" in foreign
+
+
+def test_install_writes_all_linux_browsers(linux_home: Path, host_bin: Path) -> None:
+    targets = linux_targets(home=linux_home)
+
+    rc = cmd_install(
+        host_path=host_bin,
+        targets=targets,
+        platform="linux",
+        force=False,
+    )
+    assert rc == 0
+    for t in targets:
+        assert t.manifest_path.is_file()
+        data = json.loads(t.manifest_path.read_text(encoding="utf-8"))
+        assert data["name"] == HOST_NAME
+        assert data["path"] == str(host_bin)
+        if t.family == "chromium":
+            assert "allowed_origins" in data
+        else:
+            assert "allowed_extensions" in data
+
+
+def test_install_prints_unlock_note(
+    linux_home: Path, host_bin: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = cmd_install(
+        host_path=host_bin,
+        targets=linux_targets(home=linux_home),
+        platform="linux",
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "ka unlock" in combined
+
+
+def test_collision_never_silent_without_force(
+    linux_home: Path, host_bin: Path, tmp_path: Path
+) -> None:
+    targets = linux_targets(home=linux_home)
+    chrome = next(t for t in targets if t.key == "chrome")
+    foreign = tmp_path / "other-host"
+    foreign.write_text("x", encoding="utf-8")
+    chrome.manifest_path.parent.mkdir(parents=True)
+    chrome.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", foreign.resolve())),
+        encoding="utf-8",
+    )
+    prompts: list[str] = []
+
+    def decline(msg: str) -> bool:
+        prompts.append(msg)
+        return False
+
+    rc = cmd_install(
+        host_path=host_bin,
+        targets=[chrome],
+        platform="linux",
+        force=False,
+        confirm_fn=decline,
+    )
+    assert prompts, "must ask before overwrite"
+    data = json.loads(chrome.manifest_path.read_text(encoding="utf-8"))
+    assert data["path"] == str(foreign.resolve()), "must not silently overwrite"
+    assert rc == 1
+
+
+def test_collision_force_overwrites(
+    linux_home: Path, host_bin: Path, tmp_path: Path
+) -> None:
+    targets = linux_targets(home=linux_home)
+    chrome = next(t for t in targets if t.key == "chrome")
+    foreign = tmp_path / "other-host"
+    foreign.write_text("x", encoding="utf-8")
+    chrome.manifest_path.parent.mkdir(parents=True)
+    chrome.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", foreign.resolve())),
+        encoding="utf-8",
+    )
+
+    rc = cmd_install(
+        host_path=host_bin,
+        targets=[chrome],
+        platform="linux",
+        force=True,
+        confirm_fn=lambda _m: False,  # force should not need yes
+    )
+    assert rc == 0
+    data = json.loads(chrome.manifest_path.read_text(encoding="utf-8"))
+    assert data["path"] == str(host_bin)
+
+
+def test_collision_confirm_yes_overwrites(
+    linux_home: Path, host_bin: Path, tmp_path: Path
+) -> None:
+    chrome = next(t for t in linux_targets(home=linux_home) if t.key == "chrome")
+    foreign = tmp_path / "other-host"
+    foreign.write_text("x", encoding="utf-8")
+    chrome.manifest_path.parent.mkdir(parents=True)
+    chrome.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", foreign.resolve())),
+        encoding="utf-8",
+    )
+
+    rc = cmd_install(
+        host_path=host_bin,
+        targets=[chrome],
+        platform="linux",
+        force=False,
+        confirm_fn=lambda _m: True,
+    )
+    assert rc == 0
+    data = json.loads(chrome.manifest_path.read_text(encoding="utf-8"))
+    assert data["path"] == str(host_bin)
+
+
+def test_status_reports_missing_ours_foreign(
+    linux_home: Path, host_bin: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    targets = linux_targets(home=linux_home)
+    chrome = next(t for t in targets if t.key == "chrome")
+    edge = next(t for t in targets if t.key == "edge")
+    brave = next(t for t in targets if t.key == "brave")
+
+    chrome.manifest_path.parent.mkdir(parents=True)
+    chrome.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", host_bin)), encoding="utf-8"
+    )
+    foreign = tmp_path / "keepassxc"
+    foreign.write_text("x", encoding="utf-8")
+    edge.manifest_path.parent.mkdir(parents=True)
+    edge.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", foreign.resolve())), encoding="utf-8"
+    )
+
+    assert classify_manifest(chrome.manifest_path, host_bin)[0] == "ours"
+    assert classify_manifest(edge.manifest_path, host_bin)[0] == "foreign"
+    assert classify_manifest(brave.manifest_path, host_bin)[0] == "missing"
+
+    rc = cmd_status(host_path=host_bin, targets=[chrome, edge, brave], platform="linux")
+    assert rc == 0
+    captured = capsys.readouterr()
+    text = captured.out + captured.err
+    assert "ours" in text
+    assert "foreign" in text
+    assert "missing" in text
+    assert "path=" in text
+
+
+def test_windows_install_sets_registry(
+    win_roots: tuple[Path, Path], host_bin: Path
+) -> None:
+    local, appdata = win_roots
+    targets = windows_targets(local_appdata=local, appdata=appdata)
+    registry: dict[str, str] = {}
+
+    rc = cmd_install(
+        host_path=host_bin,
+        targets=targets,
+        platform="win32",
+        registry_set=lambda k, v: registry.__setitem__(k, v),
+    )
+    assert rc == 0
+    assert len(registry) == len(targets)
+    for t in targets:
+        assert t.registry_subkey in registry
+        assert registry[t.registry_subkey] == str(t.manifest_path.resolve())
+        assert t.manifest_path.is_file()
+
+
+def test_uninstall_removes_ours_only(
+    linux_home: Path, host_bin: Path, tmp_path: Path
+) -> None:
+    chrome = next(t for t in linux_targets(home=linux_home) if t.key == "chrome")
+    edge = next(t for t in linux_targets(home=linux_home) if t.key == "edge")
+    chrome.manifest_path.parent.mkdir(parents=True)
+    chrome.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", host_bin)), encoding="utf-8"
+    )
+    foreign = tmp_path / "other"
+    foreign.write_text("x", encoding="utf-8")
+    edge.manifest_path.parent.mkdir(parents=True)
+    edge.manifest_path.write_text(
+        json.dumps(build_manifest("chromium", foreign.resolve())), encoding="utf-8"
+    )
+
+    rc = cmd_uninstall(
+        host_path=host_bin,
+        targets=[chrome, edge],
+        platform="linux",
+        force=False,
+    )
+    assert rc == 0
+    assert not chrome.manifest_path.exists()
+    assert edge.manifest_path.exists(), "foreign must remain without --force"
+
+
+def test_macos_fails_closed(host_bin: Path) -> None:
+    assert cmd_install(host_path=host_bin, platform="darwin", targets=[]) == 1
+    assert cmd_status(host_path=host_bin, platform="darwin", targets=[]) == 1
+    assert cmd_uninstall(host_path=host_bin, platform="darwin", targets=[]) == 1
+
+
+def test_resolve_host_path(host_bin: Path) -> None:
+    found = resolve_host_path(which_fn=lambda _name: str(host_bin))
+    assert found == host_bin
+    assert resolve_host_path(which_fn=lambda _name: None) is None
+
+
+def test_cli_browser_fill_help() -> None:
+    with pytest.raises(SystemExit) as ei:
+        cli_main(["browser-fill", "--help"])
+    assert ei.value.code == 0
+    with pytest.raises(SystemExit) as ei:
+        cli_main(["browser-fill", "install", "--help"])
+    assert ei.value.code == 0
+
+
+def test_cli_status_runs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "Local"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "Roaming"))
+    (tmp_path / "Local").mkdir()
+    (tmp_path / "Roaming").mkdir()
+    monkeypatch.setattr(
+        "key_amnesia.native_host_install.resolve_host_path",
+        lambda **_k: tmp_path / "missing-host",
+    )
+    rc = cli_main(["browser-fill", "status"])
+    assert rc == 0

--- a/tests/test_phase0_seams.py
+++ b/tests/test_phase0_seams.py
@@ -49,11 +49,13 @@ def test_login_cli_stub(capsys) -> None:
     assert "not implemented" in err.lower() or "Phase 0" in err
 
 
-def test_browser_fill_cli_stub(capsys) -> None:
+def test_browser_fill_cli_wired(capsys) -> None:
+    """WS-B fills install/status; seam must dispatch (not the Phase 0 stub)."""
     rc = main(["browser-fill", "status"])
-    assert rc == 1
-    err = capsys.readouterr().err
-    assert "not implemented" in err.lower() or "Phase 0" in err
+    assert rc in (0, 1)
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "not implemented" not in out.lower()
 
 
 def test_native_host_stub(capsys) -> None:


### PR DESCRIPTION
## Summary
- Implement `ka browser-fill install|status|uninstall` for Chrome/Edge/Brave/Firefox on Windows and Linux (host name `org.keepassxc.keepassxc_browser`).
- Never silently overwrite a foreign host manifest — warn and confirm, or require `--force`; `status` reports missing / ours / foreign(path=…).
- README **Browser fill — install** subsection notes that `ka unlock` is required before the extension can retrieve logins.

## Test plan
- [x] `pytest tests/test_native_host_install.py` (paths, collision, status, registry, macOS fail-closed)
- [x] Full `pytest` green on this branch (83 passed, 1 skipped)
- [ ] Manual: `ka browser-fill install` then `status` on a Windows machine with Chrome/Edge installed
- [ ] Confirm existing KeePassXC host prompts before overwrite without `--force`