### PR TITLE
Release 0.3.4 — documentation-only, refreshes the PyPI page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.3.3"
+version = "0.3.4"
 description = "Encrypted secret vault with human-prompt routing and output scrubbing"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
Version bump only. No code changed since 0.3.3.

This release exists so the PyPI project page picks up the new logo and the README image fix from #23. PyPI renders the description from the uploaded package metadata, so the project page does not update when GitHub does — it takes a new release.

## Test plan
- [x] `python -m build` succeeds
- [x] `twine check` passes on both wheel and sdist