### PR TITLE
Fix macOS CI admission test failures (peer stub)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,28 @@ from pathlib import Path
 
 import pytest
 
+from key_amnesia.peer_identity import PeerIdentity
+
+
+@pytest.fixture
+def stub_peer_identity(monkeypatch: pytest.MonkeyPatch) -> PeerIdentity:
+    """Stand-in kernel peer for tests that exercise real IPC admission.
+
+    Product `get_peer_identity` returns `None` on macOS (fail closed). Tests
+    that need a successful admit/lock/run path over a live listener request
+    this fixture so the lookup returns a stable identity for this process —
+    product code stays fail-closed on unsupported platforms.
+    """
+    peer = PeerIdentity(pid=os.getpid(), start_time=1)
+
+    def _fake_get_peer_identity(_conn=None) -> PeerIdentity:
+        return PeerIdentity(pid=os.getpid(), start_time=1)
+
+    monkeypatch.setattr(
+        "key_amnesia.peer_identity.get_peer_identity", _fake_get_peer_identity
+    )
+    return peer
+
 
 @pytest.fixture
 def ka_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/tests/test_guard_death_reporting.py
+++ b/tests/test_guard_death_reporting.py
@@ -22,13 +22,30 @@ from key_amnesia.guard import (
 )
 
 
+def _best_effort_lock_guard() -> None:
+    """Stop a leftover foreground guard so it cannot poison later tests."""
+    try:
+        if not guard_lock_path().exists():
+            return
+        lock = json.loads(guard_lock_path().read_text(encoding="utf-8"))
+        authkey = ipc.authkey_from_hex(lock["authkey_hex"])
+        conn = ipc.connect(lock["address"], authkey)
+        try:
+            ipc.send_msg(conn, {"verb": "lock", "caller_pid": 0})
+            ipc.recv_msg(conn, timeout=2)
+        finally:
+            conn.close()
+    except Exception:
+        pass
+
+
 def test_no_previous_session_message(ka_home) -> None:
     assert format_no_guard_message() == (
         "Guard is not running. No previous session recorded."
     )
 
 
-def test_guard_serve_returns_locked_reason(ka_home, monkeypatch) -> None:
+def test_guard_serve_returns_locked_reason(ka_home, monkeypatch, stub_peer_identity) -> None:
     monkeypatch.setattr("key_amnesia.guard.default_admit_prompt", lambda *a, **k: True)
     listener, address, authkey = ipc.start_listener()
     state = GuardState(
@@ -68,7 +85,7 @@ def test_guard_serve_returns_expired_reason(ka_home) -> None:
 
 
 def test_run_foreground_guard_writes_last_state_on_lock(
-    ka_home, monkeypatch, capsys
+    ka_home, monkeypatch, capsys, stub_peer_identity
 ) -> None:
     """A client `lock` request during run_foreground_guard writes reason=locked
     to last_guard_state.json before guard.lock is cleared, and the guard
@@ -82,42 +99,45 @@ def test_run_foreground_guard_writes_last_state_on_lock(
 
     t = threading.Thread(target=unlock_thread, daemon=True)
     t.start()
-
-    # Wait for guard.lock to appear.
-    deadline = time.time() + 5
-    lock = None
-    while time.time() < deadline:
-        if guard_lock_path().exists():
-            try:
-                candidate = json.loads(guard_lock_path().read_text(encoding="utf-8"))
-                if candidate:
-                    lock = candidate
-                    break
-            except Exception:
-                pass
-        time.sleep(0.05)
-    assert lock is not None
-
-    authkey = ipc.authkey_from_hex(lock["authkey_hex"])
-    conn = ipc.connect(lock["address"], authkey)
     try:
-        ipc.send_msg(conn, {"verb": "lock", "caller_pid": 12345})
-        reply = ipc.recv_msg(conn, timeout=10)
+        # Wait for guard.lock to appear.
+        deadline = time.time() + 5
+        lock = None
+        while time.time() < deadline:
+            if guard_lock_path().exists():
+                try:
+                    candidate = json.loads(guard_lock_path().read_text(encoding="utf-8"))
+                    if candidate:
+                        lock = candidate
+                        break
+                except Exception:
+                    pass
+            time.sleep(0.05)
+        assert lock is not None
+
+        authkey = ipc.authkey_from_hex(lock["authkey_hex"])
+        conn = ipc.connect(lock["address"], authkey)
+        try:
+            ipc.send_msg(conn, {"verb": "lock", "caller_pid": 12345})
+            reply = ipc.recv_msg(conn, timeout=10)
+        finally:
+            conn.close()
+        assert reply.get("ok") is True
+
+        t.join(timeout=5)
+        assert result.get("rc") == 0
+        assert not guard_lock_path().exists()
+
+        last = read_last_guard_state()
+        assert last is not None
+        assert last["reason"] == "locked"
+
+        out = capsys.readouterr().out
+        assert "Guard listening" in out
+        assert "Waiting for requests" in out
     finally:
-        conn.close()
-    assert reply.get("ok") is True
-
-    t.join(timeout=5)
-    assert result.get("rc") == 0
-    assert not guard_lock_path().exists()
-
-    last = read_last_guard_state()
-    assert last is not None
-    assert last["reason"] == "locked"
-
-    out = capsys.readouterr().out
-    assert "Guard listening" in out
-    assert "Waiting for requests" in out
+        _best_effort_lock_guard()
+        t.join(timeout=5)
 
 
 def test_run_foreground_guard_reports_interrupted(ka_home, monkeypatch, capsys) -> None:

--- a/tests/test_guard_startup_banner.py
+++ b/tests/test_guard_startup_banner.py
@@ -112,6 +112,13 @@ def test_reminder_suppressed_once_inside_extend_window(monkeypatch) -> None:
         authkey=b"a" * 32,
     )
 
+    # Force-stop shortly after hard expiry so a leftover accept thread or a
+    # poisoned concurrent guard cannot hang this test in CI.
+    def _stop_after_expiry() -> None:
+        time.sleep(1.5)
+        state.stop.set()
+
+    threading.Thread(target=_stop_after_expiry, daemon=True).start()
     guard_serve(state, _NeverConnectsListener())
 
     assert not any("remaining" in r for r in reminders)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -103,11 +103,16 @@ def test_guard_run_path_scrubs(seeded_vault: Path, password: str) -> None:
 
 
 def test_unlock_run_lock_fallback(
-    seeded_vault: Path, password: str, monkeypatch, capsys
+    seeded_vault: Path, password: str, monkeypatch, capsys, stub_peer_identity
 ) -> None:
     """Simulate unlock→run via guard→lock→fallback to per-call."""
     from key_amnesia import guard as guard_mod
     from key_amnesia import ipc
+    from key_amnesia import peer_identity
+
+    # stub_peer_identity: macOS (and other unsupported platforms) fail closed
+    # in product get_peer_identity; the fixture supplies a stable current-
+    # process identity so this in-process client/server exercise can admit.
 
     payload = load_vault(seeded_vault, password)
     secrets = {k: str(v) for k, v in payload["secrets"].items()}
@@ -133,8 +138,6 @@ def test_unlock_run_lock_fallback(
 
     import threading
 
-    from key_amnesia import peer_identity
-
     stop = threading.Event()
 
     def serve_one() -> None:
@@ -157,58 +160,61 @@ def test_unlock_run_lock_fallback(
 
     t = threading.Thread(target=serve_one, daemon=True)
     t.start()
-
-    code = "import os; print(os.environ['API_KEY'])"
-    rc = main(
-        [
-            "run",
-            "--secret",
-            "api_key",
-            "--as",
-            "api_key=API_KEY",
-            "--",
-            sys.executable,
-            "-c",
-            code,
-        ]
-    )
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "***REDACTED(api_key)***" in out
-    assert "super-secret-value-123" not in out
-
-    # Lock
-    rc = main(["lock"])
-    assert rc == 0
-    stop.set()
-    clear_guard_lock()
-    monkeypatch.setattr(guard_mod, "guard_is_alive", lambda *a, **k: False)
-
-    # Fallback: per-call with password
-    monkeypatch.setattr(
-        "key_amnesia.cli.require_human_auth",
-        lambda *a, **k: AuthOutcome(ok=True, route="inline", password=password),
-    )
-    rc = main(
-        [
-            "run",
-            "--secret",
-            "api_key",
-            "--as",
-            "api_key=API_KEY",
-            "--",
-            sys.executable,
-            "-c",
-            code,
-        ]
-    )
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "***REDACTED(api_key)***" in out
     try:
-        listener.close()
-    except Exception:
-        pass
+        code = "import os; print(os.environ['API_KEY'])"
+        rc = main(
+            [
+                "run",
+                "--secret",
+                "api_key",
+                "--as",
+                "api_key=API_KEY",
+                "--",
+                sys.executable,
+                "-c",
+                code,
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "***REDACTED(api_key)***" in out
+        assert "super-secret-value-123" not in out
+
+        # Lock
+        rc = main(["lock"])
+        assert rc == 0
+        stop.set()
+        clear_guard_lock()
+        monkeypatch.setattr(guard_mod, "guard_is_alive", lambda *a, **k: False)
+
+        # Fallback: per-call with password
+        monkeypatch.setattr(
+            "key_amnesia.cli.require_human_auth",
+            lambda *a, **k: AuthOutcome(ok=True, route="inline", password=password),
+        )
+        rc = main(
+            [
+                "run",
+                "--secret",
+                "api_key",
+                "--as",
+                "api_key=API_KEY",
+                "--",
+                sys.executable,
+                "-c",
+                code,
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "***REDACTED(api_key)***" in out
+    finally:
+        stop.set()
+        try:
+            listener.close()
+        except Exception:
+            pass
+        t.join(timeout=5)
 
 
 def test_reveal_noninteractive_status_only(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- Stub `get_peer_identity` via a `stub_peer_identity` fixture in IPC admission success-path tests (death-reporting lock, session unlock→run→lock) so macOS CI can exercise admit/lock without inventing darwin kernel peer identity.
- Best-effort lock cleanup + banner-test force-stop so a denied leftover guard cannot hang or poison later tests (was the root of the 66m suite / reminder false positive).
- **No product changes** — `get_peer_identity` remains fail-closed on darwin. Tests-only; version stays 0.4.2.

## Test plan
- [x] `pytest tests/test_guard_death_reporting.py tests/test_guard_startup_banner.py tests/test_session.py` (19 passed locally on Windows)
- [ ] CI green on `macos-latest` 3.10 + 3.13 (the previously failing matrix cells)
- [ ] Confirm ubuntu/windows still green

Made with [Cursor](https://cursor.com)