### PR TITLE
Add PyPI Funding link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 Homepage = "https://github.com/fujitoid/key-amnesia"
 Repository = "https://github.com/fujitoid/key-amnesia"
 Issues = "https://github.com/fujitoid/key-amnesia/issues"
+Funding = "https://www.buymeacoffee.com/fujitoid"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]


### PR DESCRIPTION
Adds a \`Funding\` entry to \`[project.urls]\` pointing at the Buy Me a Coffee page from PR #28. PyPI renders a \`Funding\`-labeled URL with its own icon in the project sidebar, distinct from Homepage/Repository/Issues — this is how it shows up there too, not just on GitHub.

No PyPI release has gone out since #28 merged, so this rides along in the same 0.3.6 release rather than needing its own version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)