### PR TITLE
Fix CI: POSIX console-block vs prompt_route tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,21 +76,26 @@ def block_real_isolated_console(monkeypatch: pytest.MonkeyPatch) -> None:
 
     Agent harnesses often look non-TTY on stdout, so `require_human_auth`
     takes the spawned-console path. Without this guard the suite pops real
-    password windows on the developer's desktop. Tests that exercise spawn
-    must pass `popen_fn=` (or mock `spawn_isolated_console` themselves).
+    password windows on the developer's desktop.
+
+    When *popen_fn* is omitted we still call the real platform helper, but
+    with a popen that refuses to exec — so headless Linux/macOS fail-closed
+    messages (no DISPLAY, etc.) stay product-shaped, while Windows never
+    opens a console. Tests that need a successful spawn pass `popen_fn=`.
     """
     from key_amnesia import platform as platform_mod
     from key_amnesia import prompt_route as prompt_route_mod
 
     real = platform_mod.spawn_isolated_console
 
+    def _blocked_popen(*_a, **_k):
+        raise OSError(
+            "pytest blocked real isolated-console spawn; "
+            "pass popen_fn= to require_human_auth or mock spawn_isolated_console"
+        )
+
     def _guarded(cmd, env, *, popen_fn=None):
-        if popen_fn is None:
-            raise OSError(
-                "pytest blocked real isolated-console spawn; "
-                "pass popen_fn= to require_human_auth or mock spawn_isolated_console"
-            )
-        return real(cmd, env, popen_fn=popen_fn)
+        return real(cmd, env, popen_fn=popen_fn or _blocked_popen)
 
     monkeypatch.setattr(platform_mod, "spawn_isolated_console", _guarded)
     monkeypatch.setattr(prompt_route_mod, "spawn_isolated_console", _guarded)

--- a/tests/test_prompt_route.py
+++ b/tests/test_prompt_route.py
@@ -167,15 +167,20 @@ def test_stdin_tty_stdout_not_routes_spawned(ka_home, monkeypatch) -> None:
 
     captured: dict[str, Any] = {}
 
-    def fake_popen(cmd, **kwargs):
+    def fake_spawn(cmd, env, *, popen_fn=None):
+        # Bypass platform DISPLAY/emulator gates — this test is about routing.
         captured["cmd"] = cmd
         proc = MagicMock()
         proc.poll.return_value = 1
         proc.terminate = MagicMock()
+        if popen_fn is not None:
+            return popen_fn(cmd, env=env)
         return proc
 
+    monkeypatch.setattr(prompt_route, "spawn_isolated_console", fake_spawn)
+
     req = PromptRequest(action="reveal", secret_names=["api_key"])
-    outcome = require_human_auth(req, timeout_s=2, popen_fn=fake_popen)
+    outcome = require_human_auth(req, timeout_s=2)
     assert outcome.route == "spawned-console"
     assert outcome.ok is False
     assert "cmd" in captured
@@ -186,23 +191,26 @@ def test_noninteractive_env_forces_spawn_even_when_tty(ka_home, monkeypatch) -> 
 
     captured: dict[str, Any] = {}
 
-    def fake_popen(cmd, **kwargs):
-        captured["kwargs"] = kwargs
+    def fake_spawn(cmd, env, *, popen_fn=None):
+        captured["env"] = env
         proc = MagicMock()
         proc.poll.return_value = 1
         proc.terminate = MagicMock()
+        if popen_fn is not None:
+            return popen_fn(cmd, env=env)
         return proc
+
+    monkeypatch.setattr(prompt_route, "spawn_isolated_console", fake_spawn)
 
     req = PromptRequest(action="reveal", secret_names=["x"])
     outcome = require_human_auth(
         req,
         timeout_s=2,
-        popen_fn=fake_popen,
         isatty_fn=lambda: True,
     )
     assert outcome.route == "spawned-console"
     assert outcome.ok is False
-    assert "kwargs" in captured
+    assert "env" in captured
 
 
 def test_isatty_requires_both_streams(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Ubuntu/macOS CI failed after 0.4.4:
- `test_posix_noninteractive_fail_closed` got the pytest block OSError instead of product fail-closed
- dual-stream / NONINTERACTIVE routing tests never reached `popen_fn` on headless Linux (no DISPLAY)

## Fix
- Autouse guard calls real `spawn_isolated_console` with a blocked popen when none is supplied
- Routing tests stub `spawn_isolated_console` directly (platform-independent)

## Test plan
- [x] `pytest tests/test_prompt_route.py tests/test_posix.py`
- [ ] CI matrix green