### PR TITLE
ci: use uv venv when toolcache Python is missing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,8 @@ jobs:
             command -v uv
             uv python install "${VER}"
             VENV="${RUNNER_TEMP}/ka-py${VER}"
-            uv venv --python "${VER}" "${VENV}"
+            # --seed installs pip so later `python -m pip` works (uv venvs omit it by default).
+            uv venv --seed --python "${VER}" "${VENV}"
             if [ "${{ runner.os }}" = "Windows" ]; then
               PY="${VENV}/Scripts/python.exe"
             else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,8 @@ jobs:
           if [ -n "${CAND}" ]; then
             PY=$(resolve_bin "${CAND}")
           else
-            echo "No toolcache Python ${VER} under ${BASE}; installing via uv" >&2
+            # uv-managed interpreters are PEP 668 externally-managed; pip needs a venv.
+            echo "No toolcache Python ${VER} under ${BASE}; installing via uv + venv" >&2
             ls -la "${BASE}" >&2 || true
             if ! command -v uv >/dev/null 2>&1; then
               curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -89,7 +90,13 @@ jobs:
             fi
             command -v uv
             uv python install "${VER}"
-            PY=$(uv python find "${VER}")
+            VENV="${RUNNER_TEMP}/ka-py${VER}"
+            uv venv --python "${VER}" "${VENV}"
+            if [ "${{ runner.os }}" = "Windows" ]; then
+              PY="${VENV}/Scripts/python.exe"
+            else
+              PY="${VENV}/bin/python"
+            fi
           fi
 
           if [ ! -x "${PY}" ] && [ ! -f "${PY}" ]; then


### PR DESCRIPTION
## Summary
- Master tip dispatch failed on `macos-latest` / Python 3.10: uv-installed interpreters are PEP 668 externally-managed, so bare `pip install` errors out.
- After `uv python install`, create a temp venv with `uv venv` and point subsequent steps at that interpreter (toolcache path unchanged).

## Test plan
- [ ] CI matrix green, especially `macos-latest` + `3.10` Install step
- [ ] Other OS/Python matrix cells still pass (toolcache path)
