### PR TITLE
ci: recover master from GHA setup outage + harden flaky registry test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Manual re-run after GitHub Actions infra flakes without a no-op commit.
+  workflow_dispatch:
 
 jobs:
   test:
@@ -14,12 +16,71 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.13"]
     runs-on: ${{ matrix.os }}
+    # No marketplace `uses:` steps: during Actions partial/major outages,
+    # "Set up job" fails while resolving action download info even before
+    # checkout. Prefer toolcache Python + git fetch instead.
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Checkout
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git init
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch --depth 1 origin "${{ github.sha }}"
+          git checkout --force FETCH_HEAD
+
+      - name: Select Python ${{ matrix.python-version }}
+        id: py
+        run: |
+          set -euo pipefail
+          VER="${{ matrix.python-version }}"
+          case "${{ runner.os }}" in
+            Linux)   BASE="/opt/hostedtoolcache/Python" ;;
+            macOS)   BASE="/Users/runner/hostedtoolcache/Python" ;;
+            Windows) BASE="/c/hostedtoolcache/windows/Python" ;;
+            *) echo "unsupported OS ${{ runner.os }}" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64|amd64) ARCH=x64 ;;
+            arm64|aarch64) ARCH=arm64 ;;
+            *) ARCH=x64 ;;
+          esac
+          # Prefer exact x.y.* builds already present in the runner toolcache.
+          CAND=$(ls -d "${BASE}/${VER}".*/${ARCH} 2>/dev/null | sort -V | tail -n 1 || true)
+          if [ -z "${CAND}" ]; then
+            # Fall back to any arch folder for this version.
+            CAND=$(ls -d "${BASE}/${VER}".*/* 2>/dev/null | sort -V | tail -n 1 || true)
+          fi
+          if [ -z "${CAND}" ]; then
+            echo "No toolcache Python ${VER} under ${BASE}" >&2
+            ls -la "${BASE}" >&2 || true
+            exit 1
+          fi
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            PY="${CAND}/python.exe"
+          else
+            PY="${CAND}/bin/python"
+          fi
+          if [ ! -x "${PY}" ] && [ ! -f "${PY}" ]; then
+            echo "Python binary missing: ${PY}" >&2
+            exit 1
+          fi
+          echo "python=${PY}" >> "$GITHUB_OUTPUT"
+          "${PY}" -V
+
       - name: Install
-        run: pip install -e ".[dev]"
+        run: |
+          set -euo pipefail
+          PY="${{ steps.py.outputs.python }}"
+          "${PY}" -m pip install -U pip
+          "${PY}" -m pip install -e ".[dev]"
+
       - name: Test
-        run: pytest -q
+        run: |
+          set -euo pipefail
+          PY="${{ steps.py.outputs.python }}"
+          "${PY}" -m pytest -q

--- a/tests/test_project_vaults.py
+++ b/tests/test_project_vaults.py
@@ -247,13 +247,18 @@ def test_lock_path_beside_project_vault(tmp_path: Path) -> None:
     assert guard_lock_path_for_vault(vp) == vp.parent / "guard.lock"
 
 
-def test_registry_write_remove_no_authkey(ka_home: Path) -> None:
+def test_registry_write_remove_no_authkey(
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os
+
     vp = ka_home / "vault.bin"
     vp.write_bytes(b"x")
+    fake_pid = 12345
     p = write_guard_registry_entry(
         vault_path=vp,
         address="\\\\.\\pipe\\test",
-        pid=12345,
+        pid=fake_pid,
         expires_at=time.time() + 600,
         project_root=None,
         env_name=None,
@@ -262,14 +267,19 @@ def test_registry_write_remove_no_authkey(ka_home: Path) -> None:
     assert "authkey" not in data
     assert "authkey_hex" not in data
     assert data["vault_path"] == str(vp.resolve())
-    assert data["pid"] == 12345
-    # Fake pid → list should drop as stale
+    assert data["pid"] == fake_pid
+    # Only treat the current process as alive. A recycled Windows PID (or
+    # parent_alive fail-open on ACCESS_DENIED) must not keep the fake entry.
+    monkeypatch.setattr(
+        "key_amnesia.prompt_route.parent_alive",
+        lambda pid: pid == os.getpid(),
+    )
     assert list_guard_registry_entries() == []
     # Re-write with current pid so it stays live briefly
     write_guard_registry_entry(
         vault_path=vp,
         address="addr",
-        pid=__import__("os").getpid(),
+        pid=os.getpid(),
         expires_at=time.time() + 600,
     )
     live = list_guard_registry_entries()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Failure summary

Master `tests` run [31109649588](https://github.com/fujitoid/key-amnesia/actions/runs/31109649588) (merge of #56) went red, but **not** due to product/test failures:

- Failed job: `test (macos-latest, 3.10)` at **Set up job** only
- Error: GitHub Actions `Service Unavailable` / `Failed to resolve action download info`
- All other matrix cells on that run passed full `pytest`
- Escalated to an ongoing [Actions major outage](https://www.githubstatus.com/) — subsequent PR runs cancelled or failed at setup before any tests

## Fix

1. **Drop marketplace `uses:` steps** (`actions/checkout`, `actions/setup-python`) — job setup was dying while resolving action download info. Checkout via `git fetch` + Python from the runner hosted toolcache so the matrix can start during marketplace outages.
2. Add `workflow_dispatch` for manual re-runs after infra flakes.
3. Harden `test_registry_write_remove_no_authkey` against Windows PID reuse / `parent_alive` ACCESS_DENIED fail-open (seen earlier on #52).

History squashed to one commit (removed empty re-trigger commits). No version bump / no product runtime changes.

## Test plan

- [x] Local: registry vault tests pass
- [ ] Watch this PR’s `tests` matrix until green
- [ ] Merge; confirm master `tests` green
- [ ] Close obsolete draft #57
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccbb5987-ed27-4811-9f54-5b9091eb915c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccbb5987-ed27-4811-9f54-5b9091eb915c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

