### PR TITLE
Add Buy Me a Coffee support (0.3.6)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+buy_me_a_coffee: fujitoid

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ On a real terminal, status lines use a restrained brushed-chrome palette (cool c
 
 Questions, bugs, and ideas: [Discord](https://discord.gg/4WnQfk49xX) or [GitHub issues](https://github.com/fujitoid/key-amnesia/issues).
 
+## Support
+
+key-amnesia is free and open source. If it's useful to you, you can support its development here:
+
+<a href="https://www.buymeacoffee.com/fujitoid" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;" ></a>
+
 ## Development
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.3.5"
+version = "0.3.6"
 description = "Encrypted secret vault with human-prompt routing and output scrubbing"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Adds a way to support the project financially, ahead of the larger 0.4.0 .env-replacement work.

- `.github/FUNDING.yml` — wires GitHub's native "Sponsor" button to `buymeacoffee.com/fujitoid`.
- README: short, undecorated "Support" section next to Community. One-off donations only (no membership tiers) — matches what's actually configured on the BMC page today; nothing there needed creating since the page already has a description and simple coffee-style support enabled.
- Version bump to 0.3.6 (docs/metadata only, no code changes — full suite re-verified: 172 passed / 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)