### PR TITLE
Add project vaults with merge and guard registry (0.3.10)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,8 @@ Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted v
 
 **0.3.7 (bugfix, no CLI-surface / no IPC-verb changes):** fixed the guard's stale in-memory secrets snapshot (README limit 9 / "Known limitation" below). `GuardState` gained `vault_path`, `vault_key` (derived SecretBox key only — never the password), and `vault_content_fingerprint`; `run`/`list`/`status` now call `_maybe_reload_secrets`, which re-opens the vault with the retained key (no Argon2id) whenever the fingerprint changes. `cmd_unlock` switched from `load_vault` to `load_vault_with_key` to obtain that key without deriving it twice; `vault.py` gained `load_vault_with_key`, `load_vault_with_retained_key`, and `vault_fingerprint`. Verb set is unchanged — still exactly `{run, list, lock, status, renew}`; no `reload` verb was added (`tests/test_guard_verbs_regression.py` untouched). New exposure: the guard now retains **derived key material** for the session (see "Who holds plaintext" and the note under GuardState below) — same trust tier as the plaintext secrets it already held, but worth naming explicitly. `tests/test_guard_reload.py`.
 
+**0.3.10 (project vaults + guard registry; no IPC-verb changes):** walk-up discovery of `.amnesia/` from cwd (stops at home); per-env vault files under `.amnesia/envs/<name>/`; `.amnesia/config.json` `use_global` (default true) merges the global vault with project winning on name collision; CLI `--vault` / `--global` / `--no-global` / `--env`; `ka init --project [--env NAME]` scaffolds the tree and auto-gitignores `.amnesia/`; `ka import` / fresh-auth mutations target the resolved project vault when inside a project; `ka unlock` / `run` / `list` / `status` merge when configured (two independent password prompts when both vaults exist). Guard lock + `last_guard_state.json` sit beside the active vault; discovery-only registry at `~/.key-amnesia/guards/<hash>.json` (vault path, env, pid, expiry, address — **never** authkey). `GuardState.vault_sources` extends the 0.3.7 fingerprint reload so a merged unlock refreshes when *any* contributing vault file changes. Existing global vault: zero-action compatible. Verb set unchanged. `project.py`, `tests/test_project_vaults.py`.
+
 **0.3.9 (opens the `.env`-replacement line; no IPC-verb changes; no vault-format/resolution changes):** new `ka import FILE` command plus a shared, reusable core (`dotenv_import.py`) that a later `ka scan` (roadmap) can call into for its own offer-to-import path. `ka import` parses a dotenv-format file and merges its `NAME=value` pairs into the currently-resolved vault (still the single global vault — per-project vaults land in a later PR); it is **TTY-only**, like `init`/`passwd` (never routed through the spawned-console helper — it reads the local file itself rather than having a human type each value, and drives several interactive-only decisions below). Name collisions with an existing secret **default to skip** and only overwrite on an explicit confirm. After a successful import it asks (never silently) whether to delete the source file — a "yes" is double-confirmed before anything is removed — or, if delete was declined, offers to rename it to `<name>.imported`; separately it also offers (never silently, and skipped entirely if a covering pattern already exists) adding `.env*` to `.gitignore`. Finally it generates or merges a minimal `amnesia.toml` in the current directory (one `[[secret]]` table per imported name: `name`, `required = true`, `description = ""`, `env`) — this manifest is inert until a later PR adds `ka check` / `ka run` enforcement; merging only appends blocks for names not already present, matched on their `env` field. Never prints a secret value at any point. `tests/test_dotenv_import.py`, `tests/test_import_cmd.py`.
 **0.3.8 (admission model replaced; no IPC-verb changes; no new verb):** the admission-consent layer no longer trusts a message-supplied `caller_pid` or an opaque bearer token — it binds to the connecting process's **kernel-verified identity** instead (new `peer_identity.py`: `GetNamedPipeClientProcessId` + `OpenProcess`/`GetProcessTimes` on Windows, `SO_PEERCRED` + `/proc/<pid>/stat` on Linux; macOS/other fails closed). `admitted_session.token` is **gone** — there is no on-disk admission credential anymore; `guard_request` attaches nothing beyond an optional display-only `client_name`. Admission now also supports **secret-scoped grants** (a `run` naming a secret outside the admitted tree's current grant re-prompts to expand scope, rather than either a blanket allow or a blanket re-prompt-everything) and an opt-in, single-use, loud **`ka unlock --pre-admit [--pre-admit-secret NAME ...]`** (default window `pre-admit-seconds`, config default 900s / 15m) that auto-admits the very next unrecognized peer without a prompt — unscoped (ALL secrets) if no `--pre-admit-secret` is given. New `ka connect` is a plain CLI alias for `ka status` (same handler, no separate guard verb — still exactly `{run, list, lock, status, renew}`, `tests/test_guard_verbs_regression.py` untouched). New optional `--name LABEL` on every guard-talking command sets `KEY_AMNESIA_CLIENT_NAME` so the admission prompt can show a human-friendly label — display-only, never a trust input. See "Admission consent — kernel-verified peer identity" below for the full model, `peer_identity.py`, `test_guard_admission.py`, `test_guard_admission_legacy.py` (in-memory-only backward-compat path for callers that predate kernel identity), and `test_peer_identity_e2e.py` (real spawned-process security tests).
 **Out of scope:** macOS (and Safari); browser integration of any kind (removed, not deferred — see above); passkeys / TOTP; MCP wrapper; GUI; macOS isolated-console spawn (`Terminal.app` / `osascript`); DPAPI-protecting the names sidecar. Next iteration: Rust port of the same primitives (Argon2id, SecretBox AEAD, local IPC verbs).
@@ -35,6 +37,7 @@ key-amnesia/
     __main__.py
     cli.py                         # argparse; all subcommands + --help
     paths.py
+    project.py                     # .amnesia/ walk-up, VaultContext, merge helpers (since 0.3.10)
     config.py
     crypto.py                      # Argon2id + SecretBox (vault only)
     vault.py                       # binary layout + JSON payload; migrates obsolete fill keys
@@ -43,7 +46,7 @@ key-amnesia/
     audit.py                       # JSONL; never logs passwords
     ipc.py                         # Listener/Client + authkey only
     prompt_route.py                # isatty + CREATE_NEW_CONSOLE; env handoff
-    guard.py                       # foreground singleton; admission consent; death reporting
+    guard.py                       # foreground singleton; admission consent; death reporting; multi-source reload; discovery registry
     peer_identity.py               # kernel-verified peer (pid, start_time); no message-supplied pid trusted
     run_exec.py                    # buffer-then-scrub-then-relay
     clipboard.py
@@ -118,7 +121,26 @@ env = "OPENAI_API_KEY"
 
 `address` (named pipe), `authkey_hex`, `pid`, `expires_at`.
 
+Lives **beside the active vault** since 0.3.10 (`guard_lock_path_for_vault`): global unlock → `~/.key-amnesia/guard.lock`; project unlock → `.amnesia/guard.lock` (or `.amnesia/envs/<name>/guard.lock`). Same for `last_guard_state.json`.
+
 **No `session_key_hex`.** Authkey authentication alone defines the IPC trust boundary. An extra SecretBox layer over messages was dropped: with a session key co-stored in `guard.lock` next to the authkey, the same processes that can read the authkey can read the session key — zero added protection, pure complexity.
+
+### Project vaults (`.amnesia/`, since 0.3.10)
+
+```
+.amnesia/
+  config.json              # {"use_global": true, "default_env": optional}
+  vault.bin                # default env
+  vault.names.json
+  envs/<name>/vault.bin    # --env / KA_ENV / default_env
+  envs/<name>/vault.names.json
+```
+
+Walk-up from cwd for `.amnesia/`, stop at home. No project → global vault (zero-action compatible). Merge: project secrets overlay global when `use_global` and the global vault file exists; independent ciphertexts → **two password prompts** on unlock/run. Fresh-auth cmds (`set`/`remove`/`reveal`/`copy`) target a single resolved vault only. Policy note: `use_global: false` is CLI-level isolation for agents — not a cryptographic boundary.
+
+### Guard registry (`~/.key-amnesia/guards/<hash>.json`, since 0.3.10)
+
+Discovery only — vault path, env, pid, expiry, endpoint **address**. **Never authkey** (that stays only in the vault-adjacent lock). Written/removed by `run_foreground_guard` only when an explicit `vault_path` was passed (so tests that call it without a vault never touch real home). `ka status` globs + liveness-checks; stale entries dropped. Documented daily use: one `ka unlock` per project vault.
 
 ### No admission credential on disk (since 0.3.8)
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ ka lock                             # end it early, any time
 
 | Command | What it does |
 |---------|--------------|
-| `ka init` | Create an empty vault (type master password twice; refuse if already exists) |
+| `ka init [--project] [--env NAME]` | Create an empty vault (type master password twice; refuse if already exists). `--project` creates `./.amnesia/vault.bin` (or `envs/NAME/`), writes `.amnesia/config.json`, and auto-adds `.amnesia/` to `.gitignore` |
 | `ka passwd` / `ka change-password` | Change the master password (re-encrypts the vault with a fresh salt; refuses while a session is active) |
 | `ka set NAME` | Store or update a secret (value typed hidden; password required; vault must already exist) |
 | `ka remove NAME` | Delete a secret (password required) |
-| `ka import FILE` | Import a dotenv-format file's `NAME=value` pairs into the vault (TTY-only, like `ka init`) — asks before overwriting a name that already exists, and offers to delete/rename the source file, add `.env*` to `.gitignore`, and generate/merge a minimal `amnesia.toml` |
+| `ka import FILE` | Import a dotenv-format file's `NAME=value` pairs into the resolved vault (project vault when inside a project; TTY-only) — asks before overwriting a name that already exists, and offers to delete/rename the source file, add `.env*` to `.gitignore`, and generate/merge a minimal `amnesia.toml` |
 | `ka run --secret NAME --as ENV_VAR -- <command>` | Run a command with the secret injected; output censored. The agent-facing command. |
 | `ka list` | Show secret *names* only — never values; safe for agents, no prompt |
 | `ka unlock [--pre-admit] [--pre-admit-secret NAME]` | Start a cached session; `--pre-admit` loudly auto-admits the very next connecting process for a bounded window (15m default), without a yes/no prompt — scope it to specific secrets with `--pre-admit-secret`, repeatable, or leave it off for ALL secrets |
@@ -103,8 +103,24 @@ ka lock                             # end it early, any time
 | `ka reveal NAME` | Show a value to *you* (password required every time, even mid-session) |
 | `ka copy NAME` | Copy a value to your clipboard instead of showing it (same rule) |
 | `ka config show` / `ka config set KEY VALUE` | View / change settings (changes require your password) |
-| `ka status` (alias `ka connect`) | Is a session active, and until when — plus, if not, what happened to the last one |
+| `ka status` (alias `ka connect`) | Is a session active, and until when — plus, if not, what happened to the last one; lists other live guards from the discovery registry |
 | `ka setup` | Install agent skills + the secret-guard hook for Claude Code / Cursor (`--skills-only` / `--hook-only`) |
+
+Vault-aware commands also accept `--vault PATH`, `--global`, `--no-global`, and `--env NAME` to select which vault to use.
+
+### Project vaults (since 0.3.10)
+
+```bash
+# Inside a git repo / project directory:
+ka init --project          # creates .amnesia/vault.bin + config.json; gitignores .amnesia/
+ka import .env             # lands in the project vault when .amnesia/ is found
+ka unlock                  # prompts for project password, then (if use_global) global password
+ka run --secret API_KEY -- ...
+```
+
+Walk-up from cwd finds the nearest `.amnesia/` (stops at your home directory). By default the project vault **merges** with the global `~/.key-amnesia` vault (project wins on name collision); set `"use_global": false` in `.amnesia/config.json` or pass `--no-global` to isolate. Per-environment vaults live at `.amnesia/envs/<name>/vault.bin` (`--env NAME` or `KA_ENV`). Existing global-only setups need no migration — no `.amnesia/` means everything stays global.
+
+Daily use: **one `ka unlock` per project vault**. Guard lock + death-state files sit beside the active vault; a discovery-only registry at `~/.key-amnesia/guards/` lists live guards (address/pid/expiry — **never** the authkey).
 
 Every command supports `--help`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.3.9"
+version = "0.3.10"
 description = "Encrypted secret vault with human-prompt routing and output scrubbing"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -17,6 +17,13 @@ from key_amnesia import dotenv_import
 from key_amnesia.audit import audit_event
 from key_amnesia.config import ConfigError, load_config, set_config_value
 from key_amnesia.paths import vault_path
+from key_amnesia.project import (
+    VaultContext,
+    ensure_project_scaffold,
+    merge_secret_maps,
+    merged_names_from_sidecars,
+    resolve_vault_context,
+)
 from key_amnesia.prompt_route import PromptRequest, require_human_auth
 from key_amnesia.setup_cmd import cmd_setup
 from key_amnesia import theme
@@ -41,6 +48,48 @@ def _write_command_output(stream: Any, text: str) -> None:
         stream.write(text.encode(encoding, errors="replace").decode(encoding, errors="replace"))
 
 
+def _add_vault_scope_args(parser: argparse.ArgumentParser) -> None:
+    """`--vault` / `--global` / `--no-global` / `--env` on vault-aware commands."""
+    parser.add_argument(
+        "--vault",
+        default=None,
+        metavar="PATH",
+        help="Use this vault file directly (skips project discovery)",
+    )
+    g = parser.add_mutually_exclusive_group()
+    g.add_argument(
+        "--global",
+        dest="force_global",
+        action="store_true",
+        help="Force the global ~/.key-amnesia vault (ignore project)",
+    )
+    g.add_argument(
+        "--no-global",
+        dest="no_global",
+        action="store_true",
+        help="Do not merge the global vault into a project unlock/run/list",
+    )
+    parser.add_argument(
+        "--env",
+        default=None,
+        metavar="NAME",
+        help="Project environment vault (.amnesia/envs/NAME/); also KA_ENV",
+    )
+
+
+def _ctx_from_args(args: argparse.Namespace) -> VaultContext:
+    try:
+        return resolve_vault_context(
+            vault=getattr(args, "vault", None),
+            force_global=bool(getattr(args, "force_global", False)),
+            no_global=bool(getattr(args, "no_global", False)),
+            env=getattr(args, "env", None),
+        )
+    except ValueError as e:
+        theme.error(f"Error: {e}")
+        raise SystemExit(2) from e
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="key-amnesia",
@@ -52,17 +101,29 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command")
 
     # init
-    sub.add_parser(
+    p_init = sub.add_parser(
         "init",
         help="Create an empty vault (double-confirm master password)",
     )
+    p_init.add_argument(
+        "--project",
+        action="store_true",
+        help="Create a project vault in ./.amnesia/ (auto-gitignores .amnesia/)",
+    )
+    p_init.add_argument(
+        "--env",
+        default=None,
+        metavar="NAME",
+        help="With --project: create .amnesia/envs/NAME/vault.bin",
+    )
 
     # passwd / change-password
-    sub.add_parser(
+    p_passwd = sub.add_parser(
         "passwd",
         aliases=["change-password"],
         help="Change the master password (re-encrypts the vault with a fresh salt)",
     )
+    _add_vault_scope_args(p_passwd)
 
     # set
     p_set = sub.add_parser("set", help="Store or update a secret (always fresh auth)")
@@ -73,10 +134,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Secret value (prompted if omitted; never prefer argv for secrets)",
     )
+    _add_vault_scope_args(p_set)
 
     # remove
     p_rm = sub.add_parser("remove", help="Remove a secret (always fresh auth)")
     p_rm.add_argument("name", help="Secret name")
+    _add_vault_scope_args(p_rm)
 
     # import
     p_import = sub.add_parser(
@@ -84,6 +147,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Import secrets from a dotenv file into the vault (TTY-only)",
     )
     p_import.add_argument("file", help="Path to a dotenv-format file, e.g. .env")
+    _add_vault_scope_args(p_import)
 
     # run
     p_run = sub.add_parser(
@@ -116,6 +180,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="LABEL",
         help="Display-only client label shown in the guard's admission prompt",
     )
+    _add_vault_scope_args(p_run)
 
     # list
     p_list = sub.add_parser("list", help="List secret names (no prompt; names sidecar)")
@@ -125,6 +190,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="LABEL",
         help="Display-only client label shown in the guard's admission prompt",
     )
+    _add_vault_scope_args(p_list)
 
     # unlock / lock
     p_unlock = sub.add_parser("unlock", help="Start cached guard session (requires password)")
@@ -146,6 +212,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "unscoped ALL-secrets pre-admit"
         ),
     )
+    _add_vault_scope_args(p_unlock)
     p_lock = sub.add_parser("lock", help="Tear down cached guard session")
     p_lock.add_argument(
         "--name",
@@ -153,12 +220,15 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="LABEL",
         help="Display-only client label shown in the guard's admission prompt",
     )
+    _add_vault_scope_args(p_lock)
 
     # reveal / copy
     p_rev = sub.add_parser("reveal", help="Reveal a secret (always fresh auth)")
     p_rev.add_argument("name", help="Secret name")
+    _add_vault_scope_args(p_rev)
     p_copy = sub.add_parser("copy", help="Copy a secret to clipboard (always fresh auth)")
     p_copy.add_argument("name", help="Secret name")
+    _add_vault_scope_args(p_copy)
 
     # config
     p_cfg = sub.add_parser("config", help="View or set configuration")
@@ -186,6 +256,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="LABEL",
         help="Display-only client label shown in the guard's admission prompt",
     )
+    _add_vault_scope_args(p_status)
     p_connect = sub.add_parser(
         "connect",
         help="Alias for 'status' (no separate guard verb — same status check)",
@@ -196,6 +267,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="LABEL",
         help="Display-only client label shown in the guard's admission prompt",
     )
+    _add_vault_scope_args(p_connect)
 
     # setup (agent distribution: skills + PreToolUse/preToolUse hook)
     p_setup = sub.add_parser(
@@ -260,8 +332,19 @@ def _confirm(prompt: str, *, default: bool = False) -> bool:
     return answer in ("y", "yes")
 
 
-def cmd_init(_args: argparse.Namespace) -> int:
-    vp = vault_path()
+def cmd_init(args: argparse.Namespace) -> int:
+    project = bool(getattr(args, "project", False))
+    env_name = getattr(args, "env", None)
+    if env_name and not project:
+        theme.error("Error: --env requires --project")
+        return 2
+
+    if project:
+        project_root = Path.cwd()
+        vp = ensure_project_scaffold(project_root, env_name=env_name, use_global=True)
+    else:
+        vp = vault_path()
+
     if vp.exists():
         theme.error(
             "vault already initialized, use ka set to add secrets",
@@ -282,6 +365,12 @@ def cmd_init(_args: argparse.Namespace) -> int:
         theme.error(f"Error: {e}")
         return 1
     theme.success(f"Vault initialized at {vp}")
+    if project:
+        theme.info("Added .amnesia/ to .gitignore (if not already covered).")
+        theme.info(
+            "Project vault merges the global vault by default "
+            "(use --no-global to isolate; set use_global in .amnesia/config.json)."
+        )
     theme.info(
         "Remember your master password — it cannot be recovered if forgotten."
     )
@@ -301,12 +390,12 @@ def _auth_password(request: PromptRequest) -> tuple[bool, str | None, Any]:
 
 
 def cmd_set(args: argparse.Namespace) -> int:
+    ctx = _ctx_from_args(args)
     name = args.name
     value = args.value
-    if not vault_path().exists():
-        theme.error(
-            "Vault not initialized. Run 'ka init' first.",
-        )
+    if not ctx.vault_path.exists():
+        hint = "ka init --project" if ctx.project_root else "ka init"
+        theme.error(f"Vault not initialized. Run '{hint}' first.")
         return 1
     # Prefer not putting secret values on argv — if omitted, prompt (inline only)
     # `mutation` (not `detail`!) carries the value — detail is human-facing
@@ -315,6 +404,7 @@ def cmd_set(args: argparse.Namespace) -> int:
         action="set",
         secret_names=[name],
         mutation=json.dumps({"name": name, "value": value}) if value is not None else "",
+        vault_path=str(ctx.vault_path),
     )
     # If value missing and interactive, collect value after password inline.
     ok, password, outcome = _auth_password(request)
@@ -327,7 +417,7 @@ def cmd_set(args: argparse.Namespace) -> int:
         if value is None:
             value = getpass.getpass(f"Value for '{name}': ")
         try:
-            payload = load_vault(None, password)
+            payload = load_vault(ctx.vault_path, password)
         except VaultError as e:
             theme.error(f"Error: {e}")
             audit_event(
@@ -339,7 +429,7 @@ def cmd_set(args: argparse.Namespace) -> int:
             )
             return 1
         payload["secrets"][name] = value
-        save_vault(None, password, payload)
+        save_vault(ctx.vault_path, password, payload)
         audit_event(
             "set",
             secret_names=[name],
@@ -364,8 +454,13 @@ def cmd_set(args: argparse.Namespace) -> int:
 
 
 def cmd_remove(args: argparse.Namespace) -> int:
+    ctx = _ctx_from_args(args)
     name = args.name
-    request = PromptRequest(action="remove", secret_names=[name])
+    request = PromptRequest(
+        action="remove",
+        secret_names=[name],
+        vault_path=str(ctx.vault_path),
+    )
     ok, password, outcome = _auth_password(request)
     if not ok:
         theme.error(f"Denied: {outcome.reason}")
@@ -373,7 +468,7 @@ def cmd_remove(args: argparse.Namespace) -> int:
 
     if password is not None:
         try:
-            payload = load_vault(None, password)
+            payload = load_vault(ctx.vault_path, password)
         except VaultError as e:
             theme.error(f"Error: {e}")
             return 1
@@ -388,7 +483,7 @@ def cmd_remove(args: argparse.Namespace) -> int:
             )
             return 1
         del payload["secrets"][name]
-        save_vault(None, password, payload)
+        save_vault(ctx.vault_path, password, payload)
         audit_event(
             "remove", secret_names=[name], route=outcome.route, result="allowed"
         )
@@ -425,9 +520,11 @@ def cmd_import(args: argparse.Namespace) -> int:
         theme.error(f"Error: file not found: {src}")
         return 1
 
-    vp = vault_path()
+    ctx = _ctx_from_args(args)
+    vp = ctx.vault_path
     if not vp.exists():
-        theme.error("Vault not initialized. Run 'ka init' first.")
+        hint = "ka init --project" if ctx.project_root else "ka init"
+        theme.error(f"Vault not initialized. Run '{hint}' first.")
         return 1
 
     entries = dotenv_import.parse_dotenv(src)
@@ -490,8 +587,9 @@ def cmd_import(args: argparse.Namespace) -> int:
     else:
         theme.info(f"Left {src} in place.")
 
+    root = ctx.project_root or Path.cwd()
     added_gitignore = dotenv_import.offer_gitignore(
-        Path.cwd(),
+        root,
         ask=lambda: _confirm(
             "Add '.env*' to .gitignore so these files are never committed?"
         ),
@@ -499,13 +597,45 @@ def cmd_import(args: argparse.Namespace) -> int:
     if added_gitignore:
         theme.success("Added '.env*' to .gitignore.")
 
-    manifest_path = dotenv_import.generate_or_merge_manifest(imported, Path.cwd())
+    manifest_path = dotenv_import.generate_or_merge_manifest(imported, root)
     theme.info(f"Manifest updated: {manifest_path}")
 
     return 0
 
 
+def _load_merged_secrets(
+    ctx: VaultContext,
+    password: str,
+    *,
+    prompt_global: bool = True,
+) -> dict[str, str] | None:
+    """Decrypt active vault; if merge enabled, prompt for a second (global) password.
+
+    Returns merged secrets map, or None on error (already reported).
+    """
+    try:
+        payload = load_vault(ctx.vault_path, password)
+    except VaultError as e:
+        theme.error(f"Error: {e}")
+        return None
+    secrets = {k: str(v) for k, v in payload.get("secrets", {}).items()}
+    if not ctx.merge_with_global or ctx.global_vault_path is None:
+        return secrets
+    if not prompt_global:
+        return secrets
+    theme.info("Global vault also configured — enter its master password (separate).")
+    global_pw = getpass.getpass("Global vault master password: ")
+    try:
+        g_payload = load_vault(ctx.global_vault_path, global_pw)
+    except VaultError as e:
+        theme.error(f"Error decrypting global vault: {e}")
+        return None
+    g_secrets = {k: str(v) for k, v in g_payload.get("secrets", {}).items()}
+    return merge_secret_maps(g_secrets, secrets)
+
+
 def cmd_run(args: argparse.Namespace) -> int:
+    ctx = _ctx_from_args(args)
     cmd = list(args.cmd or [])
     if cmd and cmd[0] == "--":
         cmd = cmd[1:]
@@ -526,7 +656,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Try live guard first (cached mode).
     from key_amnesia.guard import guard_is_alive, guard_request
 
-    if guard_is_alive():
+    if guard_is_alive(path=ctx.lock_path):
         resp = guard_request(
             {
                 "verb": "run",
@@ -536,6 +666,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 "cwd": os.getcwd(),
             },
             timeout=3600,
+            lock_path=ctx.lock_path,
         )
         if resp and resp.get("ok"):
             _write_command_output(sys.stdout, resp.get("scrubbed_stdout", ""))
@@ -555,7 +686,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         secret_names=secret_names,
         command=cmd,
         inject_as=inject_as,
-        vault_path=str(vault_path()),
+        vault_path=str(ctx.vault_path),
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
@@ -565,20 +696,17 @@ def cmd_run(args: argparse.Namespace) -> int:
     if password is not None:
         from key_amnesia.run_exec import run_with_secrets
 
-        try:
-            payload = load_vault(None, password)
-        except VaultError as e:
-            theme.error(f"Error: {e}")
+        secrets_map = _load_merged_secrets(ctx, password)
+        if secrets_map is None:
             audit_event(
                 "run",
                 secret_names=secret_names,
                 command=cmd,
                 route=outcome.route,
                 result="denied",
-                reason=str(e),
+                reason="vault decrypt failed",
             )
             return 1
-        secrets_map = {k: str(v) for k, v in payload["secrets"].items()}
         missing = [n for n in secret_names if n not in secrets_map]
         if missing:
             theme.error(f"Unknown secrets: {', '.join(missing)}")
@@ -606,18 +734,22 @@ def cmd_run(args: argparse.Namespace) -> int:
     return 1
 
 
-def cmd_list(_args: argparse.Namespace) -> int:
+def cmd_list(args: argparse.Namespace) -> int:
+    ctx = _ctx_from_args(args)
     # Prefer live guard names if available; else sidecar (no prompt).
     from key_amnesia.guard import guard_is_alive, guard_request
 
-    if guard_is_alive():
-        resp = guard_request({"verb": "list"})
+    if guard_is_alive(path=ctx.lock_path):
+        resp = guard_request({"verb": "list"}, lock_path=ctx.lock_path)
         if resp and resp.get("ok"):
             names = list(resp.get("names") or [])
             for n in names:
                 theme.out(n)
             return 0
-    names = read_names()
+    if ctx.merge_with_global:
+        names = merged_names_from_sidecars(ctx)
+    else:
+        names = read_names(ctx.names_path)
     for n in names:
         theme.out(n)
     return 0
@@ -631,11 +763,18 @@ def cmd_unlock(args: argparse.Namespace) -> int:
     console — but a spawned helper console refuses the unlock action itself
     (a separate console can't become this terminal's foreground guard).
     """
-    from key_amnesia.guard import guard_is_alive, run_foreground_guard
+    from key_amnesia.guard import VaultSource, guard_is_alive, run_foreground_guard
 
-    if guard_is_alive():
+    ctx = _ctx_from_args(args)
+
+    if guard_is_alive(path=ctx.lock_path):
         theme.warn("Guard session already active.")
         return 0
+
+    if not ctx.vault_path.exists():
+        hint = "ka init --project" if ctx.project_root else "ka init"
+        theme.error(f"Vault not initialized. Run '{hint}' first.")
+        return 1
 
     cfg = load_config()
     timeout_min = int(cfg.get("session-timeout-minutes", 30))
@@ -649,7 +788,7 @@ def cmd_unlock(args: argparse.Namespace) -> int:
     request = PromptRequest(
         action="unlock",
         detail=detail,
-        vault_path=str(vault_path()),
+        vault_path=str(ctx.vault_path),
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
@@ -658,13 +797,41 @@ def cmd_unlock(args: argparse.Namespace) -> int:
 
     if password is not None:
         try:
-            payload, vkey = load_vault_with_key(None, password)
+            payload, vkey = load_vault_with_key(ctx.vault_path, password)
         except VaultError as e:
             theme.error(f"Error: {e}")
             audit_event(
                 "unlock", route=outcome.route, result="denied", reason=str(e)
             )
             return 1
+
+        sources: list[VaultSource] | None = None
+        if ctx.merge_with_global and ctx.global_vault_path is not None:
+            theme.info(
+                "Global vault also configured — enter its master password (separate)."
+            )
+            global_pw = getpass.getpass("Global vault master password: ")
+            try:
+                g_payload, g_key = load_vault_with_key(
+                    ctx.global_vault_path, global_pw
+                )
+            except VaultError as e:
+                theme.error(f"Error decrypting global vault: {e}")
+                audit_event(
+                    "unlock", route=outcome.route, result="denied", reason=str(e)
+                )
+                return 1
+            sources = [
+                VaultSource(path=ctx.global_vault_path, key=g_key),
+                VaultSource(path=ctx.vault_path, key=vkey),
+            ]
+            merged = merge_secret_maps(
+                {k: str(v) for k, v in g_payload.get("secrets", {}).items()},
+                {k: str(v) for k, v in payload.get("secrets", {}).items()},
+            )
+            payload = dict(payload)
+            payload["secrets"] = merged
+
         audit_event("unlock", route=outcome.route, result="allowed")
         # Retain only the derived key (never the password) so the guard can
         # reload the vault on a content change without a fresh Argon2id run
@@ -672,8 +839,13 @@ def cmd_unlock(args: argparse.Namespace) -> int:
         return run_foreground_guard(
             payload,
             timeout_min,
-            vault_path=vault_path(),
+            vault_path=ctx.vault_path,
             vault_key=vkey,
+            vault_sources=sources,
+            lock_path=ctx.lock_path,
+            last_guard_state_path=ctx.last_guard_state_path,
+            project_root=str(ctx.project_root) if ctx.project_root else None,
+            env_name=ctx.env_name,
             pre_admit=pre_admit,
             pre_admit_secrets=pre_admit_secrets,
             pre_admit_seconds=pre_admit_seconds,
@@ -683,7 +855,7 @@ def cmd_unlock(args: argparse.Namespace) -> int:
     return 1
 
 
-def cmd_lock(_args: argparse.Namespace) -> int:
+def cmd_lock(args: argparse.Namespace) -> int:
     from key_amnesia.guard import (
         clear_guard_lock,
         format_no_guard_message,
@@ -691,12 +863,14 @@ def cmd_lock(_args: argparse.Namespace) -> int:
         guard_request,
     )
 
-    if not guard_is_alive():
-        clear_guard_lock()
-        theme.info(format_no_guard_message())
+    ctx = _ctx_from_args(args)
+
+    if not guard_is_alive(path=ctx.lock_path):
+        clear_guard_lock(path=ctx.lock_path)
+        theme.info(format_no_guard_message(path=ctx.last_guard_state_path))
         return 0
-    resp = guard_request({"verb": "lock"})
-    clear_guard_lock()
+    resp = guard_request({"verb": "lock"}, lock_path=ctx.lock_path)
+    clear_guard_lock(path=ctx.lock_path)
     if resp and resp.get("ok"):
         theme.success("Locked.")
         return 0
@@ -705,12 +879,13 @@ def cmd_lock(_args: argparse.Namespace) -> int:
 
 
 def cmd_reveal(args: argparse.Namespace) -> int:
-    # Always fresh auth — never guard shortcut.
+    # Always fresh auth — never guard shortcut. Single vault (no merge).
+    ctx = _ctx_from_args(args)
     name = args.name
     request = PromptRequest(
         action="reveal",
         secret_names=[name],
-        vault_path=str(vault_path()),
+        vault_path=str(ctx.vault_path),
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
@@ -719,7 +894,7 @@ def cmd_reveal(args: argparse.Namespace) -> int:
 
     if password is not None:
         try:
-            payload = load_vault(None, password)
+            payload = load_vault(ctx.vault_path, password)
         except VaultError as e:
             theme.error(f"Error: {e}")
             return 1
@@ -743,11 +918,12 @@ def cmd_reveal(args: argparse.Namespace) -> int:
 
 
 def cmd_copy(args: argparse.Namespace) -> int:
+    ctx = _ctx_from_args(args)
     name = args.name
     request = PromptRequest(
         action="copy",
         secret_names=[name],
-        vault_path=str(vault_path()),
+        vault_path=str(ctx.vault_path),
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
@@ -758,7 +934,7 @@ def cmd_copy(args: argparse.Namespace) -> int:
         from key_amnesia.clipboard import copy_to_clipboard
 
         try:
-            payload = load_vault(None, password)
+            payload = load_vault(ctx.vault_path, password)
         except VaultError as e:
             theme.error(f"Error: {e}")
             return 1
@@ -838,23 +1014,39 @@ def _format_remaining(expires_at_epoch: Any) -> str | None:
     return f"{minutes}m {seconds}s"
 
 
-def cmd_status(_args: argparse.Namespace) -> int:
+def cmd_status(args: argparse.Namespace) -> int:
     from key_amnesia.guard import (
         format_no_guard_message,
         guard_is_alive,
         guard_request,
+        list_guard_registry_entries,
         read_guard_lock,
     )
 
-    lock = read_guard_lock()
-    if not lock or not guard_is_alive(lock):
+    ctx = _ctx_from_args(args)
+
+    lock = read_guard_lock(path=ctx.lock_path)
+    if not lock or not guard_is_alive(lock, path=ctx.lock_path):
         theme.out("guard: inactive")
-        theme.out(format_no_guard_message())
+        theme.out(format_no_guard_message(path=ctx.last_guard_state_path))
         cfg = load_config()
         theme.out(f"session-mode: {cfg.get('session-mode')}")
+        if ctx.project_root:
+            theme.out(f"project: {ctx.project_root}")
+            theme.out(f"vault: {ctx.vault_path}")
+            theme.out(f"merge_global: {'yes' if ctx.merge_with_global else 'no'}")
+        others = list_guard_registry_entries()
+        for entry in others:
+            theme.out(
+                f"other_guard: pid={entry.get('pid')} vault={entry.get('vault_path')}"
+            )
         return 0
-    resp = guard_request({"verb": "status"})
+    resp = guard_request({"verb": "status"}, lock_path=ctx.lock_path)
     theme.out("guard: active")
+    if ctx.project_root:
+        theme.out(f"project: {ctx.project_root}")
+        theme.out(f"vault: {ctx.vault_path}")
+        theme.out(f"merge_global: {'yes' if ctx.merge_with_global else 'no'}")
     if resp and resp.get("ok"):
         theme.out(f"pid: {resp.get('pid')}")
         theme.out(f"expires_at: {resp.get('expires_at')}")
@@ -881,10 +1073,19 @@ def cmd_status(_args: argparse.Namespace) -> int:
         remaining = _format_remaining(lock.get("expires_at_epoch"))
         if remaining:
             theme.out(f"remaining: {remaining}")
+    others = [
+        e
+        for e in list_guard_registry_entries()
+        if Path(str(e.get("vault_path") or "")).resolve() != ctx.vault_path.resolve()
+    ]
+    for entry in others:
+        theme.out(
+            f"other_guard: pid={entry.get('pid')} vault={entry.get('vault_path')}"
+        )
     return 0
 
 
-def cmd_passwd(_args: argparse.Namespace) -> int:
+def cmd_passwd(args: argparse.Namespace) -> int:
     """Change the master password: re-encrypts the vault with a fresh salt.
 
     Refuses outright while a guard session is alive (the guard holds the
@@ -895,11 +1096,13 @@ def cmd_passwd(_args: argparse.Namespace) -> int:
     """
     from key_amnesia.guard import guard_is_alive
 
-    if guard_is_alive():
+    ctx = _ctx_from_args(args)
+
+    if guard_is_alive(path=ctx.lock_path):
         theme.error("Lock the vault first: ka lock")
         return 1
 
-    vp = vault_path()
+    vp = ctx.vault_path
     if not vp.exists():
         theme.error("Vault not initialized. Run 'ka init' first.")
         return 1

--- a/src/key_amnesia/guard.py
+++ b/src/key_amnesia/guard.py
@@ -37,7 +37,11 @@ from key_amnesia import peer_identity
 from key_amnesia import theme
 from key_amnesia import vault as vault_mod
 from key_amnesia.audit import audit_event
-from key_amnesia.paths import guard_lock_path, last_guard_state_path
+from key_amnesia.paths import (
+    guard_lock_path,
+    guards_registry_dir,
+    last_guard_state_path,
+)
 from key_amnesia.peer_identity import PeerIdentity
 from key_amnesia.run_exec import run_with_secrets
 
@@ -107,6 +111,20 @@ class AdmittedSession:
 
 
 @dataclass
+class VaultSource:
+    """One on-disk vault contributing to a (possibly merged) guard view.
+
+    `key` is the derived SecretBox key only — never the master password.
+    Sources are ordered low→high precedence; later sources win on name
+    collision when rebuilding `state.secrets` (global then project).
+    """
+
+    path: Path
+    key: bytes
+    fingerprint: str | None = None
+
+
+@dataclass
 class GuardState:
     secrets: dict[str, str]
     expires_at: float  # epoch seconds
@@ -132,6 +150,10 @@ class GuardState:
     # DESIGN.md "Derived key retained in guard memory".
     vault_key: bytes | None = None
     vault_content_fingerprint: str | None = None
+    # Multi-vault merge (project + global): when set, `_maybe_reload_secrets`
+    # fingerprints *every* source. Singular vault_path/vault_key remain for
+    # single-vault callers and tests.
+    vault_sources: list[VaultSource] | None = None
     # Opt-in, single-use pre-admit window (`ka unlock --pre-admit`) — see
     # `_check_admission`. `pre_admit_until` is cleared (set back to None)
     # the moment it is consumed by the first unrecognized peer, whether or
@@ -189,8 +211,12 @@ def clear_guard_lock(path: Path | None = None) -> None:
         pass
 
 
-def guard_is_alive(lock: dict[str, Any] | None = None) -> bool:
-    lock = lock if lock is not None else read_guard_lock()
+def guard_is_alive(
+    lock: dict[str, Any] | None = None,
+    *,
+    path: Path | None = None,
+) -> bool:
+    lock = lock if lock is not None else read_guard_lock(path=path)
     if not lock:
         return False
     pid = int(lock.get("pid") or 0)
@@ -204,8 +230,12 @@ def guard_is_alive(lock: dict[str, Any] | None = None) -> bool:
     return parent_alive(pid)
 
 
-def connect_guard(lock: dict[str, Any] | None = None) -> Connection | None:
-    lock = lock if lock is not None else read_guard_lock()
+def connect_guard(
+    lock: dict[str, Any] | None = None,
+    *,
+    path: Path | None = None,
+) -> Connection | None:
+    lock = lock if lock is not None else read_guard_lock(path=path)
     if not lock or not guard_is_alive(lock):
         return None
     try:
@@ -215,7 +245,12 @@ def connect_guard(lock: dict[str, Any] | None = None) -> Connection | None:
         return None
 
 
-def guard_request(msg: dict[str, Any], timeout: float = 30.0) -> dict[str, Any] | None:
+def guard_request(
+    msg: dict[str, Any],
+    timeout: float = 30.0,
+    *,
+    lock_path: Path | None = None,
+) -> dict[str, Any] | None:
     """Send a message to the live guard; return response or None.
 
     Since 0.3.8 the client attaches nothing admission-related — the guard
@@ -225,7 +260,7 @@ def guard_request(msg: dict[str, Any], timeout: float = 30.0) -> dict[str, Any] 
     `--name` / `KEY_AMNESIA_CLIENT_NAME`), defaulted here from the
     environment so every guard-talking command picks it up automatically.
     """
-    conn = connect_guard()
+    conn = connect_guard(path=lock_path)
     if conn is None:
         return None
     out = dict(msg)
@@ -582,20 +617,52 @@ def _check_admission_legacy(
 
 
 def _maybe_reload_secrets(state: GuardState) -> None:
-    """Re-open the vault if its on-disk content changed since we last looked.
+    """Re-open vault file(s) if on-disk content changed since we last looked.
 
     Fixes the guard's stale in-memory snapshot: `ka set` / `ka remove` from
     another terminal write the vault file directly, but a long-running `ka
     unlock` guard used to decrypt once at startup and never look again (see
     README security limit 9 / DESIGN.md). Cheap content fingerprint first —
-    only re-opens the vault (SecretBox decrypt with the already-derived key,
-    no Argon2id, no password prompt) when that fingerprint actually moved.
+    only re-opens (SecretBox decrypt with the already-derived key, no
+    Argon2id, no password prompt) when that fingerprint actually moved.
 
-    No-ops when the state was built without vault_path/vault_key (every
+    When `state.vault_sources` is set (project+global merge), every source
+    is fingerprinted and reloaded independently; secrets are rebuilt with
+    later sources winning on name collision. Singular vault_path/vault_key
+    remain the single-vault path.
+
+    No-ops when the state was built without vault backing (every
     guard-dispatch test constructs `GuardState` directly with just an
-    in-memory `secrets` dict and no backing vault file — those must keep
-    working unchanged).
+    in-memory `secrets` dict — those must keep working unchanged).
     """
+    if state.vault_sources:
+        changed = False
+        for src in state.vault_sources:
+            current = vault_mod.vault_fingerprint(src.path)
+            if current is None:
+                continue
+            if current != src.fingerprint:
+                changed = True
+                break
+        if not changed:
+            return
+        merged: dict[str, str] = {}
+        for src in state.vault_sources:
+            current = vault_mod.vault_fingerprint(src.path)
+            if current is None:
+                # Keep last fingerprint; skip this source's update this pass.
+                continue
+            try:
+                payload = vault_mod.load_vault_with_retained_key(src.path, src.key)
+            except vault_mod.VaultError:
+                continue
+            merged.update(
+                {k: str(v) for k, v in payload.get("secrets", {}).items()}
+            )
+            src.fingerprint = current
+        state.secrets = merged
+        return
+
     if state.vault_path is None or state.vault_key is None:
         return
     current = vault_mod.vault_fingerprint(state.vault_path)
@@ -610,6 +677,89 @@ def _maybe_reload_secrets(state: GuardState) -> None:
         return
     state.secrets = {k: str(v) for k, v in payload.get("secrets", {}).items()}
     state.vault_content_fingerprint = current
+
+
+# --- guard registry (discovery only; never authkey) -------------------------
+
+
+def _registry_key_for_vault(vault_path: Path | str) -> str:
+    import hashlib
+
+    resolved = str(Path(vault_path).resolve())
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:32]
+
+
+def write_guard_registry_entry(
+    *,
+    vault_path: Path | str,
+    address: str,
+    pid: int,
+    expires_at: float,
+    project_root: str | None = None,
+    env_name: str | None = None,
+) -> Path:
+    """Write a discovery-only registry entry. Never stores authkey."""
+    key = _registry_key_for_vault(vault_path)
+    d = guards_registry_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{key}.json"
+    data = {
+        "vault_path": str(Path(vault_path).resolve()),
+        "project_root": project_root,
+        "env": env_name,
+        "pid": pid,
+        "expires_at": _utc_iso(expires_at),
+        "expires_at_epoch": expires_at,
+        "address": address,
+        # authkey intentionally omitted — stays only in vault-adjacent lock
+    }
+    p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return p
+
+
+def remove_guard_registry_entry(vault_path: Path | str) -> None:
+    key = _registry_key_for_vault(vault_path)
+    p = guards_registry_dir() / f"{key}.json"
+    try:
+        p.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def list_guard_registry_entries() -> list[dict[str, Any]]:
+    """Return live registry entries; drop stale ones."""
+    from key_amnesia.prompt_route import parent_alive
+
+    d = guards_registry_dir()
+    if not d.is_dir():
+        return []
+    live: list[dict[str, Any]] = []
+    for p in d.glob("*.json"):
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            try:
+                p.unlink(missing_ok=True)
+            except OSError:
+                pass
+            continue
+        if not isinstance(data, dict):
+            continue
+        pid = int(data.get("pid") or 0)
+        expires = float(data.get("expires_at_epoch") or 0)
+        stale = False
+        if expires and time.time() > expires:
+            stale = True
+        elif pid <= 0 or not parent_alive(pid):
+            stale = True
+        if stale:
+            try:
+                p.unlink(missing_ok=True)
+            except OSError:
+                pass
+            continue
+        live.append(data)
+    return live
 
 
 # --- verb dispatch ----------------------------------------------------------
@@ -974,6 +1124,11 @@ def run_foreground_guard(
     *,
     vault_path: Path | str | None = None,
     vault_key: bytes | None = None,
+    vault_sources: list[VaultSource] | None = None,
+    lock_path: Path | None = None,
+    last_guard_state_path: Path | None = None,
+    project_root: str | None = None,
+    env_name: str | None = None,
     pre_admit: bool = False,
     pre_admit_secrets: list[str] | None = None,
     pre_admit_seconds: int = 900,
@@ -992,6 +1147,15 @@ def run_foreground_guard(
     `_maybe_reload_secrets`. Omitting them (as every existing test does)
     keeps the old fixed-at-startup-only behavior.
 
+    `vault_sources` (optional) enables a merged project+global view: each
+    source is fingerprinted independently; later sources win on name
+    collision. When provided, `payload["secrets"]` should already be the
+    merged map (caller builds it).
+
+    Registry write/remove runs **only** when `vault_path` is explicitly
+    passed (or derived from `vault_sources`) — tests that call this without
+    a vault path must not touch real `~/.key-amnesia/guards/`.
+
     `pre_admit` (opt-in, never the default) arms a single-use grant for the
     very next unrecognized peer within `pre_admit_seconds` — scoped to
     `pre_admit_secrets` if given, else unscoped ALL secrets. Must be loud:
@@ -1002,10 +1166,24 @@ def run_foreground_guard(
     expires_at = time.time() + timeout_minutes * 60
     listener, address, authkey = ipc.start_listener()
     pid = os.getpid()
-    vp = Path(vault_path) if vault_path is not None else None
-    fingerprint = (
-        vault_mod.vault_fingerprint(vp) if vp is not None and vault_key is not None else None
-    )
+
+    sources = list(vault_sources) if vault_sources else None
+    if sources:
+        for src in sources:
+            if src.fingerprint is None:
+                src.fingerprint = vault_mod.vault_fingerprint(src.path)
+        vp = sources[-1].path  # primary (highest precedence) vault
+        vkey = sources[-1].key
+        fingerprint = sources[-1].fingerprint
+    else:
+        vp = Path(vault_path) if vault_path is not None else None
+        vkey = vault_key
+        fingerprint = (
+            vault_mod.vault_fingerprint(vp)
+            if vp is not None and vault_key is not None
+            else None
+        )
+
     state = GuardState(
         secrets=secrets_map,
         expires_at=expires_at,
@@ -1013,8 +1191,9 @@ def run_foreground_guard(
         authkey=authkey,
         pid=pid,
         vault_path=vp,
-        vault_key=vault_key,
+        vault_key=vkey,
         vault_content_fingerprint=fingerprint,
+        vault_sources=sources,
     )
     if pre_admit:
         scoped_names = set(pre_admit_secrets or ())
@@ -1043,7 +1222,37 @@ def run_foreground_guard(
                 result="warn",
                 reason="scope: ALL (unscoped pre-admit)",
             )
-    write_guard_lock(address, authkey, pid, expires_at)
+
+    # Lock / last-state beside the active vault when paths are supplied;
+    # otherwise fall back to the global defaults (existing tests).
+    effective_lock = lock_path
+    if effective_lock is None and vp is not None:
+        from key_amnesia.paths import guard_lock_path_for_vault
+
+        effective_lock = guard_lock_path_for_vault(vp)
+    effective_last = last_guard_state_path
+    if effective_last is None and vp is not None:
+        from key_amnesia.paths import last_guard_state_path_for_vault
+
+        effective_last = last_guard_state_path_for_vault(vp)
+
+    write_guard_lock(address, authkey, pid, expires_at, path=effective_lock)
+
+    # Registry only when vault_path was explicitly provided (or via sources).
+    registry_vault: Path | None = vp
+    if registry_vault is not None:
+        try:
+            write_guard_registry_entry(
+                vault_path=registry_vault,
+                address=address,
+                pid=pid,
+                expires_at=expires_at,
+                project_root=project_root,
+                env_name=env_name,
+            )
+        except OSError:
+            pass
+
     started_at = state.created_at
 
     theme.success(
@@ -1071,9 +1280,16 @@ def run_foreground_guard(
         reason = f"crashed: {type(exc).__name__}"
         theme.error(f"Guard crashed: {exc}")
     finally:
-        _write_last_guard_state(reason, started_at, state.request_count)
+        _write_last_guard_state(
+            reason, started_at, state.request_count, path=effective_last
+        )
         state.secrets.clear()
-        clear_guard_lock()
+        clear_guard_lock(path=effective_lock)
+        if registry_vault is not None:
+            try:
+                remove_guard_registry_entry(registry_vault)
+            except OSError:
+                pass
         try:
             listener.close()
         except Exception:

--- a/src/key_amnesia/paths.py
+++ b/src/key_amnesia/paths.py
@@ -53,5 +53,24 @@ def last_guard_state_path() -> Path:
     return data_dir() / "last_guard_state.json"
 
 
+def guard_lock_path_for_vault(vault: Path | str) -> Path:
+    """`guard.lock` beside the vault file (project or global)."""
+    return Path(vault).resolve().parent / "guard.lock"
+
+
+def last_guard_state_path_for_vault(vault: Path | str) -> Path:
+    """`last_guard_state.json` beside the vault file."""
+    return Path(vault).resolve().parent / "last_guard_state.json"
+
+
+def guards_registry_dir() -> Path:
+    """Discovery-only registry of live guards (`~/.key-amnesia/guards/`).
+
+    Entries never carry authkeys — those stay only in the vault-adjacent lock.
+    Does not create the directory (callers that write should mkdir).
+    """
+    return data_dir() / "guards"
+
+
 def audit_log_path() -> Path:
     return data_dir() / "audit.log"

--- a/src/key_amnesia/project.py
+++ b/src/key_amnesia/project.py
@@ -1,0 +1,281 @@
+"""Project vault discovery, per-env paths, and vault-context resolution.
+
+Walks up from cwd looking for `.amnesia/`, stops at the home directory
+boundary (never crosses into `~`), and resolves which vault file(s) a
+command should use. Existing global `~/.key-amnesia/vault.bin` users see
+zero-action compatibility: no project → same paths as before.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from key_amnesia.paths import (
+    ENV_VAULT_PATH,
+    guard_lock_path_for_vault,
+    last_guard_state_path_for_vault,
+    vault_path as global_vault_path,
+)
+from key_amnesia.vault import names_path_for_vault
+
+AMNESIA_DIR = ".amnesia"
+PROJECT_CONFIG_NAME = "config.json"
+ENV_KA_ENV = "KA_ENV"
+
+
+@dataclass
+class VaultContext:
+    """Resolved vault target for one CLI invocation."""
+
+    vault_path: Path
+    names_path: Path
+    lock_path: Path
+    last_guard_state_path: Path
+    project_root: Path | None = None
+    env_name: str | None = None
+    merge_with_global: bool = False
+    global_vault_path: Path | None = None
+    use_global_config: bool = True
+    force_global: bool = False
+    vault_override: bool = False
+
+
+def find_project_root(start: Path | None = None) -> Path | None:
+    """Walk up from `start` (default cwd) for a directory containing `.amnesia/`.
+
+    Stops at the user's home directory (checks home itself, never walks
+    above it). When cwd is outside home, walks to the filesystem root.
+    Returns the directory that *contains* `.amnesia/`, or None.
+    """
+    cur = (start or Path.cwd()).resolve()
+    home = Path.home().resolve()
+    while True:
+        if (cur / AMNESIA_DIR).is_dir():
+            return cur
+        if cur == home or cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def amnesia_dir(project_root: Path) -> Path:
+    return project_root / AMNESIA_DIR
+
+
+def project_config_path(project_root: Path) -> Path:
+    return amnesia_dir(project_root) / PROJECT_CONFIG_NAME
+
+
+def load_project_config(project_root: Path) -> dict[str, Any]:
+    p = project_config_path(project_root)
+    if not p.exists():
+        return {"use_global": True}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"use_global": True}
+    if not isinstance(data, dict):
+        return {"use_global": True}
+    out = dict(data)
+    if "use_global" not in out:
+        out["use_global"] = True
+    return out
+
+
+def save_project_config(project_root: Path, cfg: dict[str, Any]) -> None:
+    p = project_config_path(project_root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    body = dict(cfg)
+    if "use_global" not in body:
+        body["use_global"] = True
+    p.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+
+def project_vault_path(project_root: Path, env_name: str | None = None) -> Path:
+    """`.amnesia/vault.bin` or `.amnesia/envs/<name>/vault.bin`."""
+    base = amnesia_dir(project_root)
+    if env_name:
+        return base / "envs" / env_name / "vault.bin"
+    return base / "vault.bin"
+
+
+def ensure_amnesia_gitignore(project_root: Path) -> bool:
+    """Ensure `.amnesia/` is listed in the project's `.gitignore`. No prompt.
+
+    Returns True if a line was added, False if already covered or no write.
+    """
+    gi = project_root / ".gitignore"
+    pattern = ".amnesia/"
+    covering = (".amnesia/", ".amnesia", "**/.amnesia/", "**/.amnesia")
+    if gi.exists():
+        try:
+            text = gi.read_text(encoding="utf-8")
+        except OSError:
+            return False
+        lines = {ln.strip() for ln in text.splitlines()}
+        if any(c in lines for c in covering):
+            return False
+        sep = "" if text.endswith("\n") or not text else "\n"
+        gi.write_text(text + sep + pattern + "\n", encoding="utf-8")
+        return True
+    gi.write_text(pattern + "\n", encoding="utf-8")
+    return True
+
+
+def ensure_project_scaffold(
+    project_root: Path,
+    *,
+    env_name: str | None = None,
+    use_global: bool = True,
+) -> Path:
+    """Create `.amnesia/` (and optional env dir), write config.json, gitignore.
+
+    Returns the vault path that should be initialized (does not create the vault).
+    """
+    root = project_root.resolve()
+    amnesia = amnesia_dir(root)
+    amnesia.mkdir(parents=True, exist_ok=True)
+    if env_name:
+        (amnesia / "envs" / env_name).mkdir(parents=True, exist_ok=True)
+    cfg_path = project_config_path(root)
+    if not cfg_path.exists():
+        save_project_config(root, {"use_global": bool(use_global)})
+    ensure_amnesia_gitignore(root)
+    return project_vault_path(root, env_name)
+
+
+def _resolve_env_name(
+    project_root: Path | None,
+    *,
+    env_flag: str | None,
+) -> str | None:
+    if env_flag:
+        return env_flag
+    ka_env = os.environ.get(ENV_KA_ENV)
+    if ka_env:
+        return ka_env
+    if project_root is not None:
+        cfg = load_project_config(project_root)
+        default_env = cfg.get("default_env")
+        if isinstance(default_env, str) and default_env:
+            return default_env
+    return None
+
+
+def _context_for_vault(
+    vp: Path,
+    *,
+    project_root: Path | None = None,
+    env_name: str | None = None,
+    merge_with_global: bool = False,
+    global_vp: Path | None = None,
+    use_global_config: bool = True,
+    force_global: bool = False,
+    vault_override: bool = False,
+) -> VaultContext:
+    return VaultContext(
+        vault_path=vp,
+        names_path=names_path_for_vault(vp),
+        lock_path=guard_lock_path_for_vault(vp),
+        last_guard_state_path=last_guard_state_path_for_vault(vp),
+        project_root=project_root,
+        env_name=env_name,
+        merge_with_global=merge_with_global,
+        global_vault_path=global_vp,
+        use_global_config=use_global_config,
+        force_global=force_global,
+        vault_override=vault_override,
+    )
+
+
+def resolve_vault_context(
+    *,
+    vault: str | Path | None = None,
+    force_global: bool = False,
+    no_global: bool = False,
+    env: str | None = None,
+    start: Path | None = None,
+) -> VaultContext:
+    """Resolve which vault a command should use.
+
+    Precedence:
+    1. Explicit `--vault PATH` (or KEY_AMNESIA_VAULT_PATH when set and no flags)
+    2. `--global` → global vault only
+    3. Project walk-up → project vault (+ optional global merge)
+    4. Else global vault
+
+    `--no-global` disables merge even when project config says use_global.
+    `--env` / KA_ENV / project default_env select per-env vault files.
+    """
+    # Explicit CLI --vault always wins.
+    if vault is not None:
+        vp = Path(vault)
+        return _context_for_vault(vp, vault_override=True)
+
+    # KEY_AMNESIA_VAULT_PATH: bootstrap/test override — skip project discovery.
+    env_override = os.environ.get(ENV_VAULT_PATH)
+    if env_override:
+        return _context_for_vault(Path(env_override), vault_override=True)
+
+    gvp = global_vault_path()
+
+    if force_global:
+        if env:
+            raise ValueError("--env requires a project vault (omit --global)")
+        return _context_for_vault(gvp, force_global=True)
+
+    project_root = find_project_root(start)
+    if project_root is None:
+        if env:
+            raise ValueError(
+                "--env requires a project (.amnesia/); run 'ka init --project' first"
+            )
+        return _context_for_vault(gvp)
+
+    cfg = load_project_config(project_root)
+    use_global = bool(cfg.get("use_global", True))
+    if no_global:
+        use_global = False
+
+    env_name = _resolve_env_name(project_root, env_flag=env)
+    pvp = project_vault_path(project_root, env_name)
+
+    merge = False
+    global_for_merge: Path | None = None
+    if use_global and gvp.exists() and gvp.resolve() != pvp.resolve():
+        merge = True
+        global_for_merge = gvp
+
+    return _context_for_vault(
+        pvp,
+        project_root=project_root,
+        env_name=env_name,
+        merge_with_global=merge,
+        global_vp=global_for_merge,
+        use_global_config=use_global,
+    )
+
+
+def merge_secret_maps(*maps: dict[str, str]) -> dict[str, str]:
+    """Merge secret dicts left-to-right; later maps win on collision.
+
+    Callers should pass global first, then project, so project wins.
+    """
+    out: dict[str, str] = {}
+    for m in maps:
+        out.update(m)
+    return out
+
+
+def merged_names_from_sidecars(ctx: VaultContext) -> list[str]:
+    """Union of names sidecars for list-without-guard (project wins order N/A)."""
+    from key_amnesia.vault import read_names
+
+    names: set[str] = set()
+    if ctx.merge_with_global and ctx.global_vault_path is not None:
+        names.update(read_names(names_path_for_vault(ctx.global_vault_path)))
+    names.update(read_names(ctx.names_path))
+    return sorted(names)

--- a/tests/test_project_vaults.py
+++ b/tests/test_project_vaults.py
@@ -1,0 +1,327 @@
+"""Project vaults + merge + registry (PR3 / 0.3.10).
+
+Always uses throwaway KEY_AMNESIA_HOME via the `ka_home` fixture — never
+the maintainer's real vault.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from key_amnesia import vault as vault_mod
+from key_amnesia.cli import main
+from key_amnesia.guard import (
+    AdmittedSession,
+    GuardState,
+    VaultSource,
+    guard_handle_message,
+    list_guard_registry_entries,
+    remove_guard_registry_entry,
+    write_guard_registry_entry,
+)
+from key_amnesia.paths import guard_lock_path_for_vault, guards_registry_dir
+from key_amnesia.project import (
+    ensure_project_scaffold,
+    find_project_root,
+    load_project_config,
+    merge_secret_maps,
+    project_vault_path,
+    resolve_vault_context,
+)
+
+
+ADMITTED_TOKEN = "test-admitted-token"
+
+
+def _make_project(tmp_path: Path, *, use_global: bool = True) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    ensure_project_scaffold(root, use_global=use_global)
+    return root
+
+
+def test_find_project_root_walks_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _make_project(tmp_path)
+    nested = root / "a" / "b"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    assert find_project_root() == root.resolve()
+
+
+def test_find_project_root_stops_at_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    # Put .amnesia above the home boundary so walk must not find it when
+    # cwd is under fake home with no .amnesia.
+    (tmp_path / ".amnesia").mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.chdir(home)
+    assert find_project_root() is None
+
+
+def test_init_project_creates_vault_config_gitignore(
+    ka_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    proj = tmp_path / "myproj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    pw = "project-master-pw"
+    answers = iter([pw, pw])
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(answers))
+
+    rc = main(["init", "--project"])
+    assert rc == 0
+    vp = proj / ".amnesia" / "vault.bin"
+    assert vp.exists()
+    cfg = load_project_config(proj)
+    assert cfg.get("use_global") is True
+    gi = (proj / ".gitignore").read_text(encoding="utf-8")
+    assert ".amnesia/" in gi
+    payload = vault_mod.load_vault(vp, pw)
+    assert payload["secrets"] == {}
+
+
+def test_init_project_env_path(
+    ka_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proj = tmp_path / "myproj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    pw = "env-pw"
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": pw)
+
+    rc = main(["init", "--project", "--env", "staging"])
+    assert rc == 0
+    assert (proj / ".amnesia" / "envs" / "staging" / "vault.bin").exists()
+
+
+def test_resolve_defaults_to_global_without_project(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(ka_home)
+    ctx = resolve_vault_context()
+    assert ctx.project_root is None
+    assert ctx.vault_path == ka_home / "vault.bin"
+    assert not ctx.merge_with_global
+
+
+def test_resolve_project_merge_when_global_exists(
+    ka_home: Path, tmp_path: Path, password: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Seed global vault
+    vault_mod.save_vault(
+        ka_home / "vault.bin",
+        password,
+        {"secrets": {"GLOBAL_ONLY": "g", "SHARED": "from-global"}},
+    )
+    proj = _make_project(tmp_path, use_global=True)
+    pvp = project_vault_path(proj)
+    vault_mod.save_vault(
+        pvp,
+        "proj-pw",
+        {"secrets": {"PROJ_ONLY": "p", "SHARED": "from-project"}},
+    )
+    monkeypatch.chdir(proj)
+    ctx = resolve_vault_context()
+    assert ctx.project_root == proj.resolve()
+    assert ctx.vault_path == pvp.resolve() or ctx.vault_path == pvp
+    assert ctx.merge_with_global is True
+    assert ctx.global_vault_path is not None
+
+
+def test_resolve_no_global_flag(
+    ka_home: Path, tmp_path: Path, password: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_mod.save_vault(
+        ka_home / "vault.bin", password, {"secrets": {"G": "1"}}
+    )
+    proj = _make_project(tmp_path, use_global=True)
+    vault_mod.save_vault(
+        project_vault_path(proj), "proj-pw", {"secrets": {"P": "1"}}
+    )
+    monkeypatch.chdir(proj)
+    ctx = resolve_vault_context(no_global=True)
+    assert ctx.merge_with_global is False
+
+
+def test_resolve_force_global(
+    ka_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    ctx = resolve_vault_context(force_global=True)
+    assert ctx.project_root is None
+    assert ctx.force_global is True
+    assert ctx.vault_path == ka_home / "vault.bin"
+
+
+def test_merge_secret_maps_project_wins() -> None:
+    merged = merge_secret_maps(
+        {"A": "g", "SHARED": "g"},
+        {"B": "p", "SHARED": "p"},
+    )
+    assert merged == {"A": "g", "B": "p", "SHARED": "p"}
+
+
+def test_guard_reload_covers_all_merged_sources(
+    ka_home: Path, password: str, tmp_path: Path
+) -> None:
+    global_v = ka_home / "vault.bin"
+    vault_mod.save_vault(
+        global_v, password, {"secrets": {"G": "gv1", "SHARED": "g"}}
+    )
+    proj = _make_project(tmp_path, use_global=True)
+    proj_v = project_vault_path(proj)
+    proj_pw = "proj-password"
+    vault_mod.save_vault(
+        proj_v, proj_pw, {"secrets": {"P": "pv1", "SHARED": "p"}}
+    )
+
+    g_payload, g_key = vault_mod.load_vault_with_key(global_v, password)
+    p_payload, p_key = vault_mod.load_vault_with_key(proj_v, proj_pw)
+    sources = [
+        VaultSource(
+            path=global_v,
+            key=g_key,
+            fingerprint=vault_mod.vault_fingerprint(global_v),
+        ),
+        VaultSource(
+            path=proj_v,
+            key=p_key,
+            fingerprint=vault_mod.vault_fingerprint(proj_v),
+        ),
+    ]
+    merged = merge_secret_maps(
+        {k: str(v) for k, v in g_payload["secrets"].items()},
+        {k: str(v) for k, v in p_payload["secrets"].items()},
+    )
+    state = GuardState(
+        secrets=merged,
+        expires_at=time.time() + 600,
+        address="dummy",
+        authkey=b"r" * 32,
+        vault_sources=sources,
+        vault_path=proj_v,
+        vault_key=p_key,
+    )
+    state.admitted = AdmittedSession(
+        token=ADMITTED_TOKEN, first_seen="2026-01-01T00:00:00+00:00"
+    )
+
+    reply = guard_handle_message(
+        {"verb": "list", "admission_token": ADMITTED_TOKEN}, state
+    )
+    assert reply["ok"] is True
+    assert set(reply["names"]) == {"G", "P", "SHARED"}
+
+    # Mutate global vault while merged guard is live — must refresh.
+    vault_mod.save_vault(
+        global_v,
+        password,
+        {"secrets": {"G": "gv2", "SHARED": "g", "G_NEW": "x"}},
+    )
+    reply = guard_handle_message(
+        {"verb": "list", "admission_token": ADMITTED_TOKEN}, state
+    )
+    assert reply["ok"] is True
+    assert "G_NEW" in reply["names"]
+    # Project still wins on SHARED
+    assert state.secrets["SHARED"] == "p"
+    assert state.secrets["G"] == "gv2"
+
+
+def test_lock_path_beside_project_vault(tmp_path: Path) -> None:
+    proj = _make_project(tmp_path)
+    vp = project_vault_path(proj)
+    assert guard_lock_path_for_vault(vp) == vp.parent / "guard.lock"
+
+
+def test_registry_write_remove_no_authkey(ka_home: Path) -> None:
+    vp = ka_home / "vault.bin"
+    vp.write_bytes(b"x")
+    p = write_guard_registry_entry(
+        vault_path=vp,
+        address="\\\\.\\pipe\\test",
+        pid=12345,
+        expires_at=time.time() + 600,
+        project_root=None,
+        env_name=None,
+    )
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert "authkey" not in data
+    assert "authkey_hex" not in data
+    assert data["vault_path"] == str(vp.resolve())
+    assert data["pid"] == 12345
+    # Fake pid → list should drop as stale
+    assert list_guard_registry_entries() == []
+    # Re-write with current pid so it stays live briefly
+    write_guard_registry_entry(
+        vault_path=vp,
+        address="addr",
+        pid=__import__("os").getpid(),
+        expires_at=time.time() + 600,
+    )
+    live = list_guard_registry_entries()
+    assert len(live) == 1
+    remove_guard_registry_entry(vp)
+    assert list_guard_registry_entries() == []
+
+
+def test_import_targets_project_vault(
+    ka_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proj = _make_project(tmp_path, use_global=False)
+    monkeypatch.chdir(proj)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    pw = "import-proj-pw"
+    vault_mod.save_vault(project_vault_path(proj), pw, {"secrets": {}})
+
+    env_file = proj / ".env"
+    env_file.write_text("FROM_ENV=secret-value-xyz\n", encoding="utf-8")
+
+    # password, then decline delete, decline rename, decline gitignore
+    prompts = iter([pw])
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(prompts))
+    answers = iter(["n", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    rc = main(["import", str(env_file)])
+    assert rc == 0
+    payload = vault_mod.load_vault(project_vault_path(proj), pw)
+    assert "FROM_ENV" in payload["secrets"]
+    # Must not have written into the global vault
+    assert not (ka_home / "vault.bin").exists() or "FROM_ENV" not in (
+        vault_mod.read_names(ka_home / "vault.names.json")
+        if (ka_home / "vault.names.json").exists()
+        else []
+    )
+
+
+def test_set_targets_project_vault(
+    ka_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from key_amnesia.prompt_route import AuthOutcome
+
+    proj = _make_project(tmp_path, use_global=False)
+    monkeypatch.chdir(proj)
+    pw = "set-proj-pw"
+    vault_mod.save_vault(project_vault_path(proj), pw, {"secrets": {}})
+    monkeypatch.setattr(
+        "key_amnesia.cli.require_human_auth",
+        lambda *a, **k: AuthOutcome(ok=True, route="inline", password=pw),
+    )
+    rc = main(["set", "PROJ_KEY", "proj-value"])
+    assert rc == 0
+    payload = vault_mod.load_vault(project_vault_path(proj), pw)
+    assert payload["secrets"]["PROJ_KEY"] == "proj-value"


### PR DESCRIPTION
## Summary
- Walk-up discovery of `.amnesia/` (stops at home), per-env vault files under `envs/<name>/`, and `.amnesia/config.json` `use_global` (default true) with project-wins merge against the global vault
- `ka init --project [--env NAME]` scaffolds the tree and auto-gitignores `.amnesia/`; vault-aware commands gain `--vault` / `--global` / `--no-global` / `--env`; `ka import` and fresh-auth cmds target the resolved project vault when inside a project
- Guard lock + `last_guard_state` sit beside the active vault; `GuardState.vault_sources` fingerprints every file in a merge; discovery-only registry at `~/.key-amnesia/guards/` (never authkey). Merged unlock/run prompts **two passwords** when both vaults exist. Existing global vault: zero-action compatible.

## Stack / dependencies
Depends on (do not merge out of order):
- #32 (PR2 `ka import`) — this PR's base
- #31 (PR1 peer identity)
- #30 (PR0 guard reload)

## Bootstrap safety (B3)
Vault resolution changes for project contexts only. Global-only users (no `.amnesia/`) keep the previous path. Exercise under throwaway `KEY_AMNESIA_HOME`; prior pin `0.3.9` remains installable if needed.

## Test plan
- [x] Full pytest green (243 passed, 1 skipped)
- [ ] `ka init --project` in a temp dir → `.amnesia/vault.bin`, config.json, gitignore entry
- [ ] Inside project with global vault: `ka unlock` prompts twice; `ka list` shows merged names; project wins on collision
- [ ] `ka unlock --no-global` / `use_global: false` isolates project secrets
- [ ] `--env staging` uses `.amnesia/envs/staging/vault.bin`; lock file beside that vault
- [ ] Registry entry appears under `KEY_AMNESIA_HOME/guards/` during unlock and is removed on lock; no authkey in JSON
- [ ] Outside any project: behavior unchanged from PR2 global vault