### PR TITLE
feat: ka scan --deep agent session transcripts (0.4.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Versions follow the git tags `0.4.0` … `0.4.7`.
+Versions follow the git tags `0.4.0` … `0.4.8`.
+
+## [0.4.8] — 2026-08-11
+
+### Added
+
+- `ka scan --deep` walks known **agent session transcript** JSONL trees (Claude Code `~/.claude/projects/**/*.jsonl` including subagents; Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`; Copilot CLI `~/.copilot/session-state/*/events.jsonl`). Reports path + line hits; never prints values. Detection remains advisory (regex+entropy; false positives/negatives expected).
 
 ## [0.4.7] — 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ ka setup                          # skills + secret-guard hook for Claude Code /
 ka init --project                 # or: ka init  for a global vault
 ka import .env                    # move plaintext into the vault (TTY-only; never prints values)
 ka scan                           # find remaining LEAKs (names/paths only)
+ka scan --deep                    # also home/shell/MCP + agent session transcripts
 ka run --secret API_KEY -- python my_script.py
 ```
 
+`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. Detection is **advisory** (the same regex + entropy heuristics as the secret-guard hook): false positives and false negatives are expected. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`.
 
 `ka init` asks for the master password twice; if the entries do not match, nothing is created. **There is no recovery** if you forget that password — Argon2id + SecretBox leave none by design.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.4.7"
+version = "0.4.8"
 description = "Encrypted secret vault so AI agents can use API keys without seeing them — a drop-in .env replacement"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -188,7 +188,13 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Also check home dotfiles, shell history, global git config, "
-            "and known MCP config paths (not a full home walk)"
+            "known MCP config paths, and agent session transcripts "
+            "(Claude Code ~/.claude/projects/**/*.jsonl; Codex "
+            "~/.codex/sessions|archived_sessions/**/rollout-*.jsonl; "
+            "Copilot CLI ~/.copilot/session-state/*/events.jsonl). "
+            "Not a full home walk. Detection is advisory "
+            "(regex+entropy; false positives/negatives expected); "
+            "never prints secret values."
         ),
     )
     p_scan.add_argument(
@@ -1046,7 +1052,9 @@ def cmd_scan(args: argparse.Namespace) -> int:
 
     Default exclusions skip ``node_modules``, ``.venv``/``venv``, common
     build dirs, and ``.git`` internals. ``--deep`` adds home/shell/MCP
-    paths. Never prints secret values. Non-zero exit if any LEAK count > 0.
+    paths and known agent session transcript JSONL trees. Never prints
+    secret values. Detection is advisory (regex+entropy). Non-zero exit
+    if any LEAK count > 0.
     Optionally offers to store selected dotenv findings into the project
     vault via the shared ``dotenv_import`` core.
     """

--- a/src/key_amnesia/scan.py
+++ b/src/key_amnesia/scan.py
@@ -1,10 +1,13 @@
 """``ka scan`` — LEAK (Locally Exposed Agent Keys) discovery.
 
-Walks a project tree (and optionally ``--deep`` home/shell/MCP locations)
-looking for plaintext secret *files* and light assignment patterns. Reports
-**names, paths, and counts only** — never prints, logs, or copies secret
-values.
+Walks a project tree (and optionally ``--deep`` home/shell/MCP locations
+plus known agent session transcript JSONL trees) looking for plaintext
+secret *files* and light assignment / prefix patterns. Reports **names,
+paths, counts, and (for transcripts) line numbers only** — never prints,
+logs, or copies secret values.
 
+Detection is **advisory** regex + entropy heuristics (same vocabulary as
+the secret-guard hook): false positives and false negatives are expected.
 Policy classification: Scan LEAK report is **advisory** (not cryptography).
 """
 
@@ -23,6 +26,7 @@ from key_amnesia.hooks.secret_guard import (
     _BEARER,
     _PREFIX_PATTERNS,
     _assignment_is_secret,
+    _collect_strings,
 )
 
 # Directory basenames skipped by default (B4). ``.git`` skips all git
@@ -57,6 +61,12 @@ _SKIP_SUFFIXES = (".pyc", ".pyo", ".egg-info")
 
 # Max bytes to read when content-scanning a non-dotenv file.
 _MAX_CONTENT_BYTES = 256_000
+
+# Skip oversized session transcripts (line-iter still; refuse open if huge).
+_MAX_TRANSCRIPT_BYTES = 100 * 1024 * 1024
+
+# Cap human-report line lists; full list remains in ``--json``.
+_HIT_LINES_DISPLAY_CAP = 20
 
 # Text-ish extensions worth content-scanning for assignment patterns.
 _CONTENT_SCAN_SUFFIXES = frozenset(
@@ -130,6 +140,8 @@ class Finding:
     reason: str = ""
     importable: bool = False
     scope: str = "project"  # "project" | "deep"
+    # 1-based JSONL line numbers (agent transcripts only).
+    hit_lines: list[int] = field(default_factory=list)
 
 
 def _is_dotenv_filename(name: str) -> bool:
@@ -258,6 +270,157 @@ def _content_prefix_hit(text: str) -> str | None:
     return None
 
 
+def scan_text_for_leaks(text: str) -> tuple[list[str], str | None]:
+    """Shared detector: assignment *names* + optional prefix/Bearer kind.
+
+    Never returns secret values. Same vocabulary as the secret-guard hook.
+    """
+    if not text:
+        return [], None
+    return _content_assignment_names(text), _content_prefix_hit(text)
+
+
+def _looks_like_json_container(s: str) -> bool:
+    t = s.lstrip()
+    return t.startswith("{") or t.startswith("[")
+
+
+def _strings_from_decoded_json(obj: Any) -> list[str]:
+    """Collect strings from a decoded JSON value; unwrap one nested JSON string."""
+    out: list[str] = []
+    for s in _collect_strings(obj):
+        out.append(s)
+        if not _looks_like_json_container(s):
+            continue
+        try:
+            nested = json.loads(s)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(nested, (dict, list)):
+            out.extend(_collect_strings(nested))
+    return out
+
+
+def _scan_transcript_payload(obj: Any) -> tuple[list[str], str | None]:
+    """Run detectors on all string payloads from one JSONL line object."""
+    names: list[str] = []
+    seen: set[str] = set()
+    prefix: str | None = None
+    for s in _strings_from_decoded_json(obj):
+        line_names, line_prefix = scan_text_for_leaks(s)
+        for name in line_names:
+            key = name.upper()
+            if key in seen:
+                continue
+            seen.add(key)
+            names.append(name)
+        if line_prefix and prefix is None:
+            prefix = line_prefix
+    return names, prefix
+
+
+def iter_agent_transcript_files(home: Path | None = None) -> Iterable[Path]:
+    """Yield known agent session JSONL transcript paths under ``home``.
+
+    Not a full home walk — only Claude Code / Codex / Copilot CLI layouts.
+    """
+    home = (home or Path.home()).resolve()
+    seen: set[str] = set()
+
+    def _emit(path: Path) -> Iterable[Path]:
+        try:
+            if not path.is_file():
+                return
+            key = str(path.resolve())
+        except OSError:
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        yield path
+
+    claude_projects = home / ".claude" / "projects"
+    if claude_projects.is_dir():
+        try:
+            for path in claude_projects.rglob("*.jsonl"):
+                yield from _emit(path)
+        except OSError:
+            pass
+
+    for sub in ("sessions", "archived_sessions"):
+        root = home / ".codex" / sub
+        if not root.is_dir():
+            continue
+        try:
+            for path in root.rglob("rollout-*.jsonl"):
+                yield from _emit(path)
+        except OSError:
+            pass
+
+    copilot_state = home / ".copilot" / "session-state"
+    if copilot_state.is_dir():
+        try:
+            for path in copilot_state.glob("*/events.jsonl"):
+                yield from _emit(path)
+        except OSError:
+            pass
+
+
+def _finding_for_transcript(path: Path, *, scope: str) -> Finding | None:
+    """Scan one JSONL session transcript; names/paths/line hits only."""
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return None
+    if size > _MAX_TRANSCRIPT_BYTES:
+        return None
+
+    hit_lines: list[int] = []
+    all_names: list[str] = []
+    seen_names: set[str] = set()
+
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line_no, raw in enumerate(fh, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                names, prefix = _scan_transcript_payload(obj)
+                if not names and not prefix:
+                    continue
+                hit_lines.append(line_no)
+                for name in names:
+                    key = name.upper()
+                    if key in seen_names:
+                        continue
+                    seen_names.add(key)
+                    all_names.append(name)
+    except OSError:
+        return None
+
+    if not hit_lines:
+        return None
+
+    return Finding(
+        path=str(path),
+        kind="agent_session_transcript",
+        secret_names=all_names,
+        secret_count=len(hit_lines),
+        reason=(
+            f"agent session transcript: {len(hit_lines)} line(s) with "
+            "credential-shaped content (advisory regex+entropy; false "
+            "positives/negatives expected)"
+        ),
+        importable=False,
+        scope=scope,
+        hit_lines=hit_lines,
+    )
+
+
 def _finding_for_path(path: Path, *, scope: str) -> Finding | None:
     kind = _filename_kind(path)
     if kind == "dotenv":
@@ -324,8 +487,7 @@ def _finding_for_path(path: Path, *, scope: str) -> Finding | None:
     text = _safe_read_text(path)
     if not text:
         return None
-    names = _content_assignment_names(text)
-    prefix = _content_prefix_hit(text)
+    names, prefix = scan_text_for_leaks(text)
     if not names and not prefix:
         return None
     count = len(names) if names else 1
@@ -463,7 +625,10 @@ def _deep_candidate_paths(home: Path | None = None) -> list[Path]:
 
 
 def scan_deep(home: Path | None = None) -> list[Finding]:
-    """Scan known home / shell / MCP locations (not a full home tree walk)."""
+    """Scan known home / shell / MCP / agent-transcript locations.
+
+    Not a full home tree walk — fixed candidates plus known transcript globs.
+    """
     findings: list[Finding] = []
     seen: set[str] = set()
     for path in _deep_candidate_paths(home):
@@ -481,12 +646,37 @@ def scan_deep(home: Path | None = None) -> list[Finding]:
             continue
         seen.add(finding.path)
         findings.append(finding)
+
+    for path in iter_agent_transcript_files(home):
+        try:
+            key = str(path.resolve())
+        except OSError:
+            key = str(path)
+        if key in seen:
+            continue
+        finding = _finding_for_transcript(path, scope="deep")
+        if finding is None:
+            continue
+        seen.add(finding.path)
+        # Also mark resolved key so candidate-path overlap cannot double-count.
+        seen.add(key)
+        findings.append(finding)
+
     findings.sort(key=lambda f: f.path)
     return findings
 
 
 def leak_count(findings: list[Finding]) -> int:
     return sum(max(f.secret_count, 0) for f in findings)
+
+
+def transcript_line_hit_count(findings: list[Finding]) -> int:
+    """Sum of LEAK line-hits in ``agent_session_transcript`` findings."""
+    return sum(
+        max(f.secret_count, 0)
+        for f in findings
+        if f.kind == "agent_session_transcript"
+    )
 
 
 def headline(findings: list[Finding], *, project_label: str = "this project") -> str:
@@ -501,16 +691,43 @@ def headline(findings: list[Finding], *, project_label: str = "this project") ->
 
 def findings_to_json(findings: list[Finding], *, project_root: str) -> dict[str, Any]:
     n = leak_count(findings)
+    transcript_hits = transcript_line_hit_count(findings)
     return {
         "leak_count": n,
+        "transcript_line_hits": transcript_hits,
         "headline": headline(findings),
         "project_root": project_root,
         "findings": [asdict(f) for f in findings],
+        "detection_note": (
+            "Advisory regex+entropy heuristics (secret-guard vocabulary); "
+            "false positives and false negatives are expected. "
+            "Values are never included."
+        ),
     }
+
+
+def _format_hit_lines(hit_lines: list[int]) -> str:
+    if not hit_lines:
+        return ""
+    if len(hit_lines) <= _HIT_LINES_DISPLAY_CAP:
+        shown = ", ".join(str(n) for n in hit_lines)
+        return f"\n      lines: {shown}"
+    head = hit_lines[:_HIT_LINES_DISPLAY_CAP]
+    rest = len(hit_lines) - _HIT_LINES_DISPLAY_CAP
+    shown = ", ".join(str(n) for n in head)
+    return f"\n      lines: {shown} (and {rest} more; see --json)"
 
 
 def format_human_report(findings: list[Finding], *, project_root: Path) -> str:
     lines: list[str] = [headline(findings), ""]
+    transcript_hits = transcript_line_hit_count(findings)
+    if transcript_hits:
+        unit = "LEAK" if transcript_hits == 1 else "LEAKs"
+        lines.append(
+            f"{transcript_hits} {unit} found in agent session transcripts "
+            f"(line-hits; advisory detection)"
+        )
+        lines.append("")
     if not findings:
         lines.append("No locally exposed agent keys found under default exclusions.")
         return "\n".join(lines)
@@ -524,11 +741,16 @@ def format_human_report(findings: list[Finding], *, project_root: Path) -> str:
             f"\n      names: {names}"
             f"\n      {f.reason}"
             + ("  [importable]" if f.importable else "")
+            + _format_hit_lines(f.hit_lines)
         )
         lines.append("")
     lines.append(
         "Values are never shown. Store importable dotenv findings with the "
         "post-scan offer, or run `ka import FILE`."
+    )
+    lines.append(
+        "Detection is advisory (regex + entropy heuristics); false positives "
+        "and false negatives are expected."
     )
     return "\n".join(lines)
 

--- a/tests/fixtures/agent_transcripts/claude/session-clean.jsonl
+++ b/tests/fixtures/agent_transcripts/claude/session-clean.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","message":{"role":"user","content":"List the files in this directory."},"timestamp":"2026-01-01T00:00:01.000Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Sure — I will run ls."}]},"timestamp":"2026-01-01T00:00:02.000Z"}

--- a/tests/fixtures/agent_transcripts/claude/session-with-leaks.jsonl
+++ b/tests/fixtures/agent_transcripts/claude/session-with-leaks.jsonl
@@ -1,0 +1,6 @@
+{"type":"file-history-snapshot","timestamp":"2026-01-01T00:00:00.000Z","sessionId":"11111111-1111-1111-1111-111111111111"}
+{"type":"user","message":{"role":"user","content":"Please help me debug this script."},"timestamp":"2026-01-01T00:00:01.000Z"}
+{"type":"user","message":{"role":"user","content":"Here is my Anthropic key sk-ant-FAKESECRET_for_tests_only_xx — use it carefully."},"timestamp":"2026-01-01T00:00:02.000Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"User pasted a credential-shaped token."},{"type":"text","text":"I should not echo that back."}]},"timestamp":"2026-01-01T00:00:03.000Z"}
+{"type":"user","message":{"role":"user","content":"tool payload as nested JSON string"},"toolUse":"{\"command\":\"export API_KEY=AbCdEfGh12345678XyZ && curl https://example.com\"}","timestamp":"2026-01-01T00:00:04.000Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done without repeating secrets."}]},"timestamp":"2026-01-01T00:00:05.000Z"}

--- a/tests/fixtures/agent_transcripts/claude/subagent-with-leak.jsonl
+++ b/tests/fixtures/agent_transcripts/claude/subagent-with-leak.jsonl
@@ -1,0 +1,1 @@
+{"type":"user","message":{"role":"user","content":"Subagent saw Bearer FAKESECRET_g2h3i4j5k6l7m8n9o0p1 in the log."},"timestamp":"2026-01-01T00:00:01.000Z"}

--- a/tests/fixtures/agent_transcripts/codex/rollout-with-leak.jsonl
+++ b/tests/fixtures/agent_transcripts/codex/rollout-with-leak.jsonl
@@ -1,0 +1,2 @@
+{"type":"message","role":"user","content":"Set OPENAI_API_KEY=sk-proj-NOTAREALKEY_but_long_enough_abc"}
+{"type":"message","role":"assistant","content":"I will not store that in cleartext."}

--- a/tests/fixtures/agent_transcripts/copilot/events-with-leak.jsonl
+++ b/tests/fixtures/agent_transcripts/copilot/events-with-leak.jsonl
@@ -1,0 +1,2 @@
+{"type":"event","payload":{"text":"npm token npm_abcdefghijklmnopqrstuv"}}
+{"type":"event","payload":{"text":"all clear here"}}

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -21,9 +21,11 @@ from key_amnesia.scan import (
     Finding,
     headline,
     importable_findings,
+    iter_agent_transcript_files,
     leak_count,
     scan_deep,
     scan_project,
+    transcript_line_hit_count,
 )
 
 
@@ -311,3 +313,171 @@ def test_scan_never_prints_values_human_report(
     assert "TOKEN" in captured.out
     assert SECRET_VALUE not in captured.out
     assert SECRET_VALUE not in captured.err
+
+
+# --- Agent session transcript scan (--deep) ---
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "agent_transcripts"
+
+# Planted fake secrets in fixtures — must never appear in scan output.
+_TRANSCRIPT_PLANTED = (
+    "sk-ant-FAKESECRET_for_tests_only_xx",
+    "AbCdEfGh12345678XyZ",
+    "FAKEBEARERTOKEN123456",
+    "sk-proj-NOTAREALKEY_but_long_enough_abc",
+    "npm_abcdefghijklmnopqrstuv",
+)
+
+
+def _assert_no_planted(blob: str) -> None:
+    for secret in _TRANSCRIPT_PLANTED:
+        assert secret not in blob
+
+
+def _install_transcript_home(home: Path) -> dict[str, Path]:
+    """Lay out Claude / Codex / Copilot transcript trees under fake home."""
+    claude_proj = home / ".claude" / "projects" / "C--tmp-demo"
+    claude_proj.mkdir(parents=True)
+    session = claude_proj / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl"
+    session.write_text(
+        (_FIXTURES / "claude" / "session-with-leaks.jsonl").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    clean = claude_proj / "ffffffff-1111-2222-3333-444444444444.jsonl"
+    clean.write_text(
+        (_FIXTURES / "claude" / "session-clean.jsonl").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    sub = (
+        claude_proj
+        / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        / "subagents"
+        / "agent-deadbeef.jsonl"
+    )
+    sub.parent.mkdir(parents=True)
+    sub.write_text(
+        (_FIXTURES / "claude" / "subagent-with-leak.jsonl").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    codex_day = home / ".codex" / "sessions" / "2026" / "01" / "01"
+    codex_day.mkdir(parents=True)
+    codex = codex_day / "rollout-with-leak.jsonl"
+    codex.write_text(
+        (_FIXTURES / "codex" / "rollout-with-leak.jsonl").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    copilot = home / ".copilot" / "session-state" / "sess-1" / "events.jsonl"
+    copilot.parent.mkdir(parents=True)
+    copilot.write_text(
+        (_FIXTURES / "copilot" / "events-with-leak.jsonl").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    return {
+        "claude_session": session,
+        "claude_clean": clean,
+        "claude_subagent": sub,
+        "codex": codex,
+        "copilot": copilot,
+    }
+
+
+def test_scan_deep_agent_transcripts_line_hits(
+    ka_home, tmp_path, monkeypatch
+) -> None:
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    paths = _install_transcript_home(home)
+
+    findings = scan_deep(home)
+    transcripts = [f for f in findings if f.kind == "agent_session_transcript"]
+
+    session_f = next(f for f in transcripts if Path(f.path) == paths["claude_session"])
+    # Lines 3 (sk-ant) and 5 (nested API_KEY JSON string).
+    assert session_f.hit_lines == [3, 5]
+    assert session_f.secret_count == 2
+    assert session_f.scope == "deep"
+    assert any(n.upper() == "API_KEY" for n in session_f.secret_names)
+
+    assert not any(Path(f.path) == paths["claude_clean"] for f in transcripts)
+
+    sub_f = next(f for f in transcripts if Path(f.path) == paths["claude_subagent"])
+    assert sub_f.hit_lines == [1]
+    assert sub_f.secret_count == 1
+
+    codex_f = next(f for f in transcripts if Path(f.path) == paths["codex"])
+    assert codex_f.secret_count >= 1
+    assert 1 in codex_f.hit_lines
+
+    copilot_f = next(f for f in transcripts if Path(f.path) == paths["copilot"])
+    assert copilot_f.hit_lines == [1]
+
+    assert transcript_line_hit_count(findings) == sum(
+        f.secret_count for f in transcripts
+    )
+    blob = json.dumps([f.__dict__ for f in findings])
+    _assert_no_planted(blob)
+
+
+def test_scan_default_skips_home_transcripts(
+    ka_home, project_dir, tmp_path, monkeypatch
+) -> None:
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    _install_transcript_home(home)
+
+    findings = scan_project(project_dir)
+    assert not any(f.kind == "agent_session_transcript" for f in findings)
+
+
+def test_scan_cli_deep_transcripts_no_values(
+    ka_home, project_dir, tmp_path, monkeypatch, capsys
+) -> None:
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    _install_transcript_home(home)
+
+    rc = main(["scan", "--deep", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert rc == 1
+    assert data["transcript_line_hits"] >= 4
+    assert any(f["kind"] == "agent_session_transcript" for f in data["findings"])
+    assert "advisory" in data["detection_note"].lower()
+    _assert_no_planted(captured.out)
+    _assert_no_planted(captured.err)
+    _assert_no_planted(json.dumps(data))
+
+    human_rc = main(["scan", "--deep", "--no-import"])
+    human = capsys.readouterr().out
+    assert human_rc == 1
+    assert "agent session transcripts" in human
+    assert "advisory" in human.lower()
+    _assert_no_planted(human)
+
+
+def test_iter_agent_transcript_files_globs(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    paths = _install_transcript_home(home)
+    found = {p.resolve() for p in iter_agent_transcript_files(home)}
+    assert paths["claude_session"].resolve() in found
+    assert paths["claude_subagent"].resolve() in found
+    assert paths["codex"].resolve() in found
+    assert paths["copilot"].resolve() in found
+    assert paths["claude_clean"].resolve() in found  # present on disk; clean has no LEAK


### PR DESCRIPTION
## Summary
- Extend `ka scan --deep` to Claude Code / Codex / Copilot CLI session JSONL transcripts (path + line hits; never print values).
- Reuse secret-guard assignment/prefix vocabulary; advisory confidence language in help/README/CHANGELOG.
- Bump version to **0.4.8**.

## Test plan
- [x] `pytest tests/test_scan.py` (fixtures + no value leakage)
- [ ] GitHub Actions `tests` matrix green (macOS jobs often take **≥1h** — do not cancel)
- [ ] Merge only after CI green (cloud agent owns merge)

## Merge policy
Do **not** merge from this PR description alone. A cloud agent will watch CI (long macOS waits OK), fix up to 3 times if red, then merge when green.