### PR TITLE
Fix admission/extend prompts losing a typed answer to a stdin race

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.3.4"
+version = "0.3.5"
 description = "Encrypted secret vault with human-prompt routing and output scrubbing"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/key_amnesia/guard.py
+++ b/src/key_amnesia/guard.py
@@ -77,6 +77,10 @@ class GuardState:
     stop: threading.Event = field(default_factory=threading.Event)
     admitted: AdmittedSession | None = None
     request_count: int = 0
+    # One stdin reader per guard run (see _StdinPump) — every prompt this
+    # guard shows (admission, extend) must share the same reader, or two
+    # concurrent input() calls race for the same typed line.
+    stdin_pump: "_StdinPump" = field(default_factory=lambda: _StdinPump())
 
 
 def _utc_iso(ts: float | None = None) -> str:
@@ -231,12 +235,99 @@ def _summarize_request(verb: str, msg: dict[str, Any]) -> str:
     return f"'{verb or 'unknown'}' request"
 
 
-def default_admit_prompt(caller_pid: int, summary: str) -> bool:
+class _StdinPump:
+    """Coordinates prompts so at most one thread is ever blocked in input().
+
+    Every prompt used to spawn its own thread around a blocking input()
+    call, bounded by joining that thread with a timeout. But a thread that
+    times out is never killed — Python cannot cancel a blocking input() —
+    so it keeps running, still blocked in input(), forever. If a second
+    prompt then spawned its own thread while the first was still alive,
+    both threads were blocked on the same stdin at once: whichever the OS
+    handed the next typed line to "won", and it was not necessarily the one
+    whose prompt was currently on screen. That let an explicit "y" typed in
+    answer to a visible prompt be silently swallowed by an abandoned thread
+    from an earlier, already-timed-out prompt — the visible prompt then
+    timed out too and reported denied, despite the correct answer having
+    been typed.
+
+    This coordinator starts at most one input()-reading thread at a time,
+    and that thread reads exactly one line then stops — it does not loop,
+    so a fast/non-blocking input() (real piped stdin, or a test double)
+    cannot spin it into a busy loop. read_line() either starts that one
+    read (if none is in flight) or waits on the read already in flight, so
+    concurrent callers see the same next typed line instead of racing for
+    it. An answer that arrives when nobody is waiting is discarded the next
+    time read_line() is called rather than handed to an unrelated later
+    prompt — a stale "y" for one question must not silently approve a
+    different one.
+    """
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._pending = False  # a reader thread is currently blocked in input()
+        self._result: str | None = None
+        self._have_result = False
+        self._eof = False
+
+    def _read(self) -> None:
+        try:
+            line = input()
+        except BaseException:
+            line = None
+            hit_eof = True
+        else:
+            hit_eof = False
+        with self._cond:
+            self._pending = False
+            if hit_eof:
+                self._eof = True
+            else:
+                self._result = line
+                self._have_result = True
+            self._cond.notify_all()
+
+    def read_line(self, timeout: float | None = None) -> str | None:
+        """Wait up to `timeout` seconds for the next line (block until EOF if None)."""
+        with self._cond:
+            # An unclaimed answer from an earlier read nobody was still
+            # waiting for belongs to a different question — drop it rather
+            # than silently hand it to this new one.
+            if self._have_result and not self._pending:
+                self._have_result = False
+                self._result = None
+
+            if self._eof and not self._pending:
+                return None
+
+            if not self._pending and not self._have_result:
+                self._pending = True
+                threading.Thread(target=self._read, daemon=True).start()
+
+            deadline = None if timeout is None else time.time() + timeout
+            while not self._have_result:
+                if self._eof and not self._pending:
+                    return None
+                if deadline is None:
+                    self._cond.wait()
+                    continue
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return None
+                self._cond.wait(timeout=remaining)
+
+            self._have_result = False
+            line, self._result = self._result, None
+            return line
+
+
+def default_admit_prompt(caller_pid: int, summary: str, stdin_pump: _StdinPump) -> bool:
     """Blocking yes/no prompt on the guard's own foreground TTY.
 
-    Bounded by ADMISSION_TIMEOUT_S on a daemon thread — same fail-closed
-    pattern as the inline prompts in prompt_route.py: deny on timeout, EOF,
-    or any non-yes answer.
+    Reads via the guard run's shared `stdin_pump` rather than its own
+    input() thread — see `_StdinPump` for why a per-call thread is the wrong
+    shape here; every prompt in one guard run must share the same reader.
+    Bounded by ADMISSION_TIMEOUT_S; deny on timeout or any non-yes answer.
     """
     try:
         theme.out(
@@ -246,20 +337,10 @@ def default_admit_prompt(caller_pid: int, summary: str) -> bool:
     except Exception:
         pass
 
-    outcome: dict[str, Any] = {}
-
-    def _read() -> None:
-        try:
-            outcome["ans"] = input().strip().lower()
-        except BaseException as exc:  # noqa: BLE001 — relayed via outcome
-            outcome["error"] = exc
-
-    t = threading.Thread(target=_read, daemon=True)
-    t.start()
-    t.join(timeout=ADMISSION_TIMEOUT_S)
-    if t.is_alive() or "error" in outcome:
+    line = stdin_pump.read_line(ADMISSION_TIMEOUT_S)
+    if line is None:
         return False
-    return outcome.get("ans") in ("y", "yes")
+    return line.strip().lower() in ("y", "yes")
 
 
 def _check_admission(
@@ -283,9 +364,11 @@ def _check_admission(
         state.admitted.last_summary = _summarize_request(verb, msg)
         return True, None
 
-    prompt = admit_prompt or default_admit_prompt
     summary = _summarize_request(verb, msg)
-    approved = bool(prompt(caller_pid, summary))
+    if admit_prompt is not None:
+        approved = bool(admit_prompt(caller_pid, summary))
+    else:
+        approved = bool(default_admit_prompt(caller_pid, summary, state.stdin_pump))
     if not approved:
         return False, None
 
@@ -468,7 +551,8 @@ def guard_serve(state: GuardState, listener: Any) -> str:
                     f"{int(state.expires_at - now)}s. Extend? [y/N] ",
                     end="",
                 )
-                ans = input().strip().lower()
+                line = state.stdin_pump.read_line()
+                ans = (line or "").strip().lower()
                 if ans in ("y", "yes"):
                     # Default extend by original remaining window or 30m
                     state.expires_at = time.time() + 30 * 60

--- a/tests/test_guard_stdin_pump.py
+++ b/tests/test_guard_stdin_pump.py
@@ -1,0 +1,119 @@
+"""Regression: a live yes/no prompt must not lose an answer typed for it.
+
+Each admission/extend prompt used to spawn its own thread around a blocking
+input() call, joined with a timeout. A thread that timed out was never
+killed — Python cannot cancel a blocking input() — so it kept running,
+still blocked on stdin, forever. A later prompt's fresh thread then raced
+it for the next typed line: whichever thread the OS handed the line to
+"won", so an explicit "y" typed in answer to a visible, still-open prompt
+could be silently swallowed by an abandoned thread from an earlier,
+already-timed-out one — reproduced live: a founder session that answered
+"y" to a run request still got "admission denied".
+
+_StdinPump fixes this by ensuring at most one thread is ever blocked in
+input() at a time, and that thread reads exactly one line then stops (it
+must not loop, or a fast/non-blocking input() — real piped stdin, or a
+test double — spins it into an unbounded busy loop; this regressed once
+during development and ballooned a test run to several GB of RAM).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from key_amnesia.guard import _StdinPump
+
+
+def test_late_answer_to_an_earlier_timed_out_wait_is_not_lost() -> None:
+    """A caller that gave up on timeout must not cost a later caller the
+    eventual answer to the same underlying question."""
+    calls = {"n": 0}
+    lock = threading.Lock()
+
+    def slow_input() -> str:
+        with lock:
+            calls["n"] += 1
+        time.sleep(0.3)
+        return "y"
+
+    pump = _StdinPump()
+
+    import builtins
+
+    real_input = builtins.input
+    builtins.input = slow_input
+    try:
+        # Gives up before slow_input() returns — must not spawn a second
+        # concurrent reader, and must not lose the eventual answer.
+        first = pump.read_line(timeout=0.05)
+        assert first is None
+
+        # Same underlying input() call is still in flight; this call must
+        # receive its result rather than starting a competing one.
+        second = pump.read_line(timeout=1.0)
+        assert second == "y"
+    finally:
+        builtins.input = real_input
+
+    assert calls["n"] == 1, "a stale, still-in-flight reader must be reused, not duplicated"
+
+
+def test_stale_unclaimed_answer_is_discarded_not_reused() -> None:
+    """An answer that arrives while nobody is waiting belongs to whatever
+    question was on screen when it was typed — it must not silently answer
+    a later, unrelated question instead."""
+    calls = {"n": 0}
+    lock = threading.Lock()
+
+    def input_stub() -> str:
+        with lock:
+            calls["n"] += 1
+            n = calls["n"]
+        if n == 1:
+            time.sleep(0.2)
+            return "stale-answer"
+        return "fresh-answer"
+
+    pump = _StdinPump()
+
+    import builtins
+
+    real_input = builtins.input
+    builtins.input = input_stub
+    try:
+        # Times out well before input_stub()'s first call returns.
+        assert pump.read_line(timeout=0.05) is None
+
+        # Let the first input() call actually complete with nobody waiting.
+        time.sleep(0.35)
+
+        # A new, unrelated question — must not silently receive the earlier
+        # unclaimed "stale-answer".
+        answer = pump.read_line(timeout=1.0)
+    finally:
+        builtins.input = real_input
+
+    assert answer == "fresh-answer"
+    assert calls["n"] == 2
+
+
+def test_eof_is_reported_once_pending_read_settles() -> None:
+    def raise_eof() -> str:
+        raise EOFError
+
+    pump = _StdinPump()
+
+    import builtins
+
+    real_input = builtins.input
+    builtins.input = raise_eof
+    try:
+        assert pump.read_line(timeout=1.0) is None
+        # A stream that has hit EOF will not produce more lines; further
+        # calls must fail fast rather than hang waiting for one.
+        start = time.monotonic()
+        assert pump.read_line(timeout=5.0) is None
+        assert time.monotonic() - start < 1.0
+    finally:
+        builtins.input = real_input


### PR DESCRIPTION
## Summary
Real bug, caught live: a session answered "y" to a `run` request's admission prompt in the guard's own console and still got `admission denied`.

- **Root cause**: `default_admit_prompt` spawned a new thread per call, blocking on `input()`, joined with a timeout. A thread that timed out was never killed (Python cannot cancel a blocking `input()`), so it kept running in the background. The next prompt spawned another thread, and two threads then competed for the same stdin — whichever the OS handed the next typed line to "won", not necessarily the one whose prompt was on screen. A "y" typed for a visible prompt could be swallowed by an abandoned thread from an earlier, already-timed-out one, and the visible prompt then timed out too and reported denied.
- **Fix**: `_StdinPump` ensures at most one thread is ever blocked in `input()` at a time. A `read_line()` call that finds a read already in flight (from an earlier caller who gave up) waits on that same read instead of racing it with a second thread. The reader reads exactly one line and stops — it must not loop, or a fast/non-blocking `input()` (piped stdin, or a test double) spins it into a busy loop; this regressed once mid-fix and ballooned a test run to several GB of RAM before being caught. A stale, unclaimed answer is discarded on the next distinct call rather than silently handed to an unrelated later question.
- Moved from a module-level singleton to a field on `GuardState`, so each guard run (and each test's `GuardState`) gets its own isolated reader — no cross-test bleed.
- The same reader now backs both the admission prompt and the extend-session prompt, since both blocked on `input()` directly before and could equally have raced each other.

## Test plan
- [x] `pytest tests/` — 172 passed, 1 skipped (was 169/1 before this branch)
- [x] New `tests/test_guard_stdin_pump.py`: a timed-out caller doesn't cost a later caller the eventual answer; a stale unclaimed answer doesn't leak into an unrelated question; EOF fails fast
- [x] Verified live: reproduced the original symptom in a real terminal session, then confirmed a fresh `ka run` request succeeds normally after the fix