### PR TITLE
ci: validate marketplace-free tests workflow after #58

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   # Manual re-run after GitHub Actions infra flakes without a no-op commit.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Master went red on [31109649588](https://github.com/fujitoid/key-amnesia/actions/runs/31109649588) during a [GitHub Actions major outage](https://www.githubstatus.com) (`Failed to resolve action download info` at Set up job). That was infra, not pytest.

#58 already landed the real recovery:
- marketplace-free checkout + toolcache Python (avoids action-download resolution)
- harden `test_registry_write_remove_no_authkey` against recycled Windows PIDs

#58 merged while Actions was still degraded, so master has not yet shown a full green matrix after that change.

## This PR

- Declare `permissions: contents: read` for the token used by the git-fetch checkout step
- Primary goal: get a full green `tests` matrix on the post-#58 workflow, then merge to re-validate master

## Test plan

- [ ] Full CI matrix green on this PR
- [ ] After merge, master `tests` green (or this PR’s checks as the post-merge signal if push is delayed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-effc3af6-a193-4cfb-a800-bf35ca7a4e1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-effc3af6-a193-4cfb-a800-bf35ca7a4e1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

