### PR TITLE
ci: uv fallback when toolcache lacks Python (fix macos 3.10)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
   # UI: Actions → tests → Run workflow → master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -19,7 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     # No marketplace `uses:` steps: during Actions partial/major outages,
     # "Set up job" fails while resolving action download info even before
-    # checkout. Prefer toolcache Python + git fetch instead.
+    # checkout. Prefer toolcache Python + git fetch; install via uv on miss
+    # (macos-latest toolcache currently ships 3.11+ only, not 3.10).
     defaults:
       run:
         shell: bash
@@ -50,22 +54,44 @@ jobs:
             arm64|aarch64) ARCH=arm64 ;;
             *) ARCH=x64 ;;
           esac
-          # Prefer exact x.y.* builds already present in the runner toolcache.
-          CAND=$(ls -d "${BASE}/${VER}".*/${ARCH} 2>/dev/null | sort -V | tail -n 1 || true)
-          if [ -z "${CAND}" ]; then
-            # Fall back to any arch folder for this version.
-            CAND=$(ls -d "${BASE}/${VER}".*/* 2>/dev/null | sort -V | tail -n 1 || true)
-          fi
-          if [ -z "${CAND}" ]; then
-            echo "No toolcache Python ${VER} under ${BASE}" >&2
-            ls -la "${BASE}" >&2 || true
-            exit 1
-          fi
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            PY="${CAND}/python.exe"
+
+          find_toolcache() {
+            local cand
+            cand=$(ls -d "${BASE}/${VER}".*/${ARCH} 2>/dev/null | sort -V | tail -n 1 || true)
+            if [ -z "${cand}" ]; then
+              cand=$(ls -d "${BASE}/${VER}".*/* 2>/dev/null | sort -V | tail -n 1 || true)
+            fi
+            printf '%s' "${cand}"
+          }
+
+          resolve_bin() {
+            local cand="$1"
+            if [ "${{ runner.os }}" = "Windows" ]; then
+              printf '%s' "${cand}/python.exe"
+            else
+              printf '%s' "${cand}/bin/python"
+            fi
+          }
+
+          CAND=$(find_toolcache)
+          if [ -n "${CAND}" ]; then
+            PY=$(resolve_bin "${CAND}")
           else
-            PY="${CAND}/bin/python"
+            echo "No toolcache Python ${VER} under ${BASE}; installing via uv" >&2
+            ls -la "${BASE}" >&2 || true
+            if ! command -v uv >/dev/null 2>&1; then
+              curl -LsSf https://astral.sh/uv/install.sh | sh
+              export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
+            fi
+            # Windows GitHub bash: uv often lands in USERPROFILE\.local\bin
+            if ! command -v uv >/dev/null 2>&1; then
+              export PATH="${USERPROFILE}/.local/bin:${PATH}"
+            fi
+            command -v uv
+            uv python install "${VER}"
+            PY=$(uv python find "${VER}")
           fi
+
           if [ ! -x "${PY}" ] && [ ! -f "${PY}" ]; then
             echo "Python binary missing: ${PY}" >&2
             exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [master]
   # Manual re-run after GitHub Actions infra flakes without a no-op commit.
+  # UI: Actions → tests → Run workflow → master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

1. #58 merged during the Actions major outage; master never got a `tests` run (push webhook lost).
2. A recovering Actions job then showed the #58 marketplace-free workflow **breaks macos-latest/3.10**: hosted toolcache has 3.11+ only (`No toolcache Python 3.10`).

## Fix

- Fall back to `uv python install` when the runner toolcache lacks the matrix version
- `permissions: contents: read` for the git-fetch checkout token (from #59)
- Comment documenting Actions UI `workflow_dispatch` path

Supersedes draft #59.

## Test plan

- [ ] Watch this PR’s full `tests` matrix until green
- [ ] Merge; confirm master `tests` green
- [ ] Close #59 if still open

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b9cf933-3edc-424f-8f25-35e4c0b1fd83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b9cf933-3edc-424f-8f25-35e4c0b1fd83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

