### PR TITLE
0.4.4: test isolation, agent TTY routing, guard visibility

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,8 @@ Python prototype CLI (`key-amnesia` / `ka`) for Windows-primary use. Encrypted v
 
 **0.3.7 (bugfix, no CLI-surface / no IPC-verb changes):** fixed the guard's stale in-memory secrets snapshot (README limit 11 / "Known limitation" below). `GuardState` gained `vault_path`, `vault_key` (derived SecretBox key only — never the password), and `vault_content_fingerprint`; `run`/`list`/`status` now call `_maybe_reload_secrets`, which re-opens the vault with the retained key (no Argon2id) whenever the fingerprint changes. `cmd_unlock` switched from `load_vault` to `load_vault_with_key` to obtain that key without deriving it twice; `vault.py` gained `load_vault_with_key`, `load_vault_with_retained_key`, and `vault_fingerprint`. Verb set is unchanged — still exactly `{run, list, lock, status, renew}`; no `reload` verb was added (`tests/test_guard_verbs_regression.py` untouched). New exposure: the guard now retains **derived key material** for the session (see "Who holds plaintext" and the note under GuardState below) — same trust tier as the plaintext secrets it already held, but worth naming explicitly. `tests/test_guard_reload.py`.
 
+**0.4.4 (test isolation + agent-harness TTY + guard visibility):** Suite `ka_home` is `autouse` with fail-if-outside-tmp. Auth routing requires stdin **and** stdout TTY for inline; `KEY_AMNESIA_NONINTERACTIVE` forces spawned-console. `guard_request` audits IPC abandon as `warn`; guard replies carry structured `code`; `ka run`/`list` print why the guard path was abandoned. Version `0.4.4`.
+
 **0.4.3 (Codex support; no IPC-verb changes):** `ka setup` also installs the three packaged skills into `~/.agents/skills/` and `~/.codex/skills/` (`$CODEX_HOME`), and merges a Codex `PreToolUse` hook into `~/.codex/hooks.json` (matcher `Bash|Write|Edit|apply_patch`). Secret-guard allows `apply_patch`. Docs/README/wiki note Codex restart + `/hooks` trust. Version `0.4.3`.
 
 **0.4.2 (review hardening; no IPC-verb changes):** `migrate_kam1_to_kam2` requires `confirm=` unconditionally (announce alone can no longer migrate). Windows ancestor walk takes one `CreateToolhelp32Snapshot` per chain. `guard_handle_message` requires keyword-only `peer=` (no default); legacy opaque-token path is `guard_handle_message_legacy` (tests only). Five-verb regression covers both legacy and kernel admission. Linux `SO_PEERCRED` compares kernel uid to `os.geteuid()` and fails closed on mismatch. Optional `@pytest.mark.slow` for process-spawning tests. Version `0.4.2`.
@@ -338,7 +340,8 @@ Written by the guard on **every** exit path — `started_at`, `ended_at`, `reaso
 
 ```
 Needs human auth
-  → stdin.isatty?
+  → KEY_AMNESIA_NONINTERACTIVE set? → spawn isolated console
+  → else stdin.isatty AND stdout.isatty?
       yes → getpass/input inline → KDF decrypt in-process
       no  → spawn isolated console (bare argv, env handoff)
               → Windows: CREATE_NEW_CONSOLE
@@ -353,7 +356,9 @@ Needs human auth
 
 **`unlock` is the one action a spawned helper console cannot complete.** `ka unlock` blocks in the *caller's own terminal* for the life of the session — a separate spawned console is a different process with a different TTY, so it cannot become that guard on the parent's behalf. A non-interactive `unlock` still routes through the same isatty/spawn logic as every other command (so the routing decision, and its audit trail, stay uniform), but the helper's `unlock` handler refuses immediately with a clear reason (`"unlock must be run in a foreground terminal"`) instead of trying to start anything.
 
-**Known limitation: `isatty()` is a heuristic, not a guarantee of an attentive human.** The routing above assumes a tty-shaped stdin means a real person is present to type a password inline. In practice a pseudo-terminal can exist with nobody actually watching it — observed with an AI coding agent whose own tool harness sometimes allocates a pty for a subprocess it invokes, unpredictably from the caller's side. When that happens, `key-amnesia` takes the inline branch and prints the prompt into a stream nobody reads. **Not fixed** (no reliable way to distinguish "tty-shaped" from "someone is actually there" from inside the process) — named honestly rather than silently left as a mystery. **What is fixed:** the consequence used to be an indefinite hang (`getpass`/`input` block forever with no timeout); inline password entry now runs on a `prompt-timeout-seconds`-bounded thread and fails closed with a clear "prompt timed out" outcome instead of hanging. The guard's own admission prompt (see below) uses the same bounded-thread pattern with a fixed 60s timeout.
+**Known limitation: `isatty()` is a heuristic, not a guarantee of an attentive human.** Routing requires **both** `stdin` and `stdout` to report a TTY before taking the inline path (0.4.4). Agent harnesses commonly attach a pty to stdin while redirecting stdout; the older stdin-only check selected unanswerable inline `getpass` and hung until `prompt-timeout-seconds`. That dual-stream check alone does not prove a human is present. **Override:** set `KEY_AMNESIA_NONINTERACTIVE=1` (also `true`/`yes`/`on`) to force the spawned-console route regardless of what the streams claim. **Still true:** there is no reliable way to distinguish "tty-shaped" from "someone is actually there." Inline password entry remains bounded by `prompt-timeout-seconds` and fails closed with "prompt timed out" instead of hanging forever. The guard's own admission prompt uses the same bounded-thread pattern with a fixed 60s timeout.
+
+Client `ka run` / `ka list` always print why a live guard path was abandoned (unreachable IPC, expired, admission denied, or hard denial codes) before falling back or exiting — abandoned IPC attempts are also written to `audit.log` as `guard-session` / `warn` (0.4.4).
 
 ### Nothing sensitive on argv — ever
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Your choices used to be ugly: paste the key, leave it in plaintext where the agent can read it, or do that part yourself.
 
-**key-amnesia is the fourth option.** Secrets live in an encrypted vault. The agent triggers commands that *use* them — values are injected into the child process environment, out of the agent's sight. If a command prints a secret, key-amnesia censors it before the agent sees the output. The master password can only ever be typed by you, at a real keyboard: when an agent needs approval, a **separate console window** pops up — one the agent cannot read or type into.
+**key-amnesia is the fourth option.** Secrets live in an encrypted vault. The agent triggers commands that *use* them — values are injected into the child process environment, out of the agent's sight. If a command prints a secret, key-amnesia censors it before the agent sees the output. The master password can only ever be typed by you, at a real keyboard: when an agent needs approval, a **separate console window** pops up — one the agent cannot read or type into. Auth routing requires both stdin and stdout to look like a TTY before prompting inline; set `KEY_AMNESIA_NONINTERACTIVE=1` in agent harnesses to always force that window.
 
 The agent gets amnesia. That's the whole point.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.4.3"
+version = "0.4.4"
 description = "Encrypted secret vault so AI agents can use API keys without seeing them — a drop-in .env replacement"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -1133,6 +1133,19 @@ def _load_merged_secrets(
     return merge_secret_maps(g_secrets, secrets)
 
 
+# Guard reply `code` values that must hard-stop `ka run` (no password fall-through).
+_GUARD_RUN_HARD_STOP_CODES = frozenset(
+    {
+        "unknown_secret",
+        "no_command",
+        "invalid_message",
+        "value_return_refused",
+        "unknown_verb",
+        "invalid_minutes",
+    }
+)
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     ctx = _ctx_from_args(args)
     cmd = list(args.cmd or [])
@@ -1192,15 +1205,28 @@ def cmd_run(args: argparse.Namespace) -> int:
             _write_command_output(sys.stdout, resp.get("scrubbed_stdout", ""))
             _write_command_output(sys.stderr, resp.get("scrubbed_stderr", ""))
             return int(resp.get("exit_code", 0))
-        if resp and resp.get("expired"):
+        if resp is None:
+            theme.warn(
+                "Guard unreachable (IPC failed); falling back to per-call auth."
+            )
+        elif resp.get("expired") or resp.get("code") == "session_expired":
             theme.warn("Guard session expired; falling back to per-call auth.")
-        elif resp and not resp.get("ok"):
-            # Guard reachable but denied (e.g. unknown secret) — don't fall through
-            # with a password prompt unless it's expiry/connectivity.
-            if "unknown" in str(resp.get("reason", "")):
-                theme.error(f"Error: {resp.get('reason')}")
+        elif not resp.get("ok"):
+            code = str(resp.get("code") or "")
+            reason = str(resp.get("reason") or "denied")
+            if code in _GUARD_RUN_HARD_STOP_CODES:
+                theme.error(f"Error: {reason}")
                 return 1
-
+            if code == "admission_denied":
+                theme.warn(
+                    "Guard admission denied; falling back to per-call auth. "
+                    "Approve the next request on the unlock terminal, or use "
+                    "`ka unlock --pre-admit`."
+                )
+            else:
+                theme.warn(
+                    f"Guard declined ({reason}); falling back to per-call auth."
+                )
     request = PromptRequest(
         action="run",
         secret_names=secret_names,
@@ -1266,6 +1292,15 @@ def cmd_list(args: argparse.Namespace) -> int:
             for n in names:
                 theme.out(n)
             return 0
+        if resp is None:
+            theme.warn(
+                "Guard unreachable (IPC failed); listing from vault sidecar names."
+            )
+        elif resp and not resp.get("ok"):
+            theme.warn(
+                f"Guard declined list ({resp.get('reason') or 'denied'}); "
+                "listing from vault sidecar names."
+            )
     if ctx.merge_with_global:
         names = merged_names_from_sidecars(ctx)
     else:

--- a/src/key_amnesia/guard.py
+++ b/src/key_amnesia/guard.py
@@ -258,16 +258,39 @@ def guard_request(
     `client_name` is a **display-only** label (never a credential — see
     `--name` / `KEY_AMNESIA_CLIENT_NAME`), defaulted here from the
     environment so every guard-talking command picks it up automatically.
+
+    Connectivity / protocol failures return `None` after writing a
+    `guard-session` / `warn` audit entry — never silently.
     """
-    conn = connect_guard(path=lock_path)
-    if conn is None:
-        return None
     out = dict(msg)
     out.setdefault("client_name", os.environ.get("KEY_AMNESIA_CLIENT_NAME", ""))
+    action = str(out.get("verb") or out.get("action") or "guard")
+    secret_names = [str(n) for n in (out.get("secret_names") or [])] or None
+    command = [str(c) for c in (out.get("command") or [])] or None
+
+    def _abandon(reason: str) -> None:
+        audit_event(
+            action,
+            secret_names=secret_names,
+            command=command,
+            route="guard-session",
+            result="warn",
+            reason=reason,
+            path=None,
+        )
+
+    conn = connect_guard(path=lock_path)
+    if conn is None:
+        _abandon("guard connect failed")
+        return None
     try:
         ipc.send_msg(conn, out)
         reply = ipc.recv_msg(conn, timeout=timeout)
-    except Exception:
+    except (OSError, TimeoutError, EOFError, ConnectionError, ValueError) as exc:
+        _abandon(f"{type(exc).__name__}: {exc}")
+        return None
+    except Exception as exc:  # noqa: BLE001 — never drop the reason
+        _abandon(f"{type(exc).__name__}: {exc}")
         return None
     finally:
         try:
@@ -785,7 +808,12 @@ def list_guard_registry_entries() -> list[dict[str, Any]]:
 
 def _dispatch_verb(verb: str, msg: dict[str, Any], state: GuardState) -> dict[str, Any]:
     if time.time() > state.expires_at and verb not in ("lock", "status"):
-        return {"ok": False, "reason": "session expired", "expired": True}
+        return {
+            "ok": False,
+            "reason": "session expired",
+            "expired": True,
+            "code": "session_expired",
+        }
 
     # Only verbs that consult state.secrets need a freshness check.
     if verb in ("run", "list", "status"):
@@ -836,7 +864,11 @@ def _dispatch_verb(verb: str, msg: dict[str, Any], state: GuardState) -> dict[st
     if verb == "renew":
         minutes = int(msg.get("minutes") or 30)
         if minutes < 1:
-            return {"ok": False, "reason": "invalid minutes"}
+            return {
+                "ok": False,
+                "reason": "invalid minutes",
+                "code": "invalid_minutes",
+            }
         state.expires_at = time.time() + minutes * 60
         write_guard_lock(state.address, state.authkey, state.pid, state.expires_at)
         audit_event(
@@ -857,7 +889,7 @@ def _dispatch_verb(verb: str, msg: dict[str, Any], state: GuardState) -> dict[st
         command = list(msg.get("command") or [])
         cwd = msg.get("cwd") or None
         if not command:
-            return {"ok": False, "reason": "no command"}
+            return {"ok": False, "reason": "no command", "code": "no_command"}
         missing = [n for n in secret_names if n not in state.secrets]
         if missing:
             audit_event(
@@ -868,7 +900,11 @@ def _dispatch_verb(verb: str, msg: dict[str, Any], state: GuardState) -> dict[st
                 result="denied",
                 reason=f"unknown secrets: {', '.join(missing)}",
             )
-            return {"ok": False, "reason": f"unknown secrets: {', '.join(missing)}"}
+            return {
+                "ok": False,
+                "reason": f"unknown secrets: {', '.join(missing)}",
+                "code": "unknown_secret",
+            }
         env_inject = {
             inject_as.get(n, n): state.secrets[n] for n in secret_names
         }
@@ -897,9 +933,17 @@ def _dispatch_verb(verb: str, msg: dict[str, Any], state: GuardState) -> dict[st
             result="denied",
             reason="guard has no value-return verbs",
         )
-        return {"ok": False, "reason": "guard does not expose secret values"}
+        return {
+            "ok": False,
+            "reason": "guard does not expose secret values",
+            "code": "value_return_refused",
+        }
 
-    return {"ok": False, "reason": f"unknown verb: {verb}"}
+    return {
+        "ok": False,
+        "reason": f"unknown verb: {verb}",
+        "code": "unknown_verb",
+    }
 
 
 def guard_handle_message(
@@ -919,14 +963,19 @@ def guard_handle_message(
     dispatch is only via `guard_handle_message_legacy` (tests only).
     """
     if not isinstance(msg, dict):
-        return {"ok": False, "reason": "invalid message"}
+        return {"ok": False, "reason": "invalid message", "code": "invalid_message"}
 
     verb = str(msg.get("verb") or msg.get("action") or "")
     state.request_count += 1
 
     admitted, new_token = _check_admission(peer, msg, state, verb, admit_prompt)
     if not admitted:
-        return {"ok": False, "reason": "admission denied", "admitted": False}
+        return {
+            "ok": False,
+            "reason": "admission denied",
+            "admitted": False,
+            "code": "admission_denied",
+        }
 
     reply = _dispatch_verb(verb, msg, state)
     if new_token:

--- a/src/key_amnesia/prompt_route.py
+++ b/src/key_amnesia/prompt_route.py
@@ -28,6 +28,8 @@ ENV_AUTHKEY = "KEY_AMNESIA_PROMPT_AUTHKEY"
 ENV_ADDRESS = "KEY_AMNESIA_PROMPT_ADDRESS"
 ENV_PARENT_PID = "KEY_AMNESIA_PROMPT_PARENT_PID"
 ENV_TIMEOUT = "KEY_AMNESIA_PROMPT_TIMEOUT"
+# Force spawned-console even when both streams claim to be a TTY (agent harnesses).
+ENV_NONINTERACTIVE = "KEY_AMNESIA_NONINTERACTIVE"
 
 
 @dataclass
@@ -62,11 +64,28 @@ class AuthOutcome:
     status_only: dict[str, Any] | None = None
 
 
+def _env_noninteractive() -> bool:
+    v = os.environ.get(ENV_NONINTERACTIVE, "").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
 def _isatty() -> bool:
+    """True only when *both* stdin and stdout look like a TTY.
+
+    Agent harnesses often attach a pty to stdin while redirecting stdout.
+    stdin-only checks then select the unanswerable inline path; requiring
+    both streams avoids that failure mode. Still a heuristic — see
+    KEY_AMNESIA_NONINTERACTIVE to force the spawned-console route.
+    """
     try:
-        return sys.stdin.isatty()
+        in_tty = sys.stdin.isatty()
     except Exception:
-        return False
+        in_tty = False
+    try:
+        out_tty = sys.stdout.isatty()
+    except Exception:
+        out_tty = False
+    return bool(in_tty and out_tty)
 
 
 def _prompt_password_inline(request: PromptRequest, timeout_s: int | None = None) -> str:
@@ -146,7 +165,12 @@ def require_human_auth(
     if timeout_s is None:
         timeout_s = int(cfg.get("prompt-timeout-seconds", 90))
 
-    tty = (isatty_fn or _isatty)()
+    # Env wins over stream heuristics / injected isatty_fn — agent harnesses
+    # that look like a TTY but cannot answer must force the visible console.
+    if _env_noninteractive():
+        tty = False
+    else:
+        tty = (isatty_fn or _isatty)()
     if tty:
         try:
             if password_provider is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,35 @@ import pytest
 from key_amnesia.peer_identity import PeerIdentity
 
 
+def assert_ka_paths_isolated(tmp_path: Path) -> None:
+    """Fail loudly if vault/audit/lock resolve outside pytest's tmp root.
+
+    Belt-and-braces for Defect 1: a silent regression that points
+    KEY_AMNESIA_HOME at a real home must not be able to pass the suite.
+    """
+    from key_amnesia.paths import audit_log_path, data_dir, guard_lock_path
+
+    root = tmp_path.resolve()
+    checks = (
+        ("data_dir", data_dir()),
+        ("audit_log_path", audit_log_path()),
+        ("guard_lock_path", guard_lock_path()),
+    )
+    for label, path in checks:
+        resolved = path.resolve()
+        if not resolved.is_relative_to(root):
+            pytest.fail(
+                f"KEY_AMNESIA {label} resolved outside pytest tmp: {resolved} "
+                f"(expected under {root})"
+            )
+
+
+def stub_interactive_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both streams must look like a TTY for inline auth (0.4.4 dual-stream)."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+
 @pytest.fixture
 def stub_peer_identity(monkeypatch: pytest.MonkeyPatch) -> PeerIdentity:
     """Stand-in kernel peer for tests that exercise real IPC admission.
@@ -30,13 +59,41 @@ def stub_peer_identity(monkeypatch: pytest.MonkeyPatch) -> PeerIdentity:
     return peer
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def ka_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect KEY_AMNESIA_HOME under pytest tmp — never ~/.key-amnesia."""
     home = tmp_path / "ka-home"
     home.mkdir()
     monkeypatch.setenv("KEY_AMNESIA_HOME", str(home))
     monkeypatch.delenv("KEY_AMNESIA_VAULT_PATH", raising=False)
+    assert_ka_paths_isolated(tmp_path)
     return home
+
+
+@pytest.fixture(autouse=True)
+def block_real_isolated_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never open a real CREATE_NEW_CONSOLE / Terminal window during pytest.
+
+    Agent harnesses often look non-TTY on stdout, so `require_human_auth`
+    takes the spawned-console path. Without this guard the suite pops real
+    password windows on the developer's desktop. Tests that exercise spawn
+    must pass `popen_fn=` (or mock `spawn_isolated_console` themselves).
+    """
+    from key_amnesia import platform as platform_mod
+    from key_amnesia import prompt_route as prompt_route_mod
+
+    real = platform_mod.spawn_isolated_console
+
+    def _guarded(cmd, env, *, popen_fn=None):
+        if popen_fn is None:
+            raise OSError(
+                "pytest blocked real isolated-console spawn; "
+                "pass popen_fn= to require_human_auth or mock spawn_isolated_console"
+            )
+        return real(cmd, env, popen_fn=popen_fn)
+
+    monkeypatch.setattr(platform_mod, "spawn_isolated_console", _guarded)
+    monkeypatch.setattr(prompt_route_mod, "spawn_isolated_console", _guarded)
 
 
 @pytest.fixture

--- a/tests/test_cmd_run_guard_visibility.py
+++ b/tests/test_cmd_run_guard_visibility.py
@@ -1,0 +1,148 @@
+"""Defect 3: ka run surfaces abandoned guard attempts (never silent)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from key_amnesia.cli import cmd_run
+from key_amnesia.paths import audit_log_path
+
+
+def _args(**kwargs: Any) -> argparse.Namespace:
+    return argparse.Namespace(
+        cmd=kwargs.get("cmd", ["--", "echo", "hi"]),
+        secret=kwargs.get("secret", ["api_key"]),
+        as_env=kwargs.get("as_env", []),
+        env=None,
+        vault=None,
+        force_global=False,
+        no_global=False,
+    )
+
+
+def test_run_unreachable_guard_warns_then_falls_through(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda **k: True)
+    monkeypatch.setattr("key_amnesia.guard.guard_request", lambda *a, **k: None)
+
+    auth_calls: list[Any] = []
+
+    def fake_auth(request):
+        auth_calls.append(request)
+        from key_amnesia.prompt_route import AuthOutcome
+
+        return False, None, AuthOutcome(ok=False, route="inline", reason="test stop")
+
+    monkeypatch.setattr("key_amnesia.cli._auth_password", fake_auth)
+    rc = cmd_run(_args())
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unreachable" in err.lower() or "IPC" in err
+    assert len(auth_calls) == 1
+
+
+def test_run_admission_denied_warns_then_falls_through(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda **k: True)
+    monkeypatch.setattr(
+        "key_amnesia.guard.guard_request",
+        lambda *a, **k: {
+            "ok": False,
+            "reason": "admission denied",
+            "code": "admission_denied",
+            "admitted": False,
+        },
+    )
+
+    auth_calls: list[Any] = []
+
+    def fake_auth(request):
+        auth_calls.append(request)
+        from key_amnesia.prompt_route import AuthOutcome
+
+        return False, None, AuthOutcome(ok=False, route="inline", reason="test stop")
+
+    monkeypatch.setattr("key_amnesia.cli._auth_password", fake_auth)
+    rc = cmd_run(_args())
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "admission denied" in err.lower()
+    assert len(auth_calls) == 1
+
+
+def test_run_unknown_secret_hard_stops(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda **k: True)
+    monkeypatch.setattr(
+        "key_amnesia.guard.guard_request",
+        lambda *a, **k: {
+            "ok": False,
+            "reason": "unknown secrets: missing",
+            "code": "unknown_secret",
+        },
+    )
+
+    def boom(_request):
+        raise AssertionError("_auth_password must not be called")
+
+    monkeypatch.setattr("key_amnesia.cli._auth_password", boom)
+    rc = cmd_run(_args(secret=["missing"]))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unknown secrets" in err.lower()
+
+
+def test_run_expired_warns_then_falls_through(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda **k: True)
+    monkeypatch.setattr(
+        "key_amnesia.guard.guard_request",
+        lambda *a, **k: {
+            "ok": False,
+            "reason": "session expired",
+            "expired": True,
+            "code": "session_expired",
+        },
+    )
+
+    auth_calls: list[Any] = []
+
+    def fake_auth(request):
+        auth_calls.append(request)
+        from key_amnesia.prompt_route import AuthOutcome
+
+        return False, None, AuthOutcome(ok=False, route="inline", reason="test stop")
+
+    monkeypatch.setattr("key_amnesia.cli._auth_password", fake_auth)
+    rc = cmd_run(_args())
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "expired" in err.lower()
+    assert len(auth_calls) == 1
+
+
+def test_guard_request_connect_failure_writes_audit_warn(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from key_amnesia import guard as guard_mod
+
+    monkeypatch.setattr(guard_mod, "connect_guard", lambda **k: None)
+    resp = guard_mod.guard_request({"verb": "run", "secret_names": ["x"]})
+    assert resp is None
+    log = audit_log_path()
+    assert log.exists()
+    lines = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
+    assert lines
+    last = lines[-1]
+    assert last["route"] == "guard-session"
+    assert last["result"] == "warn"
+    assert "connect" in last["reason"].lower()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,7 @@ def test_init_mismatch_creates_nothing(
     ka_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     answers = iter(["first-password", "second-password"])
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(answers))
 
@@ -31,6 +32,7 @@ def test_init_match_creates_unlockable_vault(
     ka_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     pw = "same-confirmed-password"
     answers = iter([pw, pw])
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(answers))
@@ -46,6 +48,7 @@ def test_init_refuses_if_vault_exists(
     seeded_vault: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     before = seeded_vault.read_bytes()
     # Would create if somehow allowed — must not be called successfully
     monkeypatch.setattr(
@@ -65,6 +68,7 @@ def test_set_without_vault_refuses(
 ) -> None:
     # Even with a TTY, set must refuse before auth when vault is missing
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
 
     rc = main(["set", "SOME_KEY", "value"])
     err = capsys.readouterr().err

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -1,0 +1,31 @@
+"""Suite must never touch a real ~/.key-amnesia (Defect 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from _pytest.outcomes import Failed
+
+from tests.conftest import assert_ka_paths_isolated
+
+
+def test_assert_ka_paths_isolated_rejects_outside_tmp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deliberately point HOME outside this test's tmp → fail loudly."""
+    outside = tmp_path.parent / "isolation-probe-home"
+    monkeypatch.setenv("KEY_AMNESIA_HOME", str(outside))
+    monkeypatch.delenv("KEY_AMNESIA_VAULT_PATH", raising=False)
+    with pytest.raises(Failed, match="outside pytest tmp"):
+        assert_ka_paths_isolated(tmp_path)
+
+
+def test_autouse_ka_home_keeps_paths_under_tmp(tmp_path: Path, ka_home: Path) -> None:
+    from key_amnesia.paths import audit_log_path, data_dir, guard_lock_path
+
+    root = tmp_path.resolve()
+    assert data_dir().resolve().is_relative_to(root)
+    assert audit_log_path().resolve().is_relative_to(root)
+    assert guard_lock_path().resolve().is_relative_to(root)
+    assert ka_home.resolve().is_relative_to(root)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -208,6 +208,7 @@ def test_ka_run_fails_on_missing_required(
     )
     monkeypatch.chdir(root)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": pw)
 
     # Even requesting a present secret must fail the preflight first.
@@ -231,6 +232,7 @@ def test_ka_run_ok_when_all_required_present(
     generate_or_merge_manifest(["API_KEY"], root)
     monkeypatch.chdir(root)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": pw)
 
     rc = main(

--- a/tests/test_passwd_cmd.py
+++ b/tests/test_passwd_cmd.py
@@ -23,6 +23,7 @@ def test_passwd_happy_path_reencrypts_with_fresh_salt(
     seeded_vault: Path, password: str, monkeypatch
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda *a, **k: False)
     old_salt = _salt_of(seeded_vault)
 
@@ -48,6 +49,7 @@ def test_passwd_alias_change_password(
     seeded_vault: Path, password: str, monkeypatch
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda *a, **k: False)
     answers = iter([password, "another-new-password", "another-new-password"])
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(answers))
@@ -71,6 +73,7 @@ def test_passwd_mismatch_aborts_without_changing_vault(
     seeded_vault: Path, password: str, monkeypatch
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda *a, **k: False)
     before = seeded_vault.read_bytes()
 
@@ -88,6 +91,7 @@ def test_passwd_wrong_current_password_aborts(
     seeded_vault: Path, password: str, monkeypatch
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda *a, **k: False)
     before = seeded_vault.read_bytes()
 
@@ -110,6 +114,7 @@ def test_passwd_requires_tty(seeded_vault: Path, monkeypatch, capsys) -> None:
 def test_passwd_no_vault_refuses(ka_home, monkeypatch, capsys) -> None:
     monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda *a, **k: False)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     rc = main(["passwd"])
     err = capsys.readouterr().err
     assert rc == 1

--- a/tests/test_project_vaults.py
+++ b/tests/test_project_vaults.py
@@ -74,6 +74,7 @@ def test_init_project_creates_vault_config_gitignore(
     proj.mkdir()
     monkeypatch.chdir(proj)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     pw = "project-master-pw"
     answers = iter([pw, pw])
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(answers))
@@ -97,6 +98,7 @@ def test_init_project_env_path(
     proj.mkdir()
     monkeypatch.chdir(proj)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     pw = "env-pw"
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": pw)
 
@@ -284,6 +286,7 @@ def test_import_targets_project_vault(
     proj = _make_project(tmp_path, use_global=False)
     monkeypatch.chdir(proj)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     pw = "import-proj-pw"
     vault_mod.save_vault(project_vault_path(proj), pw, {"secrets": {}})
 

--- a/tests/test_prompt_route.py
+++ b/tests/test_prompt_route.py
@@ -157,3 +157,57 @@ def test_helper_parent_death_cancels(monkeypatch) -> None:
     monkeypatch.setattr("builtins.input", lambda *a, **k: "")
     rc = run_prompt_helper()
     assert rc != 0
+
+
+def test_stdin_tty_stdout_not_routes_spawned(ka_home, monkeypatch) -> None:
+    """Agent harness shape: pty on stdin, redirected stdout → spawned-console."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    monkeypatch.delenv(prompt_route.ENV_NONINTERACTIVE, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        proc = MagicMock()
+        proc.poll.return_value = 1
+        proc.terminate = MagicMock()
+        return proc
+
+    req = PromptRequest(action="reveal", secret_names=["api_key"])
+    outcome = require_human_auth(req, timeout_s=2, popen_fn=fake_popen)
+    assert outcome.route == "spawned-console"
+    assert outcome.ok is False
+    assert "cmd" in captured
+
+
+def test_noninteractive_env_forces_spawn_even_when_tty(ka_home, monkeypatch) -> None:
+    monkeypatch.setenv(prompt_route.ENV_NONINTERACTIVE, "1")
+
+    captured: dict[str, Any] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["kwargs"] = kwargs
+        proc = MagicMock()
+        proc.poll.return_value = 1
+        proc.terminate = MagicMock()
+        return proc
+
+    req = PromptRequest(action="reveal", secret_names=["x"])
+    outcome = require_human_auth(
+        req,
+        timeout_s=2,
+        popen_fn=fake_popen,
+        isatty_fn=lambda: True,
+    )
+    assert outcome.route == "spawned-console"
+    assert outcome.ok is False
+    assert "kwargs" in captured
+
+
+def test_isatty_requires_both_streams(monkeypatch) -> None:
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    assert prompt_route._isatty() is False
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    assert prompt_route._isatty() is True

--- a/tests/test_roles_export.py
+++ b/tests/test_roles_export.py
@@ -119,6 +119,7 @@ def test_runner_denies_reveal(ka_home: Path, password: str, monkeypatch, capsys)
     save_vault(vault, password, payload)
 
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": password)
 
     rc = main(["reveal", "api_key"])
@@ -180,6 +181,7 @@ def test_remove_member_warns_to_rotate(
     save_vault(vault, password, payload)
 
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": password)
 
     # Clear local identity so role policy doesn't interfere (we aren't a member).
@@ -201,6 +203,7 @@ def test_member_add_cli_migrates_with_yes(
     _sk, pk = crypto.generate_box_keypair()
 
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": password)
 
     rc = main(

--- a/tests/test_set_never_prints_value.py
+++ b/tests/test_set_never_prints_value.py
@@ -54,6 +54,7 @@ def test_set_interactive_inline_never_prints_value(
     """The caller's own terminal (they typed the value themselves) must
     never see it echoed back."""
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": password)
 
     rc = main(["set", "new_key", SECRET])

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -3,7 +3,7 @@
 Encrypted secret vault for AI coding agents. The agent can **use** secrets
 through `ka run` without ever **seeing** the values.
 
-> **Docs as of 0.4.3.** Pages in this tree describe the shipped CLI at that
+> **Docs as of 0.4.4.** Pages in this tree describe the shipped CLI at that
 > version. The live GitHub Wiki may lag until maintainers publish from
 > in-repo `wiki/` (see that directory’s `README.md` — publish instructions
 > only; not a wiki page).

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -57,3 +57,15 @@ this project:
 ka docs          # print URL + best-effort browser open
 ka docs --print  # URL only
 ```
+
+## Environment notes
+
+| Variable | Effect |
+|----------|--------|
+| `KEY_AMNESIA_HOME` | Override data dir (default `~/.key-amnesia`) |
+| `KEY_AMNESIA_VAULT_PATH` | Override vault file path |
+| `KEY_AMNESIA_NONINTERACTIVE=1` | Force spawned-console auth (never inline `getpass`), even if both streams claim to be a TTY — use in agent harnesses |
+| `KEY_AMNESIA_CLIENT_NAME` | Display-only label on guard IPC (not a credential) |
+| `KEY_AMNESIA_HOOK_DISABLE=1` | Disable the secret-guard hook |
+
+Auth routing requires **both** stdin and stdout to look like a TTY before prompting inline; otherwise `ka` opens an isolated console the human can see.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -3,8 +3,8 @@
 These markdown files are **first drafts** for the live GitHub wiki at
 [https://github.com/fujitoid/key-amnesia/wiki](https://github.com/fujitoid/key-amnesia/wiki).
 
-**Docs as of 0.4.3** — in-repo wording targets that release. Live wiki last
-published for 0.4.3.
+**Docs as of 0.4.4** — in-repo wording targets that release. Live wiki last
+published for 0.4.3 (bump after sync).
 
 
 They are kept in-repo so PRs can review IA and wording before (or instead of)
@@ -30,7 +30,7 @@ GitHub wiki page titles come from filenames (`Home.md` → Home,
 maintainer publish instructions only.
 
 After a successful publish, update the “last published” note here (still
-keep docs-as-of version accurate). Last published: 0.4.3.
+keep docs-as-of version accurate). Last published: 0.4.3 (in-repo docs target 0.4.4).
 
 ## Proposed IA
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,4 +1,4 @@
-**Docs** *(as of 0.4.3)*
+**Docs** *(as of 0.4.4)*
 
 - [Home](Home)
 - [Why not `.env`](Why-not-dotenv)


### PR DESCRIPTION
## Summary
- **Defect 1:** `ka_home` is autouse + fail-if-outside-tmp; suite cannot touch `~/.key-amnesia`
- **Defect 2:** `_isatty` requires stdin and stdout; `KEY_AMNESIA_NONINTERACTIVE` forces spawned-console; pytest blocks real console windows
- **Defect 3:** `guard_request` audits IPC failures; structured `code` on replies; `ka run`/`list` print why guard was abandoned

## Test plan
- [x] Full pytest: 313 passed, 3 skipped
- [ ] CI matrix green