### PR TITLE
Mark wiki published for 0.4.3

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,7 +4,7 @@ These markdown files are **first drafts** for the live GitHub wiki at
 [https://github.com/fujitoid/key-amnesia/wiki](https://github.com/fujitoid/key-amnesia/wiki).
 
 **Docs as of 0.4.3** — in-repo wording targets that release. Live wiki last
-published for 0.4.2 (sync Install / Commands / Agent-usage after merge).
+published for 0.4.3.
 
 
 They are kept in-repo so PRs can review IA and wording before (or instead of)
@@ -30,8 +30,7 @@ GitHub wiki page titles come from filenames (`Home.md` → Home,
 maintainer publish instructions only.
 
 After a successful publish, update the “last published” note here (still
-keep docs-as-of version accurate). Last published: 0.4.2 (live wiki; 0.4.3
-in-repo drafts pending publish).
+keep docs-as-of version accurate). Last published: 0.4.3.
 
 ## Proposed IA
 


### PR DESCRIPTION
## Summary
- Update `wiki/README.md` last-published note to 0.4.3 after live wiki sync.

## Test plan
- [x] Confirm live wiki Install mentions Codex
- [x] Confirm Home docs-as-of 0.4.3

Made with [Cursor](https://cursor.com)