### PR TITLE
WS-D: v2 threat model, audit taxonomy, guard/fill regressions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,8 +1,8 @@
-# key-amnesia v1 — Design
+# key-amnesia v2 — Design
 
-Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted vault storage, Windows `CREATE_NEW_CONSOLE` human-prompt routing, a bounded-capability cached guard over named-pipe IPC (authkey only), and buffer-then-scrub output redaction.
+Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted vault storage, Windows `CREATE_NEW_CONSOLE` human-prompt routing, a bounded-capability cached guard over named-pipe IPC (authkey only), buffer-then-scrub output redaction, and KeePassXC-Browser Native Messaging fill (separate browser-fill IPC; guard verbs unchanged).
 
-**Out of scope for v1:** browser injection (planned as a distinct v3 sub-project), MCP wrapper, GUI, macOS isolated-console spawn (`Terminal.app` / `osascript`), DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
+**Out of scope for v2:** macOS (and Safari); forking/modifying the KeePassXC-Browser extension; atomic fill+submit; passkeys / TOTP / create-new-group; extension-driven `set-login` (stubbed — CLI `ka login add` is the only create path); per-call / no-session browser-fill (hard-require `ka unlock`); MCP wrapper; GUI; macOS isolated-console spawn (`Terminal.app` / `osascript`); DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
 
 ---
 
@@ -26,10 +26,16 @@ key-amnesia/
     crypto.py                      # Argon2id + SecretBox (vault only)
     vault.py                       # binary layout + JSON payload
     scrub.py                       # exact substring replace, no regex
-    audit.py
-    ipc.py                         # Listener/Client + authkey only
-    prompt_route.py                # isatty + CREATE_NEW_CONSOLE; env handoff
-    guard.py
+    audit.py                       # JSONL; browser-fill taxonomy never logs passwords
+    ipc.py                         # Listener/Client + authkey only (guard + fill addresses)
+    prompt_route.py                # isatty + CREATE_NEW_CONSOLE; env handoff; browser-fill-approve
+    guard.py                       # verbs frozen; co-hosts fill Listener
+    browser_fill.py                # second Listener; may return credentials after approval
+    logins.py                      # encrypted login CRUD / URL host match
+    login_cli.py                   # ka login … (WS-C)
+    native_host.py                 # KeePassXC-Browser host entry (WS-A)
+    native_host_install.py         # ka browser-fill install/status (WS-B)
+    keepass_protocol.py            # NaCl box framing (WS-A)
     run_exec.py                    # buffer-then-scrub-then-relay
     clipboard.py
     theme.py                       # branded CLI output (NO_COLOR / non-TTY safe)
@@ -37,7 +43,7 @@ key-amnesia/
   tests/
 ```
 
-Entry points: `key-amnesia` and `ka` both → `key_amnesia.cli:main`.
+Entry points: `key-amnesia` and `ka` both → `key_amnesia.cli:main`; `key-amnesia-browser-host` → `key_amnesia.native_host:main`.
 
 Deps: `pynacl`, `pyperclip`. Dev: `pytest`.
 
@@ -53,7 +59,20 @@ Deps: `pynacl`, `pyperclip`. Dev: `pytest`.
 magic[4]="KAM1" | version[1]=1 | salt[16] | opslimit[8] LE | memlimit[8] LE | SecretBox blob
 ```
 
-Payload JSON: `{"secrets": {...}, "created_at": "...", "updated_at": "..."}`.
+Payload JSON (v2 additive fields default on load for older vaults):
+
+```json
+{
+  "secrets": {"NAME": "value", ...},
+  "logins": [{"url": "https://example.com", "username": "u", "secret_name": "NAME"}],
+  "browser_associations": [{"id": "key-amnesia", "id_key_b64": "..."}],
+  "database_id": "<stable hex>",
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+Logins reference `secret_name` (no password duplication; no plaintext url/username sidecar). Domain match: equal hostnames, or `request_host.endswith("." + login_host)` (subdomain of stored host). Scheme/port ignored.
 
 KDF: `argon2id.kdf` with **OPSLIMIT_SENSITIVE / MEMLIMIT_SENSITIVE only** (deliberate; never dial down). Dir `~/.key-amnesia/` with `0o700` on POSIX; Windows user-profile ACL defaults.
 
@@ -75,9 +94,15 @@ Whole-vault AEAD cannot list names without the password. Sidecar `~/.key-amnesia
 
 **No `session_key_hex`.** Authkey authentication alone defines the IPC trust boundary. An extra SecretBox layer over messages was dropped: with a session key co-stored in `guard.lock` next to the authkey, the same processes that can read the authkey can read the session key — zero added protection, pure complexity.
 
+### Browser-fill lock (`browser_fill.lock`)
+
+Same shape as the guard lock (`address`, `authkey_hex`, `pid`, `expires_at`), distinct pipe/socket (`key-amnesia-fill-<hex>`). Authkey only. Started only as the second Listener inside the cached-mode guard child from `ka unlock`. `ka lock`, fill-IPC `lock`, and guard expiry tear down **both** listeners and delete **both** lock files — no residual fill window after lock/expiry.
+
 ### Audit (`audit.log` JSONL)
 
 `timestamp`, `action`, `secret_names`, `command`, `route` (`inline`|`spawned-console`|`guard-session`), `result` (`allowed`|`denied`|`timeout`), `reason`. Never secret values.
+
+Browser-fill actions: `browser-fill` / `browser-fill-denied` / `browser-fill-timeout`, with optional `url` (or host) and `username`. **Passwords must never appear in audit.log** (they may appear in the Native Messaging protocol response to the extension only).
 
 ---
 
@@ -128,6 +153,19 @@ Command output is **not live** — the agent sees it only after the command exit
 
 ---
 
+## Two-tier security model (v2)
+
+1. **Hard guarantee (unchanged):** the guard IPC never returns raw secrets; verbs stay exactly `{run, list, lock, status, renew}`. Automated regression asserts this dispatch set (`tests/test_guard_verbs_regression.py`).
+2. **Practical guarantee (new):** after a **mandatory per-attempt human approval popup**, a raw password may be handed to the KeePassXC-Browser extension (an uncontrolled process) over Native Messaging. The value never returns to an agent-invoked CLI context. Residual risk: an adversarial same-browser DOM observer could read autofilled fields — same honest tone as the base64-scrubbing caveat in README.
+
+**Auth precedent (call out by name):** browser-fill **reads** (`get-logins`) are **cached-session-eligible** — an explicit exception to the “always fresh auth” list, **narrowly scoped to reading an already-stored login**. The per-fill approval popup replaces the fresh-password gate **for that read only**. Vault **writes** (`ka set` / `ka login add|remove` / etc.) remain always-fresh-auth. Extension `set-login` is **not** in the exception (stubbed in v2 — return a clear protocol error; create logins only via CLI).
+
+**`ka unlock` hard requirement:** fill listener starts only inside the cached-mode guard child. There is **no** per-call / no-session fill path in v2 (Native Messaging request/response cannot hold a browser call open through a full master-password KDF + `prompt-timeout-seconds` without racing extension host timeouts). When fill IPC is unreachable, the native host returns a protocol “database locked / unavailable” error — it does not spawn a password console.
+
+**Host collision:** Native Messaging host name is fixed to `org.keepassxc.keepassxc_browser` (hardcoded by the extension). Only one active host for that name can exist per browser profile. If a foreign manifest already points elsewhere, install must warn and require confirm / `--force` — never silent overwrite.
+
+---
+
 ## Who holds plaintext (invariant-critical)
 
 | Path | Decryptor | Value use |
@@ -137,16 +175,17 @@ Command output is **not live** — the agent sees it only after the command exit
 | Cached `run` (live guard) | Guard | **Guard** spawns; IPC = scrubbed I/O + exit only |
 | Interactive reveal/copy | CLI | Same console print/clipboard |
 | Non-interactive reveal/copy | Helper | Show/copy **only in helper window**; caller gets status flag only |
+| Browser fill `get-logins` (live unlock) | Guard child / fill Listener | After yes/no approval: credentials → native host → extension only |
 
 Non-interactive per-call `run` makes the helper the one-shot decryptor and executor (bounded result shape, same as the guard path). Secrets are never handed back over IPC to the agent-invoked waiting process.
 
-Guard IPC has **no** `get-value`/`reveal` verb. Same-user processes can talk to the guard (ssh-agent limit); damage is bounded to `run`/`list`/`lock`/session-control only.
+Guard IPC has **no** `get-value`/`reveal` verb. Same-user processes can talk to the guard (ssh-agent limit); damage is bounded to `run`/`list`/`lock`/session-control only. Browser-fill is a **separate** channel — not a sixth guard verb — and is the only path that may return passwords, and only to the native host after approval.
 
 ---
 
 ## IPC
 
-`multiprocessing.connection` on `\\.\pipe\key-amnesia-<random>` + `authkey` only. Messages are ordinary pickled/JSON objects over the authenticated connection — **no additional payload SecretBox**.
+`multiprocessing.connection` on `\\.\pipe\key-amnesia-<random>` + `authkey` only. Messages are ordinary pickled/JSON objects over the authenticated connection — **no additional payload SecretBox**. Fill uses a parallel address style (`key-amnesia-fill-<hex>`).
 
 Guard verbs: `run`, `list`, `lock`, `status`, `renew` only.
 
@@ -156,10 +195,10 @@ Master password never appears on this channel in any form. Master password is ne
 
 ## Session modes
 
-- **per-call (default):** no persistent guard; each privileged op goes through password routing; discard after use.
-- **cached:** `unlock` starts guard holding decrypted vault; timeout from unlock; ~2 min before expiry prompt extend on guard’s TTY if still interactive; `lock` tears down. Live guard → `run`/`list` skip prompt.
+- **per-call (default):** no persistent guard; each privileged op goes through password routing; discard after use. Browser-fill is **unavailable** in this mode (no unlock session).
+- **cached:** `unlock` starts guard holding decrypted vault **and** the browser-fill Listener; timeout from unlock; ~2 min before expiry prompt extend on guard’s TTY if still interactive; `lock` tears down both. Live guard → `run`/`list` skip prompt; live fill → `get-logins-for-url` after per-attempt approval.
 
-Always fresh master-password routing (never guard shortcut) for `reveal`, `copy`, `remove`, `config set`, and **`set`**.
+Always fresh master-password routing (never guard shortcut) for `reveal`, `copy`, `remove`, `config set`, and **`set`**. Browser-fill **reads** are the named cached-session exception above (approval popup, not fresh password). Extension `set-login` remains stubbed — not cached-session-eligible.
 
 ---
 
@@ -198,10 +237,10 @@ def guard_handle_message(msg: dict, state: GuardState) -> dict: ...
 
 ## Guard never returns raw secret values
 
-The guard and helper IPC replies expose only: status, scrubbed stdout/stderr, exit codes, secret *names*, and session metadata. Never passwords. Never raw secret values.
+The guard and helper IPC replies expose only: status, scrubbed stdout/stderr, exit codes, secret *names*, and session metadata. Never passwords. Never raw secret values. Browser-fill is outside this channel: passwords may leave the fill Listener toward the native host only after approval, and must never be written to `audit.log`.
 
 ---
 
 ## Testing
 
-Vault round-trip / wrong password / tamper; `init` mismatch creates nothing, match creates an unlockable vault, refuses if a vault already exists; `set` refuses when no vault exists yet; scrubbing on both per-call and guard paths; crafted IPC client never gets raw values; `isatty=False` asserts `CREATE_NEW_CONSOLE`, bare argv, env handoff; password never in IPC; reveal/copy non-interactive returns status only; helper parent-death cancels; unlock→run→lock→fallback; reveal/copy ignore live guard; config/remove/`set` need password; audit with no plaintext; `--help` (including `init`); scrubber uses replace not regex; Linux emulator selection order and env/argv handoff, immediate-exit fallthrough to the next emulator, headless and no-emulator fail-closed, macOS/other-platform fail-closed (`test_posix.py`); themed output respects `NO_COLOR` and non-TTY streams, ASCII glyph fallback, scrubbed/revealed values stay unstyled (`test_theme.py`).
+Vault round-trip / wrong password / tamper; `init` mismatch creates nothing, match creates an unlockable vault, refuses if a vault already exists; `set` refuses when no vault exists yet; scrubbing on both per-call and guard paths; crafted IPC client never gets raw values; guard verb set regression (`{run,list,lock,status,renew}` only); fill lifecycle — `lock`/expiry kills fill IPC with no residual credential window; browser-fill audit actions never contain passwords; `isatty=False` asserts `CREATE_NEW_CONSOLE`, bare argv, env handoff; password never in IPC; reveal/copy non-interactive returns status only; helper parent-death cancels; unlock→run→lock→fallback; reveal/copy ignore live guard; config/remove/`set` need password; audit with no plaintext; `--help` (including `init`); scrubber uses replace not regex; Linux emulator selection order and env/argv handoff, immediate-exit fallthrough to the next emulator, headless and no-emulator fail-closed, macOS/other-platform fail-closed (`test_posix.py`); themed output respects `NO_COLOR` and non-TTY streams, ASCII glyph fallback, scrubbed/revealed values stay unstyled (`test_theme.py`).

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ For the security-curious — the full detail lives in [DESIGN.md](DESIGN.md):
 
 - **Encryption:** the vault is a single file sealed with XSalsa20-Poly1305 (libsodium's SecretBox) under a key derived from your master password via Argon2id at its most expensive (`SENSITIVE`) setting — deliberately slow to brute-force, and deliberately never dialed down.
 - **The routing rule:** any command needing your password checks whether it's running in a real terminal. Yes → asks right there. No (an agent invoked it) → spawns a fresh, isolated console window whose keyboard input can only come from you. No interactive session at all → fails closed, never falls back to something insecure.
-- **The guard never hands out secrets.** In cached mode, the guard *itself* runs your command with the secret injected and returns only the censored output and exit code. Its protocol simply has no "give me the value" request — so even another process connecting to it directly can't ask for one.
+- **The guard never hands out secrets.** In cached mode, the guard *itself* runs your command with the secret injected and returns only the censored output and exit code. Its protocol simply has no "give me the value" request — so even another process connecting to it directly can't ask for one. Guard verbs stay exactly `run` / `list` / `lock` / `status` / `renew`.
 - **Nothing sensitive on command lines.** Windows records process command lines in its audit logs (event 4688); key-amnesia passes all sensitive hand-off data between its own processes via environment variables instead.
-- **Audit log:** `~/.key-amnesia/audit.log`, append-only JSON lines — timestamp, action, secret names (never values), route, allowed/denied/timeout.
+- **Audit log:** `~/.key-amnesia/audit.log`, append-only JSON lines — timestamp, action, secret names (never values), route, allowed/denied/timeout. Browser-fill attempts use `browser-fill` / `browser-fill-denied` / `browser-fill-timeout` with site URL and optional username — still never the password.
+- **Two-tier model (v2 browser fill):** the hard guarantee above still holds for the agent/guard path. Separately, after you approve a fill popup, a password may be handed to the KeePassXC-Browser extension over Native Messaging. That value never comes back to an agent-invoked CLI. Fill requires a live `ka unlock` session (no per-call fill in v2). Extension `set-login` is stubbed — create logins via CLI only. Only one Native Messaging host named `org.keepassxc.keepassxc_browser` can be active per browser profile (install warns on collision).
 
 Files live in `~/.key-amnesia/` (override: `KEY_AMNESIA_HOME`, `KEY_AMNESIA_VAULT_PATH`).
 
@@ -92,13 +93,14 @@ Files live in `~/.key-amnesia/` (override: `KEY_AMNESIA_HOME`, `KEY_AMNESIA_VAUL
 No tool in this class can promise absolute secrecy, and we'd rather tell you exactly where the edges are:
 
 1. **A command you run can still leak its own secret.** Censoring catches exact copies of the value in output — a command that base64-encodes or otherwise obfuscates the secret before printing slips through. This limit is shared by every tool of this kind (`op run`, `teller run`).
-2. **Output is not live.** Command output is collected fully, censored, then released — the agent sees it only after the command finishes.
-3. **Secret *names* are stored in plain text** (so `ka list` can work without a password). Values never are. Treat names as non-sensitive labels.
-4. **The pop-up window assumes the agent can't control your screen.** If you've given an agent screen-reading *and* keyboard/mouse-injection powers, the window's isolation weakens — your typed password stays hidden, but a yes/no confirmation could theoretically be clicked by such an agent.
-5. **Headless machines fail closed.** No display → no way to approve → the operation is denied. By design.
-6. **Same-user processes share your privileges.** Any program running under your OS account can talk to a live guard session (this is equally true of `ssh-agent`). That's why the guard is designed to never return raw values — the worst a rogue same-user process gets is the same bounded "run a command" capability the legitimate path has.
-7. **The master password never crosses any inter-process channel**, in any form — it's consumed only inside the process that prompted you for it.
-8. **Avoid `ka set NAME VALUE` with the value inline.** It's supported for scripting, but an inline value briefly appears on the calling process's command line — visible to same-user process inspection and Windows command-line auditing. Prefer plain `ka set NAME` and type the value at the hidden prompt. (If an agent tries the inline form, the approval window shows you the incoming value before asking for your password — so you can still deny it.)
+2. **Browser autofill has a similar residual edge.** After you approve a fill, the password is in the page's form fields where a same-browser script or malicious extension could read it. key-amnesia still never returns that value to an agent CLI, and never writes it to the audit log.
+3. **Output is not live.** Command output is collected fully, censored, then released — the agent sees it only after the command finishes.
+4. **Secret *names* are stored in plain text** (so `ka list` can work without a password). Values never are. Treat names as non-sensitive labels.
+5. **The pop-up window assumes the agent can't control your screen.** If you've given an agent screen-reading *and* keyboard/mouse-injection powers, the window's isolation weakens — your typed password stays hidden, but a yes/no confirmation could theoretically be clicked by such an agent.
+6. **Headless machines fail closed.** No display → no way to approve → the operation is denied. By design.
+7. **Same-user processes share your privileges.** Any program running under your OS account can talk to a live guard session (this is equally true of `ssh-agent`). That's why the guard is designed to never return raw values — the worst a rogue same-user process gets is the same bounded "run a command" capability the legitimate path has. Browser-fill is a separate channel that *can* return passwords, but only to the native host after your per-attempt approval — and only while `ka unlock` is live.
+8. **The master password never crosses any inter-process channel**, in any form — it's consumed only inside the process that prompted you for it.
+9. **Avoid `ka set NAME VALUE` with the value inline.** It's supported for scripting, but an inline value briefly appears on the calling process's command line — visible to same-user process inspection and Windows command-line auditing. Prefer plain `ka set NAME` and type the value at the hidden prompt. (If an agent tries the inline form, the approval window shows you the incoming value before asking for your password — so you can still deny it.)
 
 ## CLI appearance
 

--- a/src/key_amnesia/audit.py
+++ b/src/key_amnesia/audit.py
@@ -12,6 +12,11 @@ from key_amnesia.paths import audit_log_path
 VALID_ROUTES = frozenset({"inline", "spawned-console", "guard-session"})
 VALID_RESULTS = frozenset({"allowed", "denied", "timeout"})
 
+# Browser-fill taxonomy (WS-D): action encodes outcome; never log passwords.
+BROWSER_FILL_ACTIONS = frozenset(
+    {"browser-fill", "browser-fill-denied", "browser-fill-timeout"}
+)
+
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
@@ -25,6 +30,8 @@ def audit_event(
     route: str,
     result: str,
     reason: str = "",
+    url: str | None = None,
+    username: str | None = None,
     path: Path | None = None,
 ) -> dict[str, Any]:
     """Append one audit record. Never includes secret values or passwords."""
@@ -47,8 +54,52 @@ def audit_event(
         "result": result,
         "reason": reason,
     }
+    # Optional browser-fill context — url/host and username only; never password.
+    if url is not None:
+        record["url"] = url
+    if username is not None:
+        record["username"] = username
+
     p = path or audit_log_path()
     p.parent.mkdir(parents=True, exist_ok=True)
     with p.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record, separators=(",", ":")) + "\n")
     return record
+
+
+def audit_browser_fill(
+    *,
+    result: str,
+    url: str = "",
+    username: str | None = None,
+    secret_names: Iterable[str] | None = None,
+    route: str = "inline",
+    reason: str = "",
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Record a browser-fill attempt.
+
+    Actions: ``browser-fill`` (allowed), ``browser-fill-denied``,
+    ``browser-fill-timeout``. Fields may include ``url`` and optional
+    ``username``; never a password.
+    """
+    if result == "allowed":
+        action = "browser-fill"
+        result_norm = "allowed"
+    elif result == "timeout":
+        action = "browser-fill-timeout"
+        result_norm = "timeout"
+    else:
+        action = "browser-fill-denied"
+        result_norm = "denied"
+
+    return audit_event(
+        action,
+        secret_names=secret_names,
+        route=route,
+        result=result_norm,
+        reason=reason,
+        url=url if url else None,
+        username=username,
+        path=path,
+    )

--- a/src/key_amnesia/browser_fill.py
+++ b/src/key_amnesia/browser_fill.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from key_amnesia import ipc
+from key_amnesia.audit import audit_browser_fill
 from key_amnesia.logins import find_logins_for_url
 from key_amnesia.paths import browser_fill_lock_path
 from key_amnesia.prompt_route import PromptRequest, require_browser_fill_approval
@@ -214,8 +215,26 @@ def fill_handle_message(
             approved = bool(so["approved"])
         else:
             approved = bool(getattr(outcome, "ok", False))
+        route = str(getattr(outcome, "route", None) or "inline")
+        if route not in ("inline", "spawned-console", "guard-session"):
+            route = "inline"
+        primary_user = usernames[0] if usernames else None
+        reason = str(getattr(outcome, "reason", "") or "")
         if not approved:
-            reason = getattr(outcome, "reason", "") or "denied"
+            reason = reason or "denied"
+            fill_result = (
+                "timeout"
+                if "timeout" in reason.lower() or "timed out" in reason.lower()
+                else "denied"
+            )
+            audit_browser_fill(
+                result=fill_result,
+                url=url,
+                username=primary_user,
+                secret_names=secret_names,
+                route=route,
+                reason=reason,
+            )
             return {"ok": False, "reason": reason}
 
         entries: list[dict[str, Any]] = []
@@ -233,7 +252,22 @@ def fill_handle_message(
                 }
             )
         if not entries:
+            audit_browser_fill(
+                result="denied",
+                url=url,
+                username=primary_user,
+                secret_names=secret_names,
+                route=route,
+                reason="no resolvable secrets",
+            )
             return {"ok": False, "reason": "no resolvable secrets"}
+        audit_browser_fill(
+            result="allowed",
+            url=url,
+            username=primary_user,
+            secret_names=secret_names,
+            route=route,
+        )
         return {"ok": True, "entries": entries}
 
     return {"ok": False, "reason": f"unknown verb: {verb}"}

--- a/tests/test_fill_lifecycle.py
+++ b/tests/test_fill_lifecycle.py
@@ -1,12 +1,14 @@
-"""Browser-fill IPC co-lifecycle with guard — lock clears fill."""
+"""Browser-fill IPC co-lifecycle with guard — lock/expiry clear fill; audit never logs passwords."""
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 from pathlib import Path
 
 from key_amnesia import ipc
+from key_amnesia.audit import BROWSER_FILL_ACTIONS, audit_browser_fill
 from key_amnesia.browser_fill import (
     FillState,
     browser_fill_request,
@@ -21,7 +23,7 @@ from key_amnesia.cli import main
 from key_amnesia.guard import (
     clear_guard_lock,
 )
-from key_amnesia.paths import browser_fill_lock_path, guard_lock_path
+from key_amnesia.paths import audit_log_path, browser_fill_lock_path, guard_lock_path
 from key_amnesia.prompt_route import AuthOutcome, PromptRequest
 from key_amnesia.vault import load_vault
 
@@ -34,8 +36,26 @@ def _auto_approve(request: PromptRequest) -> AuthOutcome:
     )
 
 
-def test_fill_handle_get_logins_after_approve() -> None:
-    state = FillState(
+def _deny(request: PromptRequest) -> AuthOutcome:
+    return AuthOutcome(
+        ok=False,
+        route="inline",
+        reason="denied",
+        status_only={"approved": False, "action": "browser-fill-approve"},
+    )
+
+
+def _timeout(request: PromptRequest) -> AuthOutcome:
+    return AuthOutcome(
+        ok=False,
+        route="spawned-console",
+        reason="approval timed out",
+        status_only={"approved": False, "action": "browser-fill-approve"},
+    )
+
+
+def _fill_state(**kwargs) -> FillState:
+    base = dict(
         secrets={"api_key": "super-secret-value-123"},
         logins=[
             {
@@ -50,48 +70,83 @@ def test_fill_handle_get_logins_after_approve() -> None:
         address="dummy",
         authkey=b"f" * 32,
     )
+    base.update(kwargs)
+    return FillState(**base)
+
+
+def test_fill_handle_get_logins_after_approve(ka_home: Path) -> None:
     reply = fill_handle_message(
         {"verb": "get-logins-for-url", "url": "https://app.example.com/login"},
-        state,
+        _fill_state(),
         approve_fn=_auto_approve,
     )
     assert reply["ok"] is True
     assert reply["entries"][0]["password"] == "super-secret-value-123"
     assert reply["entries"][0]["login"] == "alice"
 
+    # Password may be in the IPC reply — never in audit.log.
+    text = audit_log_path().read_text(encoding="utf-8")
+    assert "super-secret-value-123" not in text
+    records = [json.loads(line) for line in text.strip().splitlines()]
+    fill_recs = [r for r in records if r["action"] in BROWSER_FILL_ACTIONS]
+    assert fill_recs
+    last = fill_recs[-1]
+    assert last["action"] == "browser-fill"
+    assert last["result"] == "allowed"
+    assert last["url"] == "https://app.example.com/login"
+    assert last.get("username") == "alice"
+    assert "password" not in last
 
-def test_fill_handle_denied_without_approve() -> None:
-    state = FillState(
-        secrets={"api_key": "secret"},
-        logins=[
-            {
-                "url": "https://example.com",
-                "username": "alice",
-                "secret_name": "api_key",
-            }
-        ],
-        browser_associations=[],
-        database_id="abc",
-        expires_at=time.time() + 600,
-        address="dummy",
-        authkey=b"f" * 32,
-    )
 
-    def deny(_req: PromptRequest) -> AuthOutcome:
-        return AuthOutcome(
-            ok=False,
-            route="inline",
-            reason="denied",
-            status_only={"approved": False, "action": "browser-fill-approve"},
-        )
-
+def test_fill_handle_denied_without_approve(ka_home: Path) -> None:
     reply = fill_handle_message(
         {"verb": "get-logins-for-url", "url": "https://example.com"},
-        state,
-        approve_fn=deny,
+        _fill_state(),
+        approve_fn=_deny,
     )
     assert reply["ok"] is False
     assert "entries" not in reply
+
+    records = [
+        json.loads(line)
+        for line in audit_log_path().read_text(encoding="utf-8").strip().splitlines()
+    ]
+    last = [r for r in records if r["action"] in BROWSER_FILL_ACTIONS][-1]
+    assert last["action"] == "browser-fill-denied"
+    assert last["result"] == "denied"
+    assert "super-secret-value-123" not in json.dumps(last)
+
+
+def test_fill_handle_timeout_audited(ka_home: Path) -> None:
+    reply = fill_handle_message(
+        {"verb": "get-logins-for-url", "url": "https://example.com"},
+        _fill_state(),
+        approve_fn=_timeout,
+    )
+    assert reply["ok"] is False
+    records = [
+        json.loads(line)
+        for line in audit_log_path().read_text(encoding="utf-8").strip().splitlines()
+    ]
+    last = [r for r in records if r["action"] in BROWSER_FILL_ACTIONS][-1]
+    assert last["action"] == "browser-fill-timeout"
+    assert last["result"] == "timeout"
+    assert "password" not in last
+
+
+def test_audit_browser_fill_helper_never_password(ka_home: Path) -> None:
+    rec = audit_browser_fill(
+        result="allowed",
+        url="https://example.com",
+        username="alice",
+        secret_names=["api_key"],
+        route="inline",
+    )
+    assert rec["action"] == "browser-fill"
+    assert "password" not in rec
+    text = audit_log_path().read_text(encoding="utf-8")
+    assert "password" not in text or '"password"' not in text
+    assert "super-secret" not in text
 
 
 def test_lock_clears_browser_fill_lock(
@@ -145,12 +200,64 @@ def test_lock_clears_browser_fill_lock(
     ) is None
 
 
+def test_expiry_kills_fill_ipc(ka_home: Path) -> None:
+    """After session expiry, fill IPC cannot complete get-logins-for-url."""
+    listener, address, authkey = ipc.start_listener(
+        address=ipc.make_fill_pipe_address()
+    )
+    stop = threading.Event()
+    # Already expired — serve loop should exit; handle rejects credential verbs.
+    state = FillState(
+        secrets={"api_key": "super-secret-value-123"},
+        logins=[
+            {
+                "url": "https://example.com",
+                "username": "alice",
+                "secret_name": "api_key",
+            }
+        ],
+        browser_associations=[],
+        database_id="id",
+        expires_at=time.time() - 1,
+        address=address,
+        authkey=authkey,
+        pid=0,
+        stop=stop,
+    )
+    write_browser_fill_lock(address, authkey, 0, state.expires_at)
+
+    # Direct handle: expired session refuses credential pull.
+    reply = fill_handle_message(
+        {"verb": "get-logins-for-url", "url": "https://example.com"},
+        state,
+        approve_fn=_auto_approve,
+    )
+    assert reply.get("ok") is False
+    assert reply.get("expired") is True
+    assert "entries" not in reply
+    assert "super-secret-value-123" not in str(reply)
+
+    # fill_is_alive treats past expires_at as dead.
+    assert fill_is_alive(read_browser_fill_lock()) is False
+
+    t = threading.Thread(
+        target=fill_serve,
+        args=(state, listener),
+        kwargs={"approve_fn": _auto_approve},
+        daemon=True,
+    )
+    t.start()
+    t.join(timeout=3)
+    assert stop.is_set() or not t.is_alive()
+    clear_browser_fill_lock()
+
+
 def test_fill_lock_verb_stops_listener(ka_home: Path) -> None:
     """Fill IPC lock verb shuts down the fill listener and clears its lock."""
     listener, address, authkey = ipc.start_listener(
         address=ipc.make_fill_pipe_address()
     )
-    stop = __import__("threading").Event()
+    stop = threading.Event()
     state = FillState(
         secrets={"k": "v"},
         logins=[],

--- a/tests/test_guard_verbs_regression.py
+++ b/tests/test_guard_verbs_regression.py
@@ -1,0 +1,79 @@
+"""Guard IPC verb set is frozen — hard guarantee of the two-tier model."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from key_amnesia.guard import GuardState, guard_handle_message
+
+# Exact dispatch set — must not grow without a deliberate design change.
+GUARD_VERBS = frozenset({"run", "list", "lock", "status", "renew"})
+
+
+def _state() -> GuardState:
+    return GuardState(
+        secrets={"api_key": "super-secret-value-123"},
+        expires_at=time.time() + 600,
+        address="dummy",
+        authkey=b"g" * 32,
+    )
+
+
+def test_guard_verb_set_exactly_five() -> None:
+    """Regression: guard recognizes exactly {run, list, lock, status, renew}."""
+    state = _state()
+    recognized: set[str] = set()
+    probes = sorted(GUARD_VERBS | {"get-value", "reveal", "get", "copy", "browser-fill"})
+    for verb in probes:
+        msg: dict = {"verb": verb}
+        if verb == "run":
+            msg.update(
+                {
+                    "secret_names": ["api_key"],
+                    "inject_as": {"api_key": "API_KEY"},
+                    "command": [sys.executable, "-c", "print('ok')"],
+                }
+            )
+        if verb == "renew":
+            msg["minutes"] = 5
+        reply = guard_handle_message(msg, state)
+        reason = str(reply.get("reason") or "")
+        if reason.startswith("unknown verb"):
+            continue
+        # Explicit value-return denials still "recognize" the probe as rejected.
+        if verb in ("get-value", "reveal", "get", "copy"):
+            assert reply.get("ok") is False
+            continue
+        recognized.add(verb)
+    assert recognized == GUARD_VERBS
+
+
+def test_guard_value_return_probes_fail() -> None:
+    state = _state()
+    secret = "super-secret-value-123"
+    for verb in ("get-value", "reveal", "get", "copy", "get-logins-for-url"):
+        reply = guard_handle_message({"verb": verb, "name": "api_key", "url": "https://x"}, state)
+        assert reply.get("ok") is False
+        blob = str(reply)
+        assert secret not in blob
+        assert "password" not in reply or reply.get("password") in (None, "")
+
+
+def test_guard_run_never_returns_raw_secret() -> None:
+    state = _state()
+    secret = "super-secret-value-123"
+    code = "import os; print(os.environ['API_KEY'])"
+    reply = guard_handle_message(
+        {
+            "verb": "run",
+            "secret_names": ["api_key"],
+            "inject_as": {"api_key": "API_KEY"},
+            "command": [sys.executable, "-c", code],
+        },
+        state,
+    )
+    assert reply["ok"] is True
+    assert secret not in reply["scrubbed_stdout"]
+    assert "***REDACTED(api_key)***" in reply["scrubbed_stdout"]
+    assert secret not in str(reply)


### PR DESCRIPTION
## Summary
- Bump DESIGN current-state to v2 and document the two-tier model: frozen guard verbs vs approved browser-fill; read-only cached-session fill precedent; `ka unlock` required; stubbed `set-login`; host collision for `org.keepassxc.keepassxc_browser`.
- Extend audit with `browser-fill` / `browser-fill-denied` / `browser-fill-timeout` (url/username only, never password) and wire fill IPC to emit them.
- Add `test_guard_verbs_regression.py` and strengthen `test_fill_lifecycle.py` for lock/expiry teardown plus audit assertions.
- README threat-model additions (residual DOM autofill risk next to base64 caveat).

## Test plan
- [x] `pytest tests/test_guard_verbs_regression.py tests/test_fill_lifecycle.py tests/test_audit_cli.py` (17 passed)
- [ ] Full `pytest` after merge with other workstreams