### PR TITLE
Mark wiki last-published 0.4.4

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,7 +4,7 @@ These markdown files are **first drafts** for the live GitHub wiki at
 [https://github.com/fujitoid/key-amnesia/wiki](https://github.com/fujitoid/key-amnesia/wiki).
 
 **Docs as of 0.4.4** — in-repo wording targets that release. Live wiki last
-published for 0.4.3 (bump after sync).
+published for 0.4.4.
 
 
 They are kept in-repo so PRs can review IA and wording before (or instead of)
@@ -30,7 +30,7 @@ GitHub wiki page titles come from filenames (`Home.md` → Home,
 maintainer publish instructions only.
 
 After a successful publish, update the “last published” note here (still
-keep docs-as-of version accurate). Last published: 0.4.3 (in-repo docs target 0.4.4).
+keep docs-as-of version accurate). Last published: 0.4.4.
 
 ## Proposed IA
 


### PR DESCRIPTION
Follow-up after syncing GitHub wiki for 0.4.4.

Made with [Cursor](https://cursor.com)