### PR TITLE
Add OpenAI Codex support (0.4.3)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -8,4 +8,8 @@ Install it (and the agent skills) with:
 ka setup
 ```
 
-This merges a `PreToolUse` entry into `~/.claude/settings.json` (and a `preToolUse` entry into `~/.cursor/hooks.json` for Cursor) that runs the `key-amnesia-hook` console script. There is now exactly one canonical copy of the hook (inside the installed package); this directory is a pointer only.
+This merges a `PreToolUse` entry into `~/.claude/settings.json`, a
+`preToolUse` entry into `~/.cursor/hooks.json` for Cursor, and a `PreToolUse`
+entry into `~/.codex/hooks.json` for Codex that runs the `key-amnesia-hook`
+console script. There is now exactly one canonical copy of the hook (inside
+the installed package); this directory is a pointer only.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,8 @@ Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted v
 
 **0.3.7 (bugfix, no CLI-surface / no IPC-verb changes):** fixed the guard's stale in-memory secrets snapshot (README limit 11 / "Known limitation" below). `GuardState` gained `vault_path`, `vault_key` (derived SecretBox key only — never the password), and `vault_content_fingerprint`; `run`/`list`/`status` now call `_maybe_reload_secrets`, which re-opens the vault with the retained key (no Argon2id) whenever the fingerprint changes. `cmd_unlock` switched from `load_vault` to `load_vault_with_key` to obtain that key without deriving it twice; `vault.py` gained `load_vault_with_key`, `load_vault_with_retained_key`, and `vault_fingerprint`. Verb set is unchanged — still exactly `{run, list, lock, status, renew}`; no `reload` verb was added (`tests/test_guard_verbs_regression.py` untouched). New exposure: the guard now retains **derived key material** for the session (see "Who holds plaintext" and the note under GuardState below) — same trust tier as the plaintext secrets it already held, but worth naming explicitly. `tests/test_guard_reload.py`.
 
+**0.4.3 (Codex support; no IPC-verb changes):** `ka setup` also installs the three packaged skills into `~/.agents/skills/` and `~/.codex/skills/` (`$CODEX_HOME`), and merges a Codex `PreToolUse` hook into `~/.codex/hooks.json` (matcher `Bash|Write|Edit|apply_patch`). Secret-guard allows `apply_patch`. Docs/README/wiki note Codex restart + `/hooks` trust. Version `0.4.3`.
+
 **0.4.2 (review hardening; no IPC-verb changes):** `migrate_kam1_to_kam2` requires `confirm=` unconditionally (announce alone can no longer migrate). Windows ancestor walk takes one `CreateToolhelp32Snapshot` per chain. `guard_handle_message` requires keyword-only `peer=` (no default); legacy opaque-token path is `guard_handle_message_legacy` (tests only). Five-verb regression covers both legacy and kernel admission. Linux `SO_PEERCRED` compares kernel uid to `os.geteuid()` and fails closed on mismatch. Optional `@pytest.mark.slow` for process-spawning tests. Version `0.4.2`.
 
 **0.4.1 (admission follow-up; no IPC-verb changes):** Windows connecting-peer `OpenProcess` HANDLE is held on `PeerIdentity` for the admission lifetime (ancestor walks still open-read-close); `release()` on replace + foreground-guard teardown. README honesty on Windows vs Linux `SO_PEERCRED`, ancestry UX vs in-tree malware, and the residual GetNamedPipeClientProcessId→OpenProcess race. Legacy IPC display field renamed `caller_pid` → `claimed_pid_unverified`. Usage skill: verify with `ka status`/`ka connect` before assuming vault access. Version `0.4.1`.
@@ -70,7 +72,7 @@ key-amnesia/
     clipboard.py
     theme.py                       # branded CLI output (NO_COLOR / non-TTY safe)
     platform.py                    # isolated-console spawn (Windows CREATE_NEW_CONSOLE; Linux emulators + /dev/tty install offer; experimental macOS Terminal + PID-file wrapper)
-    setup_cmd.py                   # `ka setup`: installs skills + merges hook config into ~/.claude, ~/.cursor
+    setup_cmd.py                   # `ka setup`: installs skills + merges hook config into ~/.claude, ~/.cursor, ~/.agents, ~/.codex
     skills/                        # packaged agent skills (key-amnesia-usage / -hygiene / -migrate), package data
     hooks/
       secret_guard.py              # PreToolUse (Claude) / preToolUse (Cursor) blocking hook; console script key-amnesia-hook
@@ -517,7 +519,7 @@ Always fresh master-password routing (never guard shortcut) for `reveal`, `copy`
 - `config set session-mode|session-timeout-minutes|prompt-timeout-seconds|pre-admit-seconds` — always fresh auth
 - `status` (alias `connect`, same handler, no separate guard verb) — live guard status (pid, expiry, secret count, admission state, pre-admit-pending state) or the last session's honest death report
 - `run`/`list`/`lock`/`status`/`connect` accept `--name LABEL` — display-only client label shown in the guard's admission prompt (see "Admission consent" above); never a trust input
-- `setup` — non-interactive: copies the 3 packaged skills to `~/.claude/skills/` + `~/.cursor/skills/` and idempotently merges the secret-guard hook into `~/.claude/settings.json` (`PreToolUse`) + `~/.cursor/hooks.json` (`preToolUse`); `--skills-only` / `--hook-only` to do just one half; never mutates vault/session state
+- `setup` — non-interactive: copies the 3 packaged skills to `~/.claude/skills/` + `~/.cursor/skills/` + `~/.agents/skills/` + `~/.codex/skills/` (`$CODEX_HOME`) and idempotently merges the secret-guard hook into `~/.claude/settings.json` (`PreToolUse`) + `~/.cursor/hooks.json` (`preToolUse`) + `~/.codex/hooks.json` (`PreToolUse`, matcher includes `apply_patch`); `--skills-only` / `--hook-only` to do just one half; never mutates vault/session state
 - `docs [--print]` — print the GitHub wiki URL always; best-effort browser open (skipped with `--print`); never fails if open fails; no vault/guard/password; per-command `--docs` deferred
 - `_prompt-helper` — internal; bare argv + env handoff; omitted from top-level summary, still supports `--help`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The agent gets amnesia. That's the whole point.
 
 ```bash
 pip install key-amnesia
-ka setup                          # skills + secret-guard hook for Claude Code / Cursor
+ka setup                          # skills + secret-guard hook for Claude Code / Cursor / Codex
 ka init --project                 # or: ka init  for a global vault
 ka import .env                    # move plaintext into the vault (TTY-only; never prints values)
 ka scan                           # find remaining LEAKs (names/paths only)
@@ -70,7 +70,11 @@ this project:
    you cannot do that step yourself.
 ```
 
-`ka setup` copies the bundled skills to `~/.claude/skills/` and `~/.cursor/skills/`, and merges a PreToolUse / preToolUse hook that blocks tool calls containing inline credential-shaped tokens.
+`ka setup` copies the bundled skills to `~/.claude/skills/`, `~/.cursor/skills/`,
+`~/.agents/skills/` (Codex), and `~/.codex/skills/` (legacy Codex /
+`$CODEX_HOME`), and merges a PreToolUse / preToolUse hook that blocks tool
+calls containing inline credential-shaped tokens. Codex also needs you to
+review and trust the new hook via `/hooks` before it will run.
 
 ## Two modes: ask every time, or unlock a session
 

--- a/docs/agent-usage.md
+++ b/docs/agent-usage.md
@@ -47,7 +47,7 @@ There is no MCP “get secret” API. That is intentional.
 
 ## Related
 
-Agent-oriented short form: the `key-amnesia-usage` skill (`src/key_amnesia/skills/key-amnesia-usage/SKILL.md`), installed for Claude Code / Cursor via `ka setup`.
+Agent-oriented short form: the `key-amnesia-usage` skill (`src/key_amnesia/skills/key-amnesia-usage/SKILL.md`), installed for Claude Code / Cursor / Codex via `ka setup`.
 
 Human docs: [GitHub wiki — Agent usage](https://github.com/fujitoid/key-amnesia/wiki/Agent-usage)
 (`ka docs`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.4.2"
+version = "0.4.3"
 description = "Encrypted secret vault so AI agents can use API keys without seeing them — a drop-in .env replacement"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 authors = [{ name = "key-amnesia contributors" }]
-keywords = ["secrets", "credentials", "vault", "ai-agents", "claude", "cursor", "security"]
+keywords = ["secrets", "credentials", "vault", "ai-agents", "claude", "cursor", "codex", "security"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,10 +2,14 @@
 
 The `key-amnesia-usage`, `key-amnesia-hygiene`, and `key-amnesia-migrate` skills are now packaged inside `key_amnesia` itself (`src/key_amnesia/skills/*/SKILL.md`) instead of living here as a separate root-level copy.
 
-Install them for Claude Code / Cursor with:
+Install them for Claude Code / Cursor / Codex with:
 
 ```bash
 ka setup
 ```
 
-This copies the current package version of each `SKILL.md` to `~/.claude/skills/` and `~/.cursor/skills/`. There is now exactly one canonical copy of each skill (inside the installed package); this directory is a pointer only.
+This copies the current package version of each `SKILL.md` to
+`~/.claude/skills/`, `~/.cursor/skills/`, `~/.agents/skills/` (Codex), and
+`~/.codex/skills/` (legacy Codex / `$CODEX_HOME`). There is now exactly one
+canonical copy of each skill (inside the installed package); this directory
+is a pointer only.

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -342,7 +342,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # setup (agent distribution: skills + PreToolUse/preToolUse hook)
     p_setup = sub.add_parser(
         "setup",
-        help="Install agent skills and the secret-guard hook for Claude Code / Cursor",
+        help="Install agent skills and the secret-guard hook for Claude Code / Cursor / Codex",
     )
     p_setup.add_argument(
         "--skills-only",

--- a/src/key_amnesia/hooks/secret_guard.py
+++ b/src/key_amnesia/hooks/secret_guard.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""PreToolUse / preToolUse secret guard: blocking hook for Claude Code and Cursor.
+"""PreToolUse / preToolUse secret guard: blocking hook for Claude Code, Cursor, Codex.
 
-Inspects a pending tool call (Bash/Shell command, or Write/Edit file content) for
-inline credential-shaped tokens and **denies** the call when one is found,
-pointing the agent at ``ka set`` / ``ka run`` instead.
+Inspects a pending tool call (Bash/Shell command, Write/Edit file content, or
+Codex ``apply_patch``) for inline credential-shaped tokens and **denies** the
+call when one is found, pointing the agent at ``ka set`` / ``ka run`` instead.
 
-Two host contracts are implemented from the same detection logic:
+Host contracts from the same detection logic:
 
-- Claude Code ``PreToolUse``: stdin JSON with ``tool_name`` / ``tool_input``;
-  deny reply uses ``hookSpecificOutput.permissionDecision``.
+- Claude Code / Codex ``PreToolUse``: stdin JSON with ``tool_name`` /
+  ``tool_input``; deny reply uses ``hookSpecificOutput.permissionDecision``.
+  Codex shares Claude's deny shape (no separate contract).
 - Cursor ``preToolUse``: stdin JSON with ``tool_name`` / ``tool_input`` (plus
   Cursor-only fields like ``cursor_version`` / ``conversation_id``); deny
   reply uses the flatter ``{"permission": "deny", ...}`` shape.
@@ -185,7 +186,11 @@ def find_finding(text: str) -> str | None:
 
 
 def detect_host(payload: dict[str, Any]) -> str:
-    """Distinguish Cursor's flatter preToolUse payload from Claude's PreToolUse."""
+    """Distinguish Cursor's flatter preToolUse payload from Claude/Codex PreToolUse.
+
+    Codex uses the Claude-shaped deny contract; without Cursor-only markers we
+    return ``claude`` (covers Claude Code and Codex).
+    """
     if "cursor_version" in payload or "conversation_id" in payload:
         return "cursor"
     event = str(payload.get("hook_event_name") or "")
@@ -218,7 +223,7 @@ def deny_cursor(kind: str) -> dict[str, Any]:
     }
 
 
-_ALLOWED_TOOL_NAMES = {"bash", "shell", "write", "edit", "multiedit"}
+_ALLOWED_TOOL_NAMES = {"bash", "shell", "write", "edit", "multiedit", "apply_patch"}
 
 
 def main() -> int:

--- a/src/key_amnesia/setup_cmd.py
+++ b/src/key_amnesia/setup_cmd.py
@@ -1,9 +1,10 @@
 """`ka setup`: non-interactive install of packaged skills + secret-guard hook.
 
-Copies the three bundled agent skills to the Claude Code / Cursor skills
-directories and merges a `PreToolUse` (Claude) / `preToolUse` (Cursor) hook
-entry into each host's own config file. Safe to re-run (idempotent upsert);
-never drops unrelated keys or other hooks/matchers already present.
+Copies the three bundled agent skills to the Claude Code / Cursor / Codex
+skills directories and merges a `PreToolUse` (Claude, Codex) / `preToolUse`
+(Cursor) hook entry into each host's own config file. Safe to re-run
+(idempotent upsert); never drops unrelated keys or other hooks/matchers
+already present.
 """
 
 from __future__ import annotations
@@ -22,12 +23,23 @@ SKILL_NAMES = ["key-amnesia-usage", "key-amnesia-hygiene", "key-amnesia-migrate"
 
 CLAUDE_MATCHER = "Bash|Write|Edit"
 CURSOR_MATCHER = "Shell|Write"
+# Codex: Bash + apply_patch aliases (Write/Edit also match apply_patch edits).
+CODEX_MATCHER = "Bash|Write|Edit|apply_patch"
 HOOK_COMMAND = "key-amnesia-hook"
 HOOK_COMMAND_FALLBACK = "python -m key_amnesia.hooks.secret_guard"
 
 
 def _skills_root():
     return resources.files("key_amnesia") / "skills"
+
+
+def _codex_home(home: Path | None = None) -> Path:
+    """Resolve Codex home: ``$CODEX_HOME`` if set, else ``~/.codex``."""
+    home = home or Path.home()
+    env = os.environ.get("CODEX_HOME")
+    if env:
+        return Path(env)
+    return home / ".codex"
 
 
 def _copy_skills(dest_roots: list[Path]) -> list[str]:
@@ -69,7 +81,8 @@ def _is_our_hook_command(command: str) -> bool:
     return "key-amnesia-hook" in command or "key_amnesia.hooks.secret_guard" in command
 
 
-def _merge_claude_settings(path: Path) -> None:
+def _merge_pretooluse_hooks(path: Path, matcher: str) -> None:
+    """Idempotently upsert our PreToolUse entry (Claude / Codex shape)."""
     settings = _load_json_object(path)
     hooks = settings.get("hooks")
     if not isinstance(hooks, dict):
@@ -91,12 +104,20 @@ def _merge_claude_settings(path: Path) -> None:
     kept = [e for e in pretooluse if not _is_ours(e)]
     kept.append(
         {
-            "matcher": CLAUDE_MATCHER,
+            "matcher": matcher,
             "hooks": [{"type": "command", "command": _hook_command()}],
         }
     )
     hooks["PreToolUse"] = kept
     _write_json(path, settings)
+
+
+def _merge_claude_settings(path: Path) -> None:
+    _merge_pretooluse_hooks(path, CLAUDE_MATCHER)
+
+
+def _merge_codex_hooks(path: Path) -> None:
+    _merge_pretooluse_hooks(path, CODEX_MATCHER)
 
 
 def _merge_cursor_hooks(path: Path) -> None:
@@ -150,19 +171,28 @@ def cmd_setup(args: argparse.Namespace) -> int:
         return 2
 
     home = Path.home()
+    codex_home = _codex_home(home)
     lines: list[str] = []
 
     if not hook_only:
-        dest_roots = [home / ".claude" / "skills", home / ".cursor" / "skills"]
+        dest_roots = [
+            home / ".claude" / "skills",
+            home / ".cursor" / "skills",
+            home / ".agents" / "skills",
+            codex_home / "skills",
+        ]
         lines.extend(_copy_skills(dest_roots))
 
     if not skills_only:
         claude_settings = home / ".claude" / "settings.json"
         cursor_hooks = home / ".cursor" / "hooks.json"
+        codex_hooks = codex_home / "hooks.json"
         _merge_claude_settings(claude_settings)
         lines.append(f"hook installed: {claude_settings} (PreToolUse)")
         _merge_cursor_hooks(cursor_hooks)
         lines.append(f"hook installed: {cursor_hooks} (preToolUse)")
+        _merge_codex_hooks(codex_hooks)
+        lines.append(f"hook installed: {codex_hooks} (PreToolUse)")
 
     lines.append(_check_path())
 
@@ -170,8 +200,11 @@ def cmd_setup(args: argparse.Namespace) -> int:
         theme.out(line)
 
     theme.info(
-        "Restart Claude Code / Cursor (or reload the window) to pick up the "
-        "new skills and hook."
+        "Restart Claude Code / Cursor / Codex (or reload the window) to pick "
+        "up the new skills and hook."
+    )
+    theme.info(
+        "Codex: review and trust the new hook via `/hooks` before it will run."
     )
     theme.info(
         "In your own terminal: `ka init` (first time) or `ka unlock` (start a session)."

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -169,6 +169,19 @@ def test_main_write_tool_scans_contents(monkeypatch, capsys) -> None:
     assert reply is not None
 
 
+def test_main_codex_apply_patch_blocks_claude_shape(monkeypatch, capsys) -> None:
+    """Codex apply_patch uses Claude-shaped PreToolUse deny."""
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {"command": "*** Update File: .env\n+" + "sk-" + "a" * 25},
+    }
+    rc, reply = _run_main(payload, monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert reply["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
 def test_main_clean_command_allows(monkeypatch, capsys) -> None:
     payload = {
         "hook_event_name": "PreToolUse",

--- a/tests/test_setup_cmd.py
+++ b/tests/test_setup_cmd.py
@@ -33,12 +33,17 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def test_setup_copies_all_skills_to_both_hosts(fake_home: Path) -> None:
     rc = sc.cmd_setup(_ns())
     assert rc == 0
-    for host_dir in ("claude", "cursor"):
+    for host_dir in ("claude", "cursor", "agents"):
+        root = fake_home / f".{host_dir}" / "skills"
         for name in sc.SKILL_NAMES:
-            dest = fake_home / f".{host_dir}" / "skills" / name / "SKILL.md"
+            dest = root / name / "SKILL.md"
             assert dest.exists()
             content = dest.read_text(encoding="utf-8")
             assert content.startswith("---\nname: " + name)
+    for name in sc.SKILL_NAMES:
+        dest = fake_home / ".codex" / "skills" / name / "SKILL.md"
+        assert dest.exists()
+        assert dest.read_text(encoding="utf-8").startswith("---\nname: " + name)
 
 
 def test_setup_skill_content_matches_package_source(fake_home: Path) -> None:
@@ -67,15 +72,21 @@ def test_setup_skills_only_skips_hook_files(fake_home: Path) -> None:
     sc.cmd_setup(_ns(skills_only=True))
     assert not (fake_home / ".claude" / "settings.json").exists()
     assert not (fake_home / ".cursor" / "hooks.json").exists()
+    assert not (fake_home / ".codex" / "hooks.json").exists()
     assert (fake_home / ".claude" / "skills" / sc.SKILL_NAMES[0] / "SKILL.md").exists()
+    assert (fake_home / ".agents" / "skills" / sc.SKILL_NAMES[0] / "SKILL.md").exists()
+    assert (fake_home / ".codex" / "skills" / sc.SKILL_NAMES[0] / "SKILL.md").exists()
 
 
 def test_setup_hook_only_skips_skills(fake_home: Path) -> None:
     sc.cmd_setup(_ns(hook_only=True))
     assert not (fake_home / ".claude" / "skills").exists()
     assert not (fake_home / ".cursor" / "skills").exists()
+    assert not (fake_home / ".agents" / "skills").exists()
+    assert not (fake_home / ".codex" / "skills").exists()
     assert (fake_home / ".claude" / "settings.json").exists()
     assert (fake_home / ".cursor" / "hooks.json").exists()
+    assert (fake_home / ".codex" / "hooks.json").exists()
 
 
 def test_setup_rejects_both_only_flags(fake_home: Path, capsys) -> None:
@@ -200,6 +211,75 @@ def test_claude_hooks_matcher_is_bash_write_edit(fake_home: Path) -> None:
     path = fake_home / ".claude" / "settings.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["hooks"]["PreToolUse"][0]["matcher"] == sc.CLAUDE_MATCHER
+
+
+# --- Codex hooks.json merge -------------------------------------------------
+
+
+def test_codex_hooks_merge_preserves_unrelated_entries(fake_home: Path) -> None:
+    path = fake_home / ".codex" / "hooks.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "description": "workspace hooks",
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "some-other-hook"}],
+                        }
+                    ],
+                    "PostToolUse": [{"matcher": "*", "hooks": []}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    sc.cmd_setup(_ns(hook_only=True))
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["description"] == "workspace hooks"
+    assert "PostToolUse" in data["hooks"]
+    matchers = [entry["matcher"] for entry in data["hooks"]["PreToolUse"]]
+    assert "Bash" in matchers
+    commands = [
+        h["command"]
+        for entry in data["hooks"]["PreToolUse"]
+        for h in entry["hooks"]
+    ]
+    assert "some-other-hook" in commands
+    assert any("key-amnesia" in c or "secret_guard" in c for c in commands)
+
+
+def test_codex_hooks_merge_idempotent(fake_home: Path) -> None:
+    sc.cmd_setup(_ns(hook_only=True))
+    path = fake_home / ".codex" / "hooks.json"
+    first = json.loads(path.read_text(encoding="utf-8"))
+
+    sc.cmd_setup(_ns(hook_only=True))
+    second = json.loads(path.read_text(encoding="utf-8"))
+
+    assert len(second["hooks"]["PreToolUse"]) == len(first["hooks"]["PreToolUse"]) == 1
+
+
+def test_codex_hooks_matcher_includes_apply_patch(fake_home: Path) -> None:
+    sc.cmd_setup(_ns(hook_only=True))
+    path = fake_home / ".codex" / "hooks.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["hooks"]["PreToolUse"][0]["matcher"] == sc.CODEX_MATCHER
+
+
+def test_codex_home_env_redirects_skills_and_hooks(
+    fake_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom = tmp_path / "custom-codex"
+    monkeypatch.setenv("CODEX_HOME", str(custom))
+    sc.cmd_setup(_ns())
+    assert (custom / "skills" / sc.SKILL_NAMES[0] / "SKILL.md").exists()
+    assert (custom / "hooks.json").exists()
+    assert not (fake_home / ".codex" / "hooks.json").exists()
 
 
 # --- PATH check --------------------------------------------------------------

--- a/wiki/Agent-usage.md
+++ b/wiki/Agent-usage.md
@@ -70,6 +70,6 @@ never ask them to paste the result back into chat:
 
 ## Related
 
-Bundled skill: `key-amnesia-usage` (installed by `ka setup`). Longer
-operator notes: repository `docs/agent-usage.md`. Migration flow:
-[Quickstart migration](Quickstart-migration).
+Bundled skill: `key-amnesia-usage` (installed by `ka setup` for Claude Code,
+Cursor, and Codex). Longer operator notes: repository `docs/agent-usage.md`.
+Migration flow: [Quickstart migration](Quickstart-migration).

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -19,7 +19,7 @@ notes live in the repository `DESIGN.md`.
 | `ka reveal NAME` / `ka copy NAME` | Human-only surface of a value; always fresh auth |
 | `ka config show` / `ka config set KEY VALUE` | Settings |
 | `ka status` / `ka connect` | Session status (+ registry of live guards). `connect` is a **CLI alias** for `status` — not a sixth IPC verb |
-| `ka setup [--skills-only] [--hook-only]` | Install skills + secret-guard hook |
+| `ka setup [--skills-only] [--hook-only]` | Install skills + secret-guard hook (Claude / Cursor / Codex) |
 | `ka docs [--print]` | Print wiki URL; open browser unless `--print` |
 | `ka identity create` / `show` | Local X25519 identity for KAM2 |
 | `ka member add` / `list` / `remove` | Members/roles (first add enables KAM2) |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -3,7 +3,7 @@
 Encrypted secret vault for AI coding agents. The agent can **use** secrets
 through `ka run` without ever **seeing** the values.
 
-> **Docs as of 0.4.2.** Pages in this tree describe the shipped CLI at that
+> **Docs as of 0.4.3.** Pages in this tree describe the shipped CLI at that
 > version. The live GitHub Wiki may lag until maintainers publish from
 > in-repo `wiki/` (see that directory’s `README.md` — publish instructions
 > only; not a wiki page).

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -23,9 +23,15 @@ ka setup
 ```
 
 Copies bundled skills (`key-amnesia-usage`, `key-amnesia-hygiene`,
-`key-amnesia-migrate`) into `~/.claude/skills/` and `~/.cursor/skills/`, and
-merges a PreToolUse / preToolUse hook that blocks tool calls containing
-inline credential-shaped tokens. Restart or reload the host afterward.
+`key-amnesia-migrate`) into `~/.claude/skills/`, `~/.cursor/skills/`,
+`~/.agents/skills/` (current Codex user path), and `~/.codex/skills/`
+(legacy / `$CODEX_HOME`), and merges a PreToolUse / preToolUse hook that
+blocks tool calls containing inline credential-shaped tokens. Restart or
+reload the host afterward. On Codex, review and trust the new hook via
+`/hooks` before it will run.
+
+Codex also reads project `AGENTS.md` for instructions; that is separate from
+skills installed by `ka setup`.
 
 Flags: `--skills-only`, `--hook-only`.
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -3,7 +3,8 @@
 These markdown files are **first drafts** for the live GitHub wiki at
 [https://github.com/fujitoid/key-amnesia/wiki](https://github.com/fujitoid/key-amnesia/wiki).
 
-**Docs as of 0.4.2** — in-repo wording targets that release. Live wiki published for 0.4.2.
+**Docs as of 0.4.3** — in-repo wording targets that release. Live wiki last
+published for 0.4.2 (sync Install / Commands / Agent-usage after merge).
 
 
 They are kept in-repo so PRs can review IA and wording before (or instead of)
@@ -29,7 +30,8 @@ GitHub wiki page titles come from filenames (`Home.md` → Home,
 maintainer publish instructions only.
 
 After a successful publish, update the “last published” note here (still
-keep docs-as-of version accurate). Last published: 0.4.2 (live wiki).
+keep docs-as-of version accurate). Last published: 0.4.2 (live wiki; 0.4.3
+in-repo drafts pending publish).
 
 ## Proposed IA
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,4 +1,4 @@
-**Docs** *(as of 0.4.2)*
+**Docs** *(as of 0.4.3)*
 
 - [Home](Home)
 - [Why not `.env`](Why-not-dotenv)


### PR DESCRIPTION
## Summary
- `ka setup` installs the three packaged skills into `~/.agents/skills/` (Codex) and `~/.codex/skills/` (legacy / ``), alongside existing Claude/Cursor paths
- Merges Codex `PreToolUse` into `~/.codex/hooks.json` (matcher `Bash|Write|Edit|apply_patch`); secret-guard allows `apply_patch`
- Docs/README/wiki updated for Codex restart + `/hooks` trust; version bump to **0.4.3**

## Test plan
- [x] `pytest tests/test_setup_cmd.py tests/test_secret_guard.py` (58 passed)
- [x] Full suite: `303 passed, 3 skipped`
- [ ] Manual: `ka setup` then confirm skills under `~/.agents/skills` and `~/.codex/skills`, hook in `~/.codex/hooks.json`
- [ ] Manual (Codex): trust hook via `/hooks`, restart, verify Bash/apply_patch deny on inline secret-shaped tokens

## Notes
- Not merged (for review)
- Live GitHub wiki **not** updated in this PR — in-repo `wiki/` is ready for a separate publish

Made with [Cursor](https://cursor.com)