### PR TITLE
ci: allow workflow_dispatch after GHA setup flakes

### DIFF
--- a/.github/workflows/tests-auto-rerun.yml
+++ b/.github/workflows/tests-auto-rerun.yml
@@ -1,0 +1,72 @@
+name: tests-auto-rerun
+
+# One automatic re-run of failed matrix jobs when the first attempt dies
+# during GitHub Actions job setup (action download / runner provision),
+# before any Install/Test step runs. Real pytest failures are left alone.
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+jobs:
+  rerun-setup-flakes-once:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Re-run if failures are setup-only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate)"
+          echo "Failed jobs:"
+          echo "$jobs_json" | jq -r '.jobs[] | select(.conclusion=="failure") | .name'
+
+          # Count failures that reached a real Install/Test step vs setup-only.
+          non_setup_failures="$(echo "$jobs_json" | jq '
+            [
+              .jobs[]
+              | select(.conclusion == "failure")
+              | select(
+                  any(
+                    .steps[]?;
+                    .conclusion == "failure"
+                    and (.name == "Install" or .name == "Test"
+                         or (.name | startswith("Run pytest"))
+                         or (.name | startswith("Run pip")))
+                  )
+                )
+            ] | length
+          ')"
+
+          setup_failures="$(echo "$jobs_json" | jq '
+            [
+              .jobs[]
+              | select(.conclusion == "failure")
+              | select(
+                  (any(.steps[]?; .conclusion == "failure" and .name == "Set up job"))
+                  or ([.steps[]? | select(.conclusion == "failure")] | length) == 0
+                )
+            ] | length
+          ')"
+
+          echo "non_setup_failures=${non_setup_failures} setup_failures=${setup_failures}"
+
+          if [ "${non_setup_failures}" -gt 0 ]; then
+            echo "Product/test step failed — not auto-rerunning."
+            exit 0
+          fi
+          if [ "${setup_failures}" -eq 0 ]; then
+            echo "No setup-only failures detected — not auto-rerunning."
+            exit 0
+          fi
+
+          echo "Setup-only infra failures detected — re-running failed jobs once."
+          gh run rerun -R "${REPO}" "${RUN_ID}" --failed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Manual re-run after GitHub Actions infra flakes (e.g. action download
+  # "Service Unavailable" during job setup) without needing a no-op commit.
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Failure summary

Master `tests` run [31109649588](https://github.com/fujitoid/key-amnesia/actions/runs/31109649588) (merge of #56) went red, but **not** due to product/test failures:

- Failed job: `test (macos-latest, 3.10)` at **Set up job** only
- Error: GitHub Actions `Service Unavailable` / `Failed to resolve action download info` (infra)
- All other matrix cells (ubuntu/windows 3.10+3.13, macos 3.13) **passed**, including full `pytest`
- The same commit’s PR (#56) CI was already green

This coincides with an active [GitHub Actions partial outage](https://www.githubstatus.com) (incident “Incident with Actions”). PR CI attempts during the outage hit the same setup-only failures across OSes. Agent token cannot `gh run rerun` (`actions: write` denied).

## Fix

1. **`workflow_dispatch`** on `tests` — manual re-trigger after GHA outages without a no-op commit
2. **`tests-auto-rerun`** — one automatic `gh run rerun --failed` when the first attempt’s failures are setup-only (Install/Test never failed). Real pytest failures are left alone. Takes effect for future runs once on `master`.

No version bump / no PyPI / no product code changes.

## Test plan

- [x] Local smoke: `pytest -q tests/test_prompt_route.py tests/test_isolation.py`
- [ ] Watch this PR’s `tests` workflow matrix until green (after Actions incident clears)
- [ ] Merge; confirm master `tests` is green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-effc3af6-a193-4cfb-a800-bf35ca7a4e1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-effc3af6-a193-4cfb-a800-bf35ca7a4e1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

