### PR TITLE
v2 integrate: bump to 0.2.0

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,7 +39,7 @@ key-amnesia/
     run_exec.py                    # buffer-then-scrub-then-relay
     clipboard.py
     theme.py                       # branded CLI output (NO_COLOR / non-TTY safe)
-    platform.py                    # isolated-console spawn (Windows CREATE_NEW_CONSOLE; Linux terminal emulators)
+    platform.py                    # isolated-console spawn (Windows CREATE_NEW_CONSOLE; Linux emulators + /dev/tty install offer)
   tests/
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.1.0"
+version = "0.2.0"
 description = "Encrypted secret vault with human-prompt routing and output scrubbing"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version to `0.2.0` after merging WS-A–E.
- Note Linux `/dev/tty` emulator install offer on `platform.py` in the DESIGN package tree.

## Test plan
- [x] Full pytest green on master after WS-E (123 passed, 1 skipped)
- [ ] Re-run pytest after merge (pass count should hold)