### PR TITLE
Mark wiki last-published 0.4.5

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,7 +4,7 @@ These markdown files are **first drafts** for the live GitHub wiki at
 [https://github.com/fujitoid/key-amnesia/wiki](https://github.com/fujitoid/key-amnesia/wiki).
 
 **Docs as of 0.4.5** — in-repo wording targets that release. Live wiki last
-published for 0.4.4.
+published for 0.4.5.
 
 
 They are kept in-repo so PRs can review IA and wording before (or instead of)
@@ -30,7 +30,7 @@ GitHub wiki page titles come from filenames (`Home.md` → Home,
 maintainer publish instructions only.
 
 After a successful publish, update the “last published” note here (still
-keep docs-as-of version accurate). Last published: 0.4.4.
+keep docs-as-of version accurate). Last published: 0.4.5.
 
 ## Proposed IA
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Live wiki was already synced for 0.4.5. Update the in-repo `wiki/README.md` publish note so “last published” matches.

No package version bump / no PyPI republish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d5509ad-b185-4c14-b61b-667154e0af62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d5509ad-b185-4c14-b61b-667154e0af62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

