### PR TITLE
Register ka with agent-harness permission systems (0.4.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ ENV/
 # Distribution / packaging
 build/
 dist/
+dist-archive/
 *.egg-info/
 *.egg
 .eggs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Versions follow the git tags `0.4.0` … `0.4.8`.
+Versions follow the git tags `0.4.0` … `0.4.9`.
+
+## [0.4.9] — 2026-08-17
+
+### Behavior change
+
+- Agents that previously ran `ka set` (and other mutating verbs) because `_KA_SAFE` skipped secret scanning will now be **hook-denied**. The deny message names the exact command to run in the user's own terminal (do not paste the result into chat). File allow-lists are best-effort so unattended `ka run` / `ka list` can proceed; **the PreToolUse hook is the load-bearing deny**.
+
+### Added
+
+- `ka setup` merges harness **allow** rules (Claude `permissions.allow` plus existing `autoMode.allow`; Cursor prefixes only when that cannot clobber the IDE list). `--permissions-only`, `--permissions-remove`, `--yes`. Codex remains print-only (`config.toml` has no command rules); trust the hook via `/hooks`.
+- Hook verb-deny for forbidden `ka` invocations (including `python -m key_amnesia`, `uvx`/`pipx`, path suffixes, `env` prefixes, `sh -c`, and nested `ka run -- …`). `ka scan --yes` is denied; unrecognized verbs fail open.
+- Secret scan of the command **after** `ka run --` (so `python deploy.py --api-key sk-ant-…` is denied) without nagging on `--secret NAME --as NAME=VAR`.
+- `ka run --cwd DIR` (absolute resolve; missing/not-a-directory → exit 2).
+
+### Changed
+
+- Usage skill prefers a bare `ka run --cwd DIR --secret … --as … -- <command>` — no `cd &&`, pipes, or `2>&1`.
+- `ka init` prints `Next: ka setup`.
 
 ## [0.4.8] — 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,22 @@ this project:
 
 `ka setup` copies the bundled skills to `~/.claude/skills/`, `~/.cursor/skills/`,
 `~/.agents/skills/` (Codex), and `~/.codex/skills/` (legacy Codex /
-`$CODEX_HOME`), and merges a PreToolUse / preToolUse hook that blocks tool
-calls containing inline credential-shaped tokens. Codex also needs you to
-review and trust the new hook via `/hooks` before it will run.
+`$CODEX_HOME`), merges a PreToolUse / preToolUse hook that **denies forbidden
+`ka` verbs** (and inline credential-shaped tokens), and best-effort **allow**
+rules so the harness will let unattended `ka run` / `ka list` through. Files
+try to let the agent run `ka`; the hook stops `ka set`, `ka reveal`,
+`ka scan --yes`, and other mutating verbs. Codex also needs you to review and
+trust the new hook via `/hooks` before it will run. If Claude `autoMode.allow`
+entries vanish after a restart, re-run `ka setup`. Cursor: `ka setup` never
+creates `~/.cursor/permissions.json` (that file replaces the in-app terminal
+allowlist).
+
+Agent-facing `ka run` should be a **bare** command with `--cwd` rather than
+`cd && … | tail`:
+
+```bash
+ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- <command>
+```
 
 ## Two modes: ask every time, or unlock a session
 
@@ -130,6 +143,9 @@ No tool in this class can promise absolute secrecy, and we'd rather tell you exa
 11. **`--admit-tree` is a separate opt-in trust-widening (also never the default, no config/env).** At the first unrecognized-peer prompt it lets you pick a kernel-verified *ancestor* as the admission root, so every real OS descendant of that root (including later sibling CLI invocations under the same parent) is silently in-tree for the rest of the session. That is wider than admitting the short-lived connecting `ka` process alone — use it only when you intend lineage trust, and read the loud `via=interactive-tree` announce + audit line for the root you actually chose. It does **not** change `--pre-admit` (arrival-time grant vs lineage root).
 12. **A live guard session reloads on change, not on a fixed schedule.** The guard checks a cheap content fingerprint of the vault file on every `run`/`list`/`status`; when another terminal changes it, the guard re-opens with the SecretBox key it already derived at unlock — no new password prompt. The tradeoff: the guard keeps that **derived key** in memory for the session. Detail: [DESIGN.md](DESIGN.md) and the [threat-model wiki page](https://github.com/fujitoid/key-amnesia/wiki/Threat-model).
 13. **Runner role is not a cryptographic ACL against you.** If your local identity is enrolled as `runner`, `ka` refuses `reveal`/`copy` — effective against an agent. Anyone who knows the master password can still decrypt the vault offline. Per-member `ka export` ciphertext *is* cryptographic (only that member's key opens it).
+14. **Harness file allow-lists are best-effort; the PreToolUse hook is the deny.** Claude `permissions.allow` / `autoMode.allow` and Cursor prefixes try to let the agent run `ka run` / `ka list`. They do not authorize `cd && … | tail` compound chains (each subcommand is classified separately). Codex has no command rules in `config.toml`. Without a trusted hook, auto-mode deny is inert. An agent that can write harness config can remove or disable the hook; hook self-protection is not in this release.
+15. **Hook verb-deny is not a complete `ka` sandbox.** Shell aliases, functions, and renamed copies of the binary are not recognized. A trailing command that *constructs* a `ka` invocation at runtime (`python -c "os.system('ka set …')"`) is not verb-denied. `KEY_AMNESIA_HOOK_DISABLE` on the inner command does not disable the hook process; a **user login** env var can inherit into the harness and is the operator bypass.
+16. **Write/Edit tools are not verb-denied** so docs can mention `ka set`. Secret scanning on those tools is unchanged.
 
 Longer honesty notes and policy-vs-crypto labels: [wiki — Threat model](https://github.com/fujitoid/key-amnesia/wiki/Threat-model) (draft; maintainer judgement flagged).
 

--- a/docs/agent-usage.md
+++ b/docs/agent-usage.md
@@ -16,10 +16,11 @@ There is no MCP “get secret” API. That is intentional.
 2. Run tools through injection:
 
    ```bash
-   ka run --secret OPENAI_API_KEY -- python my_script.py
+   ka run --cwd DIR --secret OPENAI_API_KEY --as OPENAI_API_KEY=OPENAI_API_KEY -- python my_script.py
    ```
 
    Remap with `--as NAME=ENVVAR` (vault name on the left). Wrong: `--as OPENAI_API_KEY` without `=`.
+   Prefer `--cwd` over `cd &&`; do not wrap `ka run` in pipes or `2>&1`.
 
 3. Use scrubbed stdout/stderr and the exit code. Do not try to recover the original secret from output.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.4.8"
+version = "0.4.9"
 description = "Encrypted secret vault so AI agents can use API keys without seeing them — a drop-in .env replacement"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -251,6 +251,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Command to run (use -- before command)",
     )
     p_run.add_argument(
+        "--cwd",
+        default=None,
+        metavar="DIR",
+        help="Directory to run the command in (absolute path after resolve)",
+    )
+    p_run.add_argument(
         "--name",
         default=None,
         metavar="LABEL",
@@ -356,7 +362,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # setup (agent distribution: skills + PreToolUse/preToolUse hook)
     p_setup = sub.add_parser(
         "setup",
-        help="Install agent skills and the secret-guard hook for Claude Code / Cursor / Codex",
+        help="Install agent skills, the secret-guard hook, and harness allow-lists",
     )
     p_setup.add_argument(
         "--skills-only",
@@ -367,6 +373,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "--hook-only",
         action="store_true",
         help="Only merge the hook config; skip installing skills",
+    )
+    p_setup.add_argument(
+        "--permissions-only",
+        action="store_true",
+        help="Only merge harness allow-lists; skip skills and hook install",
+    )
+    p_setup.add_argument(
+        "--permissions-remove",
+        action="store_true",
+        help="Remove previously recorded key-amnesia allow/deny rules",
+    )
+    p_setup.add_argument(
+        "--yes",
+        action="store_true",
+        help="Do not prompt before writing permission files (never deletes user allows)",
     )
 
     # docs — open/print wiki URL; no vault/guard/password
@@ -550,6 +571,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     theme.info(
         "Remember your master password — it cannot be recovered if forgotten."
     )
+    theme.info("Next: ka setup")
     return 0
 
 
@@ -1171,6 +1193,16 @@ def cmd_run(args: argparse.Namespace) -> int:
         theme.error("Usage: key-amnesia run --secret NAME [--as NAME=ENV] -- command...")
         return 2
 
+    cwd_raw = getattr(args, "cwd", None)
+    if cwd_raw:
+        cwd_path = Path(cwd_raw).expanduser().resolve()
+        if not cwd_path.is_dir():
+            theme.error(f"Error: --cwd is not a directory: {cwd_raw}")
+            return 2
+        run_cwd = str(cwd_path)
+    else:
+        run_cwd = os.getcwd()
+
     inject_as = _parse_as_mappings(args.as_env)
     secret_names = list(args.secret or [])
     # Also include names only referenced in --as
@@ -1212,7 +1244,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 "secret_names": secret_names,
                 "inject_as": inject_as,
                 "command": cmd,
-                "cwd": os.getcwd(),
+                "cwd": run_cwd,
             },
             timeout=3600,
             lock_path=ctx.lock_path,
@@ -1249,6 +1281,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         command=cmd,
         inject_as=inject_as,
         vault_path=str(ctx.vault_path),
+        cwd=run_cwd,
     )
     ok, password, outcome = _auth_password(request)
     if not ok:
@@ -1275,7 +1308,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             return 1
         env_inject = {inject_as.get(n, n): secrets_map[n] for n in secret_names}
         by_name = {n: secrets_map[n] for n in secret_names}
-        result = run_with_secrets(cmd, env_inject, by_name)
+        result = run_with_secrets(cmd, env_inject, by_name, cwd=run_cwd)
         audit_event(
             "run",
             secret_names=secret_names,

--- a/src/key_amnesia/harness_permissions.py
+++ b/src/key_amnesia/harness_permissions.py
@@ -1,0 +1,822 @@
+"""Best-effort harness allow-lists. Deny is the PreToolUse hook."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from key_amnesia import theme
+from key_amnesia.ka_policy import COVERAGE_ALLOW, FILE_DENY_VERBS, VALUE_EMIT_VERBS
+from key_amnesia.paths import permissions_manifest_path
+
+ConfirmFn = Callable[[str, bool], bool]
+
+AUTOMODE_QUALIFIER = "key-amnesia"
+MANIFEST_VERSION = 1
+
+_CLAUDE_BINARIES = ("ka", "key-amnesia")
+_SHELLS = ("Bash", "PowerShell")
+_HOOK_MARKERS = ("key-amnesia-hook", "key_amnesia.hooks.secret_guard")
+
+FILE_ALLOW_COMMANDS: tuple[str, ...] = tuple(sorted(COVERAGE_ALLOW))
+FILE_DENY_COMMANDS: tuple[str, ...] = tuple(sorted(FILE_DENY_VERBS))
+
+
+def _is_our_hook_command(command: str) -> bool:
+    return any(m in command for m in _HOOK_MARKERS)
+
+
+def _claude_matcher(shell: str, binary: str, command: str) -> str:
+    if command.startswith("--"):
+        return f"{shell}({binary} {command})"
+    return f"{shell}({binary} {command}:*)"
+
+
+def claude_allow_matchers() -> list[str]:
+    out: list[str] = []
+    for shell in _SHELLS:
+        for binary in _CLAUDE_BINARIES:
+            for command in FILE_ALLOW_COMMANDS:
+                out.append(_claude_matcher(shell, binary, command))
+    return out
+
+
+def claude_deny_matchers() -> list[str]:
+    out: list[str] = []
+    for shell in _SHELLS:
+        for binary in _CLAUDE_BINARIES:
+            for command in FILE_DENY_COMMANDS:
+                out.append(_claude_matcher(shell, binary, command))
+    return out
+
+
+def claude_automode_allow_matchers() -> list[str]:
+    return [f"{m} — {AUTOMODE_QUALIFIER}" for m in claude_allow_matchers()]
+
+
+def cursor_allow_prefixes() -> list[str]:
+    out: list[str] = []
+    for binary in ("ka", "key-amnesia", "ka.exe", "key-amnesia.exe"):
+        for command in FILE_ALLOW_COMMANDS:
+            out.append(f"{binary} {command}")
+    return out
+
+
+def _matcher_core(entry: str) -> str:
+    core = entry.split(" — ", 1)[0].strip()
+    return core.replace(":*", " *")
+
+
+def deny_in_allow_conflicts(allow_entries: Iterable[str]) -> list[str]:
+    """Exact allow strings whose matcher is a generated deny verb.
+
+    Match by matcher prefix inside a qualified string (`` — `` qualifier or
+    `` in the …`` Claude project qualifier). ``Bash(ka set:*)`` ≡ ``Bash(ka set *)``.
+    """
+    deny_matchers = claude_deny_matchers()
+    deny_cores = {_matcher_core(m) for m in deny_matchers}
+    found: list[str] = []
+    for entry in allow_entries:
+        if not isinstance(entry, str):
+            continue
+        raw = entry.split(" — ", 1)[0].strip()
+        core = _matcher_core(entry)
+        if core in deny_cores:
+            found.append(entry)
+            continue
+        hit = False
+        for dm in deny_matchers:
+            dcore = _matcher_core(dm)
+            if raw.startswith(dm) or core.startswith(dcore):
+                found.append(entry)
+                hit = True
+                break
+        if hit:
+            continue
+    return found
+
+
+def load_json_object_strict(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Fail closed: missing file is empty dict; malformed / non-object is an error."""
+    if not path.exists():
+        return {}, None
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
+        return None, f"unparseable JSON at {path}: {e}"
+    if not isinstance(data, dict):
+        return None, f"{path} is not a JSON object"
+    return data, None
+
+
+def dump_json(data: dict[str, Any]) -> str:
+    return json.dumps(data, indent=2) + "\n"
+
+
+def claude_hook_registered(settings: dict[str, Any]) -> bool:
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    pre = hooks.get("PreToolUse")
+    if not isinstance(pre, list):
+        return False
+    for entry in pre:
+        if not isinstance(entry, dict):
+            continue
+        for hook in entry.get("hooks") or []:
+            if isinstance(hook, dict) and _is_our_hook_command(
+                str(hook.get("command") or "")
+            ):
+                return True
+    return False
+
+
+def cursor_hook_registered(hooks_doc: dict[str, Any]) -> bool:
+    hooks = hooks_doc.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    pre = hooks.get("preToolUse")
+    if not isinstance(pre, list):
+        return False
+    for entry in pre:
+        if isinstance(entry, dict) and _is_our_hook_command(
+            str(entry.get("command") or "")
+        ):
+            return True
+    return False
+
+
+def merge_string_list(
+    existing: list[Any],
+    ours: list[str],
+    stale_manifest: list[str],
+) -> tuple[list[str] | None, str | None]:
+    """Keep user strings; drop stale manifested rules; append missing ours."""
+    if not all(isinstance(x, str) for x in existing):
+        return None, "allow/deny list contains a non-string entry"
+    stale = set(stale_manifest) - set(ours)
+    out = [x for x in existing if x not in stale]
+    have = set(out)
+    for rule in ours:
+        if rule not in have:
+            out.append(rule)
+            have.add(rule)
+    return out, None
+
+
+def load_manifest() -> dict[str, Any]:
+    path = permissions_manifest_path()
+    data, err = load_json_object_strict(path)
+    if err or data is None:
+        return {"version": MANIFEST_VERSION, "rules": {}}
+    rules = data.get("rules")
+    if not isinstance(rules, dict):
+        return {"version": MANIFEST_VERSION, "rules": {}}
+    return data
+
+
+def save_manifest(rules: dict[str, list[str]]) -> None:
+    path = permissions_manifest_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": MANIFEST_VERSION, "rules": rules}
+    path.write_text(dump_json(payload), encoding="utf-8")
+
+
+def _manifest_list(manifest: dict[str, Any], key: str) -> list[str]:
+    rules = manifest.get("rules") or {}
+    val = rules.get(key) if isinstance(rules, dict) else None
+    if isinstance(val, list) and all(isinstance(x, str) for x in val):
+        return list(val)
+    return []
+
+
+@dataclass
+class FileChange:
+    path: Path
+    new_text: str
+    summary: str
+    manifest_key: str
+    manifest_rules: list[str]
+
+
+@dataclass
+class HarnessOutcome:
+    name: str
+    ok: bool = True
+    lines: list[str] = field(default_factory=list)
+    changes: list[FileChange] = field(default_factory=list)
+    conflicts: list[tuple[Path, str]] = field(default_factory=list)
+    hook_missing: bool = False
+    hook_path: Path | None = None
+
+
+def _ensure_string_list(obj: dict[str, Any], key: str) -> tuple[list[str] | None, str | None]:
+    if key not in obj:
+        obj[key] = []
+    val = obj[key]
+    if not isinstance(val, list):
+        return None, f"{key!r} is not a list"
+    if not all(isinstance(x, str) for x in val):
+        return None, f"{key!r} contains a non-string entry"
+    return val, None
+
+
+def prepare_claude(
+    home: Path,
+    manifest: dict[str, Any],
+) -> HarnessOutcome:
+    out = HarnessOutcome(name="claude")
+    claude_home = home / ".claude"
+    if not claude_home.is_dir():
+        out.lines.append("skip Claude permissions: ~/.claude is absent")
+        return out
+
+    path = claude_home / "settings.json"
+    data, err = load_json_object_strict(path)
+    if err:
+        out.ok = False
+        out.lines.append(f"Claude: {err} (fail closed; no write)")
+        out.lines.extend(_pasteable_claude())
+        return out
+    assert data is not None
+
+    if not claude_hook_registered(data):
+        out.hook_missing = True
+        out.hook_path = path
+
+    perms = data.get("permissions")
+    if perms is None:
+        perms = {}
+        data["permissions"] = perms
+    if not isinstance(perms, dict):
+        out.ok = False
+        out.lines.append(f"Claude: {path} permissions is not an object (fail closed)")
+        out.lines.extend(_pasteable_claude())
+        return out
+
+    allow_ours = claude_allow_matchers()
+    deny_ours = claude_deny_matchers()
+    for verb in VALUE_EMIT_VERBS:
+        leaked = any(
+            f" {verb}:*" in m or m.endswith(f" {verb})") for m in allow_ours
+        )
+        if leaked:
+            raise RuntimeError(
+                f"value-emit verb {verb} leaked into file allow list"
+            )
+
+    allow_list, err = _ensure_string_list(perms, "allow")
+    if err:
+        out.ok = False
+        out.lines.append(f"Claude: {path} permissions.allow {err} (fail closed)")
+        out.lines.extend(_pasteable_claude())
+        return out
+    deny_list, err = _ensure_string_list(perms, "deny")
+    if err:
+        out.ok = False
+        out.lines.append(f"Claude: {path} permissions.deny {err} (fail closed)")
+        out.lines.extend(_pasteable_claude())
+        return out
+    assert allow_list is not None and deny_list is not None
+
+    for conflict in deny_in_allow_conflicts(allow_list):
+        out.conflicts.append((path, conflict))
+
+    new_allow, err = merge_string_list(
+        allow_list, allow_ours, _manifest_list(manifest, "claude.permissions.allow")
+    )
+    if err:
+        out.ok = False
+        out.lines.append(f"Claude: {err}")
+        return out
+    new_deny, err = merge_string_list(
+        deny_list, deny_ours, _manifest_list(manifest, "claude.permissions.deny")
+    )
+    if err:
+        out.ok = False
+        out.lines.append(f"Claude: {err}")
+        return out
+    assert new_allow is not None and new_deny is not None
+    perms["allow"] = new_allow
+    perms["deny"] = new_deny
+
+    auto = data.get("autoMode")
+    auto_ours = claude_automode_allow_matchers()
+    auto_manifest_rules: list[str] = []
+    if isinstance(auto, dict) and isinstance(auto.get("allow"), list):
+        auto_allow = auto["allow"]
+        if not all(isinstance(x, str) for x in auto_allow):
+            out.ok = False
+            out.lines.append(
+                f"Claude: {path} autoMode.allow has a non-string entry (fail closed)"
+            )
+            out.lines.extend(_pasteable_claude())
+            return out
+        for conflict in deny_in_allow_conflicts(auto_allow):
+            out.conflicts.append((path, conflict))
+        merged_auto, err = merge_string_list(
+            auto_allow, auto_ours, _manifest_list(manifest, "claude.autoMode.allow")
+        )
+        if err:
+            out.ok = False
+            out.lines.append(f"Claude: {err}")
+            return out
+        assert merged_auto is not None
+        auto["allow"] = merged_auto
+        auto_manifest_rules = auto_ours
+        # Never rewrite/reorder autoMode.environment — we did not touch it.
+
+    out.changes.append(
+        FileChange(
+            path=path,
+            new_text=dump_json(data),
+            summary=f"Claude permissions.allow/deny (+ autoMode.allow if present): {path}",
+            manifest_key="claude.settings.json",
+            manifest_rules=[],
+        )
+    )
+    setattr(
+        out,
+        "_claude_manifest",
+        {
+            "claude.permissions.allow": allow_ours,
+            "claude.permissions.deny": deny_ours,
+            "claude.autoMode.allow": auto_manifest_rules,
+        },
+    )
+    return out
+
+
+def prepare_cursor(
+    home: Path,
+    manifest: dict[str, Any],
+) -> HarnessOutcome:
+    out = HarnessOutcome(name="cursor")
+    cursor_home = home / ".cursor"
+    if not cursor_home.is_dir():
+        out.lines.append("skip Cursor permissions: ~/.cursor is absent")
+        return out
+
+    hooks_path = cursor_home / "hooks.json"
+    hooks_doc, hooks_err = load_json_object_strict(hooks_path)
+    if hooks_err:
+        out.ok = False
+        out.lines.append(f"Cursor hooks.json: {hooks_err} (fail closed; no write)")
+        return out
+    assert hooks_doc is not None
+    if not cursor_hook_registered(hooks_doc):
+        out.hook_missing = True
+        out.hook_path = hooks_path
+
+    prefixes = cursor_allow_prefixes()
+    perm_path = cursor_home / "permissions.json"
+    if not perm_path.exists():
+        out.lines.append(
+            "Cursor: ~/.cursor/permissions.json is absent — not creating it "
+            "(that file replaces the in-app terminal allowlist). "
+            "In Cursor Settings → Agents / Terminal allowlist, add prefixes:"
+        )
+        for p in prefixes[:8]:
+            out.lines.append(f"  {p}")
+        out.lines.append("  … (ka / key-amnesia allow verbs; hook denies the rest)")
+    else:
+        data, err = load_json_object_strict(perm_path)
+        if err:
+            out.ok = False
+            out.lines.append(f"Cursor: {err} (fail closed; no write)")
+            out.lines.extend(_pasteable_cursor(prefixes))
+            return out
+        assert data is not None
+        if "terminalAllowlist" in data:
+            allow = data["terminalAllowlist"]
+            if not isinstance(allow, list) or not all(isinstance(x, str) for x in allow):
+                out.ok = False
+                out.lines.append(
+                    f"Cursor: {perm_path} terminalAllowlist is not a string list "
+                    "(fail closed)"
+                )
+                out.lines.extend(_pasteable_cursor(prefixes))
+                return out
+            merged, err = merge_string_list(
+                allow, prefixes, _manifest_list(manifest, "cursor.terminalAllowlist")
+            )
+            if err:
+                out.ok = False
+                out.lines.append(f"Cursor: {err}")
+                return out
+            assert merged is not None
+            data["terminalAllowlist"] = merged
+            out.changes.append(
+                FileChange(
+                    path=perm_path,
+                    new_text=dump_json(data),
+                    summary=f"Cursor terminalAllowlist: {perm_path}",
+                    manifest_key="cursor.terminalAllowlist",
+                    manifest_rules=prefixes,
+                )
+            )
+        else:
+            # Do not add terminalAllowlist. Optional allow_instructions only.
+            auto = data.get("autoRun")
+            if auto is None:
+                data["autoRun"] = {}
+                auto = data["autoRun"]
+            if not isinstance(auto, dict):
+                out.ok = False
+                out.lines.append(
+                    f"Cursor: {perm_path} autoRun is not an object (fail closed)"
+                )
+                return out
+            if "block_instructions" in auto:
+                pass  # never write or modify block_instructions
+            text = (
+                "Allow unattended key-amnesia: ka run / ka list / ka status / "
+                "ka connect / ka check / ka scan / ka lock / ka config show / "
+                "ka identity show / ka member list / ka docs / ka --version / "
+                "ka --help. The PreToolUse hook denies ka set, reveal, export, "
+                "copy, and other mutating verbs."
+            )
+            existing = auto.get("allow_instructions")
+            if existing is None:
+                auto["allow_instructions"] = text
+            elif isinstance(existing, str):
+                if "ka run" not in existing:
+                    auto["allow_instructions"] = existing.rstrip() + "\n" + text
+            else:
+                out.ok = False
+                out.lines.append(
+                    f"Cursor: {perm_path} autoRun.allow_instructions is not a string "
+                    "(fail closed)"
+                )
+                return out
+            out.changes.append(
+                FileChange(
+                    path=perm_path,
+                    new_text=dump_json(data),
+                    summary=f"Cursor autoRun.allow_instructions: {perm_path}",
+                    manifest_key="cursor.allow_instructions",
+                    manifest_rules=[text],
+                )
+            )
+
+    cli_path = cursor_home / "cli-config.json"
+    if cli_path.exists():
+        data, err = load_json_object_strict(cli_path)
+        if err:
+            out.ok = False
+            out.lines.append(f"Cursor CLI: {err} (fail closed; no write)")
+            return out
+        assert data is not None
+        perms = data.get("permissions")
+        if isinstance(perms, dict) and isinstance(perms.get("allow"), list):
+            allow = perms["allow"]
+            if not all(isinstance(x, str) for x in allow):
+                out.ok = False
+                out.lines.append(
+                    f"Cursor CLI: {cli_path} permissions.allow has a non-string "
+                    "(fail closed)"
+                )
+                return out
+            merged, err = merge_string_list(
+                allow, prefixes, _manifest_list(manifest, "cursor.cli.allow")
+            )
+            if err:
+                out.ok = False
+                out.lines.append(f"Cursor CLI: {err}")
+                return out
+            assert merged is not None
+            perms["allow"] = merged
+            out.changes.append(
+                FileChange(
+                    path=cli_path,
+                    new_text=dump_json(data),
+                    summary=f"Cursor cli-config.json permissions.allow: {cli_path}",
+                    manifest_key="cursor.cli.allow",
+                    manifest_rules=prefixes,
+                )
+            )
+        else:
+            out.lines.append(
+                f"Cursor CLI: {cli_path} present but schema has no "
+                "permissions.allow string list — not modifying"
+            )
+    return out
+
+
+def _pasteable_claude() -> list[str]:
+    lines = ["Paste-able Claude permissions.allow:"]
+    for m in claude_allow_matchers()[:6]:
+        lines.append(f"  {m}")
+    lines.append("  …")
+    return lines
+
+
+def _pasteable_cursor(prefixes: list[str]) -> list[str]:
+    lines = ["Paste-able Cursor terminal prefixes:"]
+    for p in prefixes[:6]:
+        lines.append(f"  {p}")
+    lines.append("  …")
+    return lines
+
+
+def prepare_codex(home: Path) -> HarnessOutcome:
+    out = HarnessOutcome(name="codex")
+    out.lines.append(
+        "Codex: no command allow/deny list in config.toml (sandbox/trust only) "
+        "— not writing command rules. Trust the key-amnesia hook via /hooks; "
+        "until then, verb-deny does not run. File-edit tools may not fire "
+        "PreToolUse; `ka set` is a Bash command, so Bash PreToolUse is the path "
+        "that matters."
+    )
+    if not (home / ".codex").is_dir() and not os.environ.get("CODEX_HOME"):
+        out.lines.append("skip Codex files: ~/.codex is absent (print-only anyway)")
+    return out
+
+
+def _confirm_default(prompt: str, default: bool) -> bool:
+    suffix = " [Y/n]: " if default else " [y/N]: "
+    try:
+        answer = input(prompt + suffix).strip().lower()
+    except EOFError:
+        return default
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+def _print_diff(path: Path, new_text: str) -> None:
+    old = path.read_text(encoding="utf-8") if path.exists() else ""
+    if old == new_text:
+        theme.info(f"unchanged: {path}")
+        return
+    theme.info(f"--- {path}")
+    old_lines = old.splitlines()
+    new_lines = new_text.splitlines()
+    # Compact: show only added lines that look like ka rules, plus counts.
+    added = [ln for ln in new_lines if ln not in old_lines]
+    removed = [ln for ln in old_lines if ln not in new_lines]
+    theme.out(f"  +{len(added)} / -{len(removed)} lines")
+    for ln in added[:20]:
+        theme.out(f"  + {ln.rstrip()}")
+    if len(added) > 20:
+        theme.out(f"  + … ({len(added) - 20} more)")
+
+
+def apply_permission_plan(
+    outcomes: list[HarnessOutcome],
+    *,
+    yes: bool,
+    may_install_hook: bool,
+    install_hook_fn: Callable[[str], None] | None,
+    confirm_fn: ConfirmFn | None = None,
+    tty: bool | None = None,
+) -> int:
+    """Show diffs, handle hook-missing / conflicts, write, update manifest.
+
+    ``yes`` skips the write prompt and must not delete user allows.
+    ``yes`` is not acknowledgement that allow may ship without the hook.
+    """
+    import sys
+
+    confirm = confirm_fn or _confirm_default
+    is_tty = sys.stdin.isatty() if tty is None else tty
+    rc = 0
+    manifest = load_manifest()
+    new_rules: dict[str, list[str]] = dict(manifest.get("rules") or {})
+    if not isinstance(new_rules, dict):
+        new_rules = {}
+
+    theme.info(
+        "Files try to let the agent run `ka`; the hook stops forbidden `ka` verbs."
+    )
+
+    for outcome in outcomes:
+        for line in outcome.lines:
+            theme.out(line)
+        if not outcome.ok:
+            rc = 1
+
+    # Conflicts: loud, default No, --yes must not delete.
+    all_conflicts = [(o, p, s) for o in outcomes for p, s in o.conflicts]
+    if all_conflicts:
+        theme.warn(
+            "A deny-verb already appears in an allow list. The hook still "
+            "denies it. Exact strings:"
+        )
+        for _o, path, exact in all_conflicts:
+            theme.warn(f"  {path}: {exact}")
+            theme.warn("    (permits a forbidden ka verb at the file layer)")
+        if yes or not is_tty:
+            theme.info("Leaving those user allow rules in place (not deleting).")
+        else:
+            if confirm("Remove the conflicting allow rules listed above?", False):
+                for outcome, path, exact in all_conflicts:
+                    for change in outcome.changes:
+                        if change.path != path:
+                            continue
+                        data = json.loads(change.new_text)
+                        _drop_exact_string(data, exact)
+                        change.new_text = dump_json(data)
+
+    # Hook missing: never write allows silently.
+    for outcome in outcomes:
+        if not outcome.hook_missing:
+            continue
+        if not outcome.changes:
+            continue
+        theme.warn(
+            f"{outcome.name}: key-amnesia hook is not registered. Writing "
+            "allow lists without the hook would unblock `ka` including `ka set`."
+        )
+        installed = False
+        if may_install_hook and install_hook_fn is not None:
+            if is_tty and confirm(
+                f"Install the key-amnesia hook for {outcome.name} now?", False
+            ):
+                install_hook_fn(outcome.name)
+                installed = True
+                outcome.hook_missing = False
+        if installed:
+            continue
+        ack = False
+        if is_tty:
+            ack = confirm(
+                f"Write {outcome.name} allow lists anyway without the deny hook?",
+                False,
+            )
+        if not ack:
+            theme.error(
+                f"Skipping {outcome.name} allow write (hook missing; "
+                "`--yes` is not this acknowledgement)."
+            )
+            outcome.changes = []
+            rc = 1
+
+    pending = [c for o in outcomes if o.ok for c in o.changes]
+    if not pending:
+        _save_rules_from_outcomes(new_rules, outcomes)
+        return rc
+
+    for change in pending:
+        _print_diff(change.path, change.new_text)
+
+    do_write = True
+    if yes:
+        do_write = True
+    elif is_tty:
+        do_write = confirm("Write the permission file changes above?", True)
+    # non-TTY without --yes: write (setup is otherwise non-interactive)
+
+    if not do_write:
+        theme.info("No permission files written.")
+        return rc
+
+    for outcome in outcomes:
+        if not outcome.ok:
+            continue
+        for change in outcome.changes:
+            change.path.parent.mkdir(parents=True, exist_ok=True)
+            # Re-read at write time
+            current, err = load_json_object_strict(change.path)
+            if err:
+                theme.error(f"Abort write {change.path}: {err}")
+                rc = 1
+                continue
+            if current is None:
+                theme.error(f"Abort write {change.path}: unreadable")
+                rc = 1
+                continue
+            change.path.write_text(change.new_text, encoding="utf-8")
+            theme.out(f"wrote {change.path}")
+            if change.manifest_key and change.manifest_rules:
+                new_rules[change.manifest_key] = list(change.manifest_rules)
+        extra = getattr(outcome, "_claude_manifest", None)
+        if isinstance(extra, dict):
+            new_rules.update(extra)
+
+    save_manifest(new_rules)
+    return rc
+
+
+def _drop_exact_string(obj: Any, exact: str) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(v, list):
+                obj[k] = [x for x in v if x != exact]
+            else:
+                _drop_exact_string(v, exact)
+    elif isinstance(obj, list):
+        for item in obj:
+            _drop_exact_string(item, exact)
+
+
+def _save_rules_from_outcomes(
+    new_rules: dict[str, list[str]], outcomes: list[HarnessOutcome]
+) -> None:
+    for outcome in outcomes:
+        extra = getattr(outcome, "_claude_manifest", None)
+        if isinstance(extra, dict):
+            new_rules.update(extra)
+        for change in outcome.changes:
+            if change.manifest_key and change.manifest_rules:
+                new_rules[change.manifest_key] = list(change.manifest_rules)
+
+
+def remove_manifested_rules(home: Path) -> int:
+    """Delete only strings recorded in the permissions manifest."""
+    manifest = load_manifest()
+    rules = manifest.get("rules") or {}
+    if not isinstance(rules, dict) or not rules:
+        theme.info("No permissions manifest entries to remove.")
+        return 0
+
+    rc = 0
+    mapping: list[tuple[str, Path, tuple[str, ...]]] = [
+        (
+            "claude.permissions.allow",
+            home / ".claude" / "settings.json",
+            ("permissions", "allow"),
+        ),
+        (
+            "claude.permissions.deny",
+            home / ".claude" / "settings.json",
+            ("permissions", "deny"),
+        ),
+        (
+            "claude.autoMode.allow",
+            home / ".claude" / "settings.json",
+            ("autoMode", "allow"),
+        ),
+        (
+            "cursor.terminalAllowlist",
+            home / ".cursor" / "permissions.json",
+            ("terminalAllowlist",),
+        ),
+        (
+            "cursor.cli.allow",
+            home / ".cursor" / "cli-config.json",
+            ("permissions", "allow"),
+        ),
+    ]
+    for key, path, trail in mapping:
+        recorded = rules.get(key)
+        if not isinstance(recorded, list) or not recorded:
+            continue
+        if not path.exists():
+            continue
+        data, err = load_json_object_strict(path)
+        if err or data is None:
+            theme.error(f"skip remove at {path}: {err}")
+            rc = 1
+            continue
+        target = data
+        ok = True
+        for part in trail[:-1]:
+            nxt = target.get(part) if isinstance(target, dict) else None
+            if not isinstance(nxt, dict):
+                ok = False
+                break
+            target = nxt
+        if not ok:
+            continue
+        last = trail[-1]
+        lst = target.get(last) if isinstance(target, dict) else None
+        if not isinstance(lst, list):
+            continue
+        drop = set(recorded)
+        target[last] = [x for x in lst if x not in drop]
+        path.write_text(dump_json(data), encoding="utf-8")
+        theme.out(f"removed manifested rules from {path} ({key})")
+
+    save_manifest({})
+    theme.info("Cleared permissions manifest.")
+    return rc
+
+
+def run_permissions(
+    home: Path,
+    *,
+    yes: bool,
+    may_install_hook: bool,
+    install_hook_fn: Callable[[str], None] | None,
+    confirm_fn: ConfirmFn | None = None,
+    tty: bool | None = None,
+) -> int:
+    manifest = load_manifest()
+    outcomes = [
+        prepare_claude(home, manifest),
+        prepare_cursor(home, manifest),
+        prepare_codex(home),
+    ]
+    return apply_permission_plan(
+        outcomes,
+        yes=yes,
+        may_install_hook=may_install_hook,
+        install_hook_fn=install_hook_fn,
+        confirm_fn=confirm_fn,
+        tty=tty,
+    )

--- a/src/key_amnesia/hooks/secret_guard.py
+++ b/src/key_amnesia/hooks/secret_guard.py
@@ -2,8 +2,15 @@
 """PreToolUse / preToolUse secret guard: blocking hook for Claude Code, Cursor, Codex.
 
 Inspects a pending tool call (Bash/Shell command, Write/Edit file content, or
-Codex ``apply_patch``) for inline credential-shaped tokens and **denies** the
-call when one is found, pointing the agent at ``ka set`` / ``ka run`` instead.
+Codex ``apply_patch``) and **denies** it when:
+
+- the Bash/Shell command is a forbidden ``ka`` verb (``set``, ``reveal``,
+  ``scan --yes``, nested ``ka run -- ka set``, …), or
+- the text contains an inline credential-shaped token.
+
+Allowed agent path is ``ka run`` / ``ka list`` / ``ka status``. Forbidden
+verbs must be run in the user's own terminal. Write/Edit contents that
+*mention* ``ka set`` are not verb-denied (docs); secret scanning still runs.
 
 Host contracts from the same detection logic:
 
@@ -28,6 +35,13 @@ import re
 import sys
 from collections import Counter
 from typing import Any, Iterable
+
+from key_amnesia.ka_policy import (
+    deny_message,
+    iter_non_ka_chain_texts,
+    ka_run_trailing_texts,
+    ka_verb_deny_reason,
+)
 
 DISABLE_ENV = "KEY_AMNESIA_HOOK_DISABLE"
 
@@ -165,9 +179,16 @@ def _command_text(tool_input: Any) -> str:
     return ""
 
 
-def find_finding(text: str) -> str | None:
-    """Return a short human-readable finding kind, or None if text looks clean."""
-    if not text or _KA_SAFE.search(text):
+def find_finding(text: str, *, ignore_ka_safe: bool = False) -> str | None:
+    """Return a short human-readable finding kind, or None if text looks clean.
+
+    ``ignore_ka_safe`` is for the argv after ``ka run --``: the outer command
+    matches ``_KA_SAFE`` but a hardcoded key on the trailing command must still
+    deny.
+    """
+    if not text:
+        return None
+    if not ignore_ka_safe and _KA_SAFE.search(text):
         return None
 
     for kind, pattern in _PREFIX_PATTERNS:
@@ -199,8 +220,8 @@ def detect_host(payload: dict[str, Any]) -> str:
     return "claude"
 
 
-def deny_claude(kind: str) -> dict[str, Any]:
-    reason = _SUGGESTION.format(kind=kind)
+def deny_claude(kind: str, *, reason: str | None = None) -> dict[str, Any]:
+    reason = reason or _SUGGESTION.format(kind=kind)
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
@@ -211,8 +232,8 @@ def deny_claude(kind: str) -> dict[str, Any]:
     }
 
 
-def deny_cursor(kind: str) -> dict[str, Any]:
-    reason = _SUGGESTION.format(kind=kind)
+def deny_cursor(kind: str, *, reason: str | None = None) -> dict[str, Any]:
+    reason = reason or _SUGGESTION.format(kind=kind)
     return {
         "permission": "deny",
         "agent_message": reason,
@@ -223,7 +244,19 @@ def deny_cursor(kind: str) -> dict[str, Any]:
     }
 
 
-_ALLOWED_TOOL_NAMES = {"bash", "shell", "write", "edit", "multiedit", "apply_patch"}
+_SHELL_TOOL_NAMES = {"bash", "shell", "powershell"}
+
+
+def _emit_deny(host: str, kind: str, *, reason: str | None = None) -> dict[str, Any]:
+    if host == "cursor":
+        reply = deny_cursor(kind, reason=reason)
+        if reason is not None:
+            reply["user_message"] = reason
+        return reply
+    return deny_claude(kind, reason=reason)
+
+
+_ALLOWED_TOOL_NAMES = {"bash", "shell", "powershell", "write", "edit", "multiedit", "apply_patch"}
 
 
 def main() -> int:
@@ -244,14 +277,39 @@ def main() -> int:
             return 0
 
         tool_name = str(payload.get("tool_name") or "")
-        if tool_name and tool_name.lower() not in _ALLOWED_TOOL_NAMES:
+        tool_l = tool_name.lower()
+        if tool_name and tool_l not in _ALLOWED_TOOL_NAMES:
             return 0
 
         text = _command_text(payload.get("tool_input"))
-        finding = find_finding(text)
+        host = detect_host(payload)
+        is_shell = tool_l in _SHELL_TOOL_NAMES
+
+        # Verb deny before find_finding / _KA_SAFE (Bash/Shell only).
+        if is_shell:
+            kind = ka_verb_deny_reason(text)
+            if kind:
+                reply = _emit_deny(host, kind, reason=deny_message(kind))
+                json.dump(reply, sys.stdout)
+                sys.stdout.write("\n")
+                return 0
+
+        finding: str | None = None
+        if is_shell:
+            scan_texts = list(ka_run_trailing_texts(text))
+            scan_texts.extend(iter_non_ka_chain_texts(text))
+            if scan_texts:
+                for piece in scan_texts:
+                    finding = find_finding(piece, ignore_ka_safe=True)
+                    if finding:
+                        break
+            else:
+                finding = find_finding(text)
+        else:
+            finding = find_finding(text)
+
         if finding:
-            host = detect_host(payload)
-            reply = deny_cursor(finding) if host == "cursor" else deny_claude(finding)
+            reply = _emit_deny(host, finding)
             json.dump(reply, sys.stdout)
             sys.stdout.write("\n")
             return 0

--- a/src/key_amnesia/ka_policy.py
+++ b/src/key_amnesia/ka_policy.py
@@ -1,0 +1,336 @@
+"""Agent-facing `ka` verb policy (allow vs deny). No secret values."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Iterable
+
+# CLI subcommands the agent may run unattended (hook does not verb-deny).
+ALLOW_VERBS: frozenset[str] = frozenset(
+    {
+        "run",
+        "list",
+        "status",
+        "connect",
+        "check",
+        "scan",
+        "lock",
+        "docs",
+        "--version",
+        "--help",
+    }
+)
+
+ALLOW_NESTED: dict[str, frozenset[str]] = {
+    "config": frozenset({"show"}),
+    "identity": frozenset({"show"}),
+    "member": frozenset({"list"}),
+}
+
+DENY_VERBS: frozenset[str] = frozenset(
+    {
+        "set",
+        "remove",
+        "import",
+        "passwd",
+        "change-password",
+        "init",
+        "unlock",
+        "grant",
+        "revoke",
+        "setup",
+        "reveal",
+        "export",
+        "copy",
+        "_prompt-helper",
+    }
+)
+
+DENY_NESTED: dict[str, frozenset[str]] = {
+    "config": frozenset({"set"}),
+    "identity": frozenset({"create"}),
+    "member": frozenset({"add", "remove"}),
+}
+
+# File allow/deny lists never include the hidden helper.
+VALUE_EMIT_VERBS: frozenset[str] = frozenset({"reveal", "export", "copy"})
+
+
+def _coverage_labels(
+    verbs: frozenset[str], nested: dict[str, frozenset[str]]
+) -> frozenset[str]:
+    labels = set(verbs)
+    for group, subs in nested.items():
+        labels.update(f"{group} {sub}" for sub in subs)
+    return frozenset(labels)
+
+
+# Labels for the cli.py coverage test (exactly one table each).
+# Derived from the tables classify_ka_argv actually enforces.
+COVERAGE_ALLOW: frozenset[str] = _coverage_labels(ALLOW_VERBS, ALLOW_NESTED)
+COVERAGE_DENY: frozenset[str] = _coverage_labels(DENY_VERBS, DENY_NESTED)
+FILE_DENY_VERBS: frozenset[str] = COVERAGE_DENY - {"_prompt-helper"}
+
+_KA_BASENAMES = frozenset({"ka", "ka.exe", "key-amnesia", "key-amnesia.exe"})
+_SHELL_BASENAMES = frozenset({"sh", "bash", "zsh", "dash", "busybox"})
+_CHAIN_OPS = frozenset({"&&", "||", ";", "|", "|&", "&"})
+
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.")
+
+
+def _basename(token: str) -> str:
+    t = token.replace("\\", "/").rstrip("/")
+    if "/" in t:
+        t = t.rsplit("/", 1)[-1]
+    return t.lower()
+
+
+def _is_ka_binary(token: str) -> bool:
+    return _basename(token) in _KA_BASENAMES
+
+
+def _is_python(token: str) -> bool:
+    b = _basename(token)
+    if b in {"py", "py.exe"}:
+        return True
+    return b.startswith("python")
+
+
+def _is_shell(token: str) -> bool:
+    return _basename(token) in _SHELL_BASENAMES
+
+
+def _tokenize(text: str) -> list[str]:
+    text = text.strip()
+    if not text:
+        return []
+    # Backslashes are Windows path separators; POSIX shlex would eat them.
+    posix = "\\" not in text
+    try:
+        return shlex.split(text, posix=posix, comments=False)
+    except ValueError:
+        try:
+            return shlex.split(text, posix=not posix, comments=False)
+        except ValueError:
+            return text.split()
+
+
+def _skip_env_prefix(tokens: list[str], i: int) -> int:
+    if i < len(tokens) and _basename(tokens[i]) == "env":
+        i += 1
+        while i < len(tokens) and tokens[i].startswith("-") and tokens[i] not in _CHAIN_OPS:
+            i += 1
+    while i < len(tokens) and _ENV_ASSIGN.match(tokens[i]):
+        i += 1
+    return i
+
+
+def _extract_shell_c_scripts(tokens: list[str]) -> list[str]:
+    scripts: list[str] = []
+    i = 0
+    while i < len(tokens):
+        if _is_shell(tokens[i]):
+            j = i + 1
+            saw_c = False
+            while j < len(tokens) and tokens[j].startswith("-") and tokens[j] not in _CHAIN_OPS:
+                flag = tokens[j]
+                compact = flag.lstrip("-")
+                if flag in ("-c", "-lc") or (
+                    not flag.startswith("--") and "c" in compact
+                ):
+                    saw_c = True
+                j += 1
+            if saw_c and j < len(tokens) and not tokens[j].startswith("-"):
+                scripts.append(tokens[j])
+                i = j + 1
+                continue
+        i += 1
+    return scripts
+
+
+def _split_chain(tokens: list[str]) -> list[list[str]]:
+    chunks: list[list[str]] = []
+    cur: list[str] = []
+    for tok in tokens:
+        if tok in _CHAIN_OPS:
+            if cur:
+                chunks.append(cur)
+                cur = []
+            continue
+        cur.append(tok)
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+def iter_ka_argvs(text: str) -> Iterable[list[str]]:
+    """Yield argv *after* the ka/key-amnesia launcher (subcommand + rest)."""
+    tokens = _tokenize(text)
+    if not tokens:
+        return
+    for script in _extract_shell_c_scripts(tokens):
+        yield from iter_ka_argvs(script)
+    for chunk in _split_chain(tokens):
+        yield from _iter_ka_argvs_chunk(chunk)
+
+
+def _iter_ka_argvs_chunk(tokens: list[str]) -> Iterable[list[str]]:
+    i = _skip_env_prefix(tokens, 0)
+    if i >= len(tokens):
+        return
+    if _basename(tokens[i]) == "uvx" and i + 1 < len(tokens):
+        nxt = tokens[i + 1]
+        if nxt in ("key-amnesia", "ka") or _is_ka_binary(nxt):
+            yield tokens[i + 2 :]
+            return
+    if (
+        _basename(tokens[i]) == "pipx"
+        and i + 2 < len(tokens)
+        and tokens[i + 1] == "run"
+        and (tokens[i + 2] in ("key-amnesia", "ka") or _is_ka_binary(tokens[i + 2]))
+    ):
+        yield tokens[i + 3 :]
+        return
+    if _is_python(tokens[i]):
+        j = i + 1
+        while j < len(tokens) and tokens[j].startswith("-") and tokens[j] != "-m":
+            j += 1
+        if j + 1 < len(tokens) and tokens[j] == "-m":
+            mod = tokens[j + 1].replace("-", "_")
+            if mod == "key_amnesia":
+                yield tokens[j + 2 :]
+                return
+    if _is_ka_binary(tokens[i]):
+        yield tokens[i + 1 :]
+
+
+def _first_verb(argv: list[str]) -> tuple[str, list[str]]:
+    """Return the subcommand token and the remainder of argv.
+
+    The ``i += 2`` path assumes a leading ``-flag`` takes a value. That is
+    safe only because the top-level parser exposes no optional arguments
+    other than ``--version`` / ``--help`` (see
+    ``test_top_level_parser_only_version_help``). A new value-less global
+    flag would consume the verb (``ka --quiet set FOO bar`` → verb ``FOO``)
+    and fail open.
+    """
+    i = 0
+    while i < len(argv) and argv[i].startswith("-") and argv[i] not in ("--",):
+        if argv[i] in ("--version", "-V"):
+            return "--version", argv[i + 1 :]
+        if argv[i] in ("--help", "-h"):
+            return "--help", argv[i + 1 :]
+        if "=" not in argv[i] and i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+            i += 2
+            continue
+        i += 1
+    if i >= len(argv):
+        return "", []
+    return argv[i], argv[i + 1 :]
+
+
+def _argv_after_double_dash(argv: list[str]) -> list[str] | None:
+    try:
+        idx = argv.index("--")
+    except ValueError:
+        return None
+    return argv[idx + 1 :]
+
+
+def classify_ka_argv(argv: list[str]) -> str | None:
+    """Return a deny kind, or None if this argv is not a denied ka invocation.
+
+    Unrecognized verbs fail open (None). Nested ``ka run -- <cmd>`` is checked
+    recursively on the trailing command.
+    """
+    verb, rest = _first_verb(argv)
+    if verb in ("--version", "--help", ""):
+        return None
+    if verb == "scan":
+        if any(a == "--yes" or a.startswith("--yes=") for a in rest):
+            return "ka scan --yes"
+        return None
+    if verb == "run":
+        trailing = _argv_after_double_dash(argv)
+        if trailing:
+            inner = ka_verb_deny_reason(" ".join(trailing))
+            if inner:
+                return f"ka run wrapping {inner}"
+        return None
+    if verb in DENY_VERBS:
+        return f"ka {verb}"
+    if verb in DENY_NESTED:
+        nested, _ = _first_verb(rest)
+        if nested in DENY_NESTED[verb]:
+            return f"ka {verb} {nested}"
+        return None
+    return None
+
+
+def ka_verb_deny_reason(text: str) -> str | None:
+    """If text contains a denied key-amnesia invocation, return a short kind."""
+    if not text:
+        return None
+    for argv in iter_ka_argvs(text):
+        kind = classify_ka_argv(argv)
+        if kind:
+            return kind
+    return None
+
+
+def ka_run_trailing_texts(text: str) -> list[str]:
+    """Shell text of commands after ``ka run … --`` (for secret scanning)."""
+    out: list[str] = []
+    for argv in iter_ka_argvs(text):
+        verb, _ = _first_verb(argv)
+        if verb != "run":
+            continue
+        trailing = _argv_after_double_dash(argv)
+        if not trailing:
+            continue
+        joined = " ".join(trailing)
+        out.append(joined)
+        out.extend(ka_run_trailing_texts(joined))
+    return out
+
+
+def iter_non_ka_chain_texts(text: str) -> Iterable[str]:
+    """Yield chain chunks that are not key-amnesia invocations.
+
+    Sibling of ``ka run … -- python a.py && curl …`` is the ``curl`` chunk;
+    the ``ka run`` prefix is not yielded (anti-nag on ``--secret`` / ``--as``).
+    Recurses into ``sh -c`` / ``bash -lc`` scripts with the same splitter.
+    """
+    tokens = _tokenize(text)
+    if not tokens:
+        return
+    for script in _extract_shell_c_scripts(tokens):
+        yield from iter_non_ka_chain_texts(script)
+    for chunk in _split_chain(tokens):
+        if list(_iter_ka_argvs_chunk(chunk)):
+            continue
+        yield " ".join(chunk)
+
+
+def deny_message(kind: str) -> str:
+    """Tell the human the exact command to run in their own terminal.
+
+    Nested kinds (``ka run wrapping ka scan --yes``) name the wrapper in the
+    explanation; the runnable slot is the inner command only.
+    """
+    inner = kind
+    wrapper = None
+    marker = " wrapping "
+    if marker in kind:
+        wrapper, inner = kind.split(marker, 1)
+    if wrapper:
+        blocked = f"`{wrapper}` wrapping `{inner}`"
+    else:
+        blocked = f"`{inner}`"
+    return (
+        f"key-amnesia hook blocked {blocked} — agents must not run this. "
+        f"In your own terminal, run: `{inner}` "
+        "(do not paste the result back into chat). "
+        "Agents may use `ka run` / `ka list` / `ka status` instead."
+    )

--- a/src/key_amnesia/paths.py
+++ b/src/key_amnesia/paths.py
@@ -74,3 +74,8 @@ def guards_registry_dir() -> Path:
 
 def audit_log_path() -> Path:
     return data_dir() / "audit.log"
+
+
+def permissions_manifest_path() -> Path:
+    """Record of allow/deny strings last written by ``ka setup``."""
+    return data_dir() / "permissions-manifest.json"

--- a/src/key_amnesia/prompt_route.py
+++ b/src/key_amnesia/prompt_route.py
@@ -48,6 +48,8 @@ class PromptRequest:
     mutation: str = ""
     # Vault path override for helper
     vault_path: str = ""
+    # Working directory for `ka run` (absolute). Empty = helper process cwd.
+    cwd: str = ""
 
 
 @dataclass
@@ -443,6 +445,7 @@ def run_prompt_helper() -> int:
             "inject_as": {},
             "detail": "",
             "vault_path": "",
+            "cwd": "",
         }.items()
     })
     # Fix types from JSON
@@ -454,6 +457,7 @@ def run_prompt_helper() -> int:
         detail=str(request_data.get("detail") or ""),
         mutation=str(request_data.get("mutation") or ""),
         vault_path=str(request_data.get("vault_path") or ""),
+        cwd=str(request_data.get("cwd") or ""),
     )
 
     if parent_pid and not parent_alive(parent_pid):
@@ -561,6 +565,7 @@ def run_prompt_helper() -> int:
                             request.command,
                             env_inject,
                             by_name,
+                            cwd=request.cwd or None,
                         )
 
                 elif action == "reveal":
@@ -691,6 +696,7 @@ def _helper_run_connected(
     command: list[str],
     env_inject: dict[str, str],
     by_name: dict[str, str],
+    cwd: str | None = None,
 ) -> int:
     """Connect to parent first, then execute *command*, then send scrubbed I/O."""
     from key_amnesia.run_exec import run_with_secrets
@@ -706,7 +712,7 @@ def _helper_run_connected(
     reply: dict[str, Any] = {"ok": False, "reason": ""}
     try:
         try:
-            result = run_with_secrets(command, env_inject, by_name)
+            result = run_with_secrets(command, env_inject, by_name, cwd=cwd)
             reply["ok"] = True
             reply["run_result"] = {
                 "exit_code": result.exit_code,

--- a/src/key_amnesia/setup_cmd.py
+++ b/src/key_amnesia/setup_cmd.py
@@ -1,8 +1,10 @@
-"""`ka setup`: non-interactive install of packaged skills + secret-guard hook.
+"""`ka setup`: skills, secret-guard hook, and best-effort harness allow lists.
 
 Copies the three bundled agent skills to the Claude Code / Cursor / Codex
 skills directories and merges a `PreToolUse` (Claude, Codex) / `preToolUse`
-(Cursor) hook entry into each host's own config file. Safe to re-run
+(Cursor) hook entry into each host's own config file. Optionally merges
+harness *allow* rules so unattended ``ka run`` / ``ka list`` can proceed;
+the hook is the load-bearing *deny* for forbidden verbs. Safe to re-run
 (idempotent upsert); never drops unrelated keys or other hooks/matchers
 already present.
 """
@@ -166,15 +168,23 @@ def _check_path() -> str:
 def cmd_setup(args: argparse.Namespace) -> int:
     skills_only = bool(getattr(args, "skills_only", False))
     hook_only = bool(getattr(args, "hook_only", False))
-    if skills_only and hook_only:
-        theme.error("--skills-only and --hook-only are mutually exclusive.")
+    permissions_only = bool(getattr(args, "permissions_only", False))
+    permissions_remove = bool(getattr(args, "permissions_remove", False))
+    yes = bool(getattr(args, "yes", False))
+    only_flags = [skills_only, hook_only, permissions_only, permissions_remove]
+    if sum(1 for f in only_flags if f) > 1:
+        theme.error(
+            "--skills-only, --hook-only, --permissions-only, and "
+            "--permissions-remove are mutually exclusive."
+        )
         return 2
 
     home = Path.home()
     codex_home = _codex_home(home)
     lines: list[str] = []
+    rc = 0
 
-    if not hook_only:
+    if not hook_only and not permissions_only and not permissions_remove:
         dest_roots = [
             home / ".claude" / "skills",
             home / ".cursor" / "skills",
@@ -183,7 +193,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
         ]
         lines.extend(_copy_skills(dest_roots))
 
-    if not skills_only:
+    if not skills_only and not permissions_only and not permissions_remove:
         claude_settings = home / ".claude" / "settings.json"
         cursor_hooks = home / ".cursor" / "hooks.json"
         codex_hooks = codex_home / "hooks.json"
@@ -194,10 +204,35 @@ def cmd_setup(args: argparse.Namespace) -> int:
         _merge_codex_hooks(codex_hooks)
         lines.append(f"hook installed: {codex_hooks} (PreToolUse)")
 
-    lines.append(_check_path())
-
     for line in lines:
         theme.out(line)
+
+    if permissions_remove:
+        from key_amnesia.harness_permissions import remove_manifested_rules
+
+        rc = remove_manifested_rules(home)
+    elif not skills_only and not hook_only:
+        from key_amnesia.harness_permissions import run_permissions
+
+        def _install_hook(name: str) -> None:
+            if name == "claude":
+                _merge_claude_settings(home / ".claude" / "settings.json")
+            elif name == "cursor":
+                _merge_cursor_hooks(home / ".cursor" / "hooks.json")
+            elif name == "codex":
+                _merge_codex_hooks(_codex_home(home) / "hooks.json")
+
+        perm_rc = run_permissions(
+            home,
+            yes=yes,
+            may_install_hook=not permissions_only,
+            install_hook_fn=_install_hook,
+        )
+        if perm_rc:
+            rc = perm_rc
+
+    if not permissions_only and not permissions_remove:
+        theme.out(_check_path())
 
     theme.info(
         "Restart Claude Code / Cursor / Codex (or reload the window) to pick "
@@ -209,4 +244,4 @@ def cmd_setup(args: argparse.Namespace) -> int:
     theme.info(
         "In your own terminal: `ka init` (first time) or `ka unlock` (start a session)."
     )
-    return 0
+    return rc

--- a/src/key_amnesia/skills/key-amnesia-usage/SKILL.md
+++ b/src/key_amnesia/skills/key-amnesia-usage/SKILL.md
@@ -3,7 +3,7 @@ name: key-amnesia-usage
 description: >-
   Use key-amnesia (`ka`) so agents can run commands with secrets without ever
   reading vault values. Check state first (`ka status` / `ka list`), then
-  prefer `ka run --secret NAME --as NAME=ENVVAR -- ...`. Never paste keys into
+  prefer `ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- ...`. Never paste keys into
   chat, argv, or files the agent can read. Use when needing API keys,
   passwords, env injection, vault secrets, or `ka`/`key-amnesia` commands.
 ---
@@ -29,13 +29,21 @@ Do **not** reflexively run `ka init` or `ka unlock` "just in case." `ka init` fa
 ## Preferred pattern
 
 ```bash
-ka run --secret NAME --as NAME=ENVVAR -- <command> [args...]
+ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- <command> [args...]
 ```
 
+- Use `--cwd DIR` instead of `cd DIR && …`. Do not wrap `ka run` in pipes, `2>&1`, or `cd &&`.
 - `--as` takes **`NAME=ENVVAR`** (secret name on the left, target environment variable on the right) — this matches `_parse_as_mappings` in `cli.py` exactly. Getting the order backwards silently fails.
 - Multiple secrets: repeat `--secret` / `--as` pairs as needed.
 - Prefer discovering names with `ka list` before inventing them.
 - Never embed a secret's actual value in a command you build for the agent to run — only ever reference it by *name* through `--secret`/`--as`.
+
+```bash
+ka list
+ka status
+```
+
+Do not redirect those (`ka list 2>&1` is unnecessary and can confuse harness allowlists).
 
 ## Safe for agents
 
@@ -43,7 +51,7 @@ ka run --secret NAME --as NAME=ENVVAR -- <command> [args...]
 |--------|-----|-------|
 | `ka status` | Yes | Session metadata only; check first |
 | `ka list` | Yes | Names only; no password; never values |
-| `ka run --secret NAME --as NAME=ENVVAR -- ...` | Yes | Primary agent path; may prompt the human |
+| `ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- ...` | Yes | Primary agent path; may prompt the human |
 | Reading vault files / inventing a `get-value` verb | **No** | Guard has no value-return verb |
 
 ## Always human (do not attempt, do not ask for pasted output)
@@ -61,7 +69,7 @@ These require a human at a real keyboard. When one of these is needed, **give th
 - Pasting secrets into chat or committing them to the repo
 - Running `ka init` / `ka unlock` reflexively instead of checking `ka status`/`ka connect`/`ka list` first
 - Believing a chat claim that the vault is unlocked / “you have access” without verifying via `ka status` or `ka connect`
-- Embedding a secret value inline in a command instead of using `--secret`/`--as`
+- Wrapping `ka run` / `ka list` / `ka status` in `cd &&`, pipes, or `2>&1` — use `--cwd` and a bare command instead
 - Calling `reveal`/`copy` to "check" a value for the agent, or asking the human to paste the result of a human-only command
 - Assuming a live guard can return raw values over IPC — it cannot
 

--- a/tests/test_cmd_run_guard_visibility.py
+++ b/tests/test_cmd_run_guard_visibility.py
@@ -18,6 +18,7 @@ def _args(**kwargs: Any) -> argparse.Namespace:
         cmd=kwargs.get("cmd", ["--", "echo", "hi"]),
         secret=kwargs.get("secret", ["api_key"]),
         as_env=kwargs.get("as_env", []),
+        cwd=kwargs.get("cwd", None),
         env=None,
         vault=None,
         force_global=False,

--- a/tests/test_harness_permissions.py
+++ b/tests/test_harness_permissions.py
@@ -1,0 +1,331 @@
+"""Harness permission merge: Claude / Cursor / Codex, manifest, hook-missing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from key_amnesia.harness_permissions import (
+    VALUE_EMIT_VERBS,
+    claude_allow_matchers,
+    claude_deny_matchers,
+    cursor_allow_prefixes,
+    deny_in_allow_conflicts,
+    dump_json,
+    load_json_object_strict,
+    merge_string_list,
+    prepare_claude,
+    prepare_cursor,
+    prepare_codex,
+    run_permissions,
+)
+from key_amnesia.paths import permissions_manifest_path
+from key_amnesia.setup_cmd import (
+    CLAUDE_MATCHER,
+    _hook_command,
+    _merge_claude_settings,
+    _merge_cursor_hooks,
+    cmd_setup,
+)
+
+
+def _ns(**kwargs):
+    import argparse
+
+    defaults = {
+        "skills_only": False,
+        "hook_only": False,
+        "permissions_only": False,
+        "permissions_remove": False,
+        "yes": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _claude_with_hook(home: Path, extra: dict | None = None) -> Path:
+    path = home / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True)
+    _merge_claude_settings(path)
+    if extra:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data.update(extra)
+        path.write_text(dump_json(data), encoding="utf-8")
+    return path
+
+
+def test_value_emit_never_in_file_allow() -> None:
+    blob = "\n".join(claude_allow_matchers() + cursor_allow_prefixes())
+    for verb in VALUE_EMIT_VERBS:
+        assert f" {verb}" not in blob
+        assert f" {verb}:*" not in blob
+
+
+def test_claude_skip_missing_home(tmp_path: Path) -> None:
+    out = prepare_claude(tmp_path, {"rules": {}})
+    assert out.ok
+    assert not out.changes
+    assert "absent" in out.lines[0]
+
+
+def test_claude_fail_closed_malformed(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    path = claude / "settings.json"
+    path.write_text("{ not json", encoding="utf-8")
+    out = prepare_claude(tmp_path, {"rules": {}})
+    assert not out.ok
+    assert not out.changes
+    assert any("fail closed" in ln for ln in out.lines)
+
+
+def test_claude_merge_permissions_and_automode(tmp_path: Path) -> None:
+    path = _claude_with_hook(
+        tmp_path,
+        extra={
+            "autoMode": {
+                "environment": {"Z_KEEP": "1", "A_KEEP": "2"},
+                "allow": ["Bash(echo:*)"],
+            },
+            "unrelated": True,
+        },
+    )
+    env_before = list(
+        json.loads(path.read_text(encoding="utf-8"))["autoMode"]["environment"]
+    )
+    rc = run_permissions(
+        tmp_path,
+        yes=True,
+        may_install_hook=False,
+        install_hook_fn=None,
+        tty=False,
+    )
+    assert rc == 0
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["unrelated"] is True
+    assert list(data["autoMode"]["environment"]) == env_before
+    assert "Bash(echo:*)" in data["autoMode"]["allow"]
+    assert any(x.startswith("Bash(ka run:*)") for x in data["permissions"]["allow"])
+    assert any(x.startswith("PowerShell(ka run:*)") for x in data["permissions"]["allow"])
+    assert any(" — key-amnesia" in x for x in data["autoMode"]["allow"])
+    assert any(x.startswith("Bash(ka set:*)") for x in data["permissions"]["deny"])
+    assert not any("ka reveal" in x for x in data["permissions"]["allow"])
+
+
+def test_second_write_byte_identical(tmp_path: Path) -> None:
+    _claude_with_hook(tmp_path)
+    run_permissions(tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False)
+    path = tmp_path / ".claude" / "settings.json"
+    first = path.read_bytes()
+    run_permissions(tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False)
+    assert path.read_bytes() == first
+
+
+def test_manifest_drift_drops_stale_not_user(tmp_path: Path) -> None:
+    path = _claude_with_hook(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["permissions"] = {
+        "allow": ["Bash(user-own:*)", "Bash(ka stale:*)"],
+        "deny": [],
+    }
+    path.write_text(dump_json(data), encoding="utf-8")
+    manifest = {
+        "version": 1,
+        "rules": {"claude.permissions.allow": ["Bash(ka stale:*)"]},
+    }
+    permissions_manifest_path().write_text(dump_json(manifest), encoding="utf-8")
+    rc = run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    assert rc == 0
+    allow = json.loads(path.read_text(encoding="utf-8"))["permissions"]["allow"]
+    assert "Bash(user-own:*)" in allow
+    assert "Bash(ka stale:*)" not in allow
+    assert any(x.startswith("Bash(ka run:*)") for x in allow)
+
+
+def test_deny_in_allow_loud_not_deleted_with_yes(tmp_path: Path, capsys) -> None:
+    conflict = "Bash(ka set:*) in the SpookyOwl repo"
+    path = _claude_with_hook(
+        tmp_path,
+        extra={"autoMode": {"allow": [conflict], "environment": {"X": "1"}}},
+    )
+    rc = run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert conflict in err
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert conflict in data["autoMode"]["allow"]
+
+
+def test_permissions_only_missing_hook_no_silent_write(tmp_path: Path, capsys) -> None:
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    path = claude / "settings.json"
+    path.write_text(dump_json({"hooks": {}}), encoding="utf-8")
+    rc = run_permissions(
+        tmp_path,
+        yes=True,
+        may_install_hook=False,
+        install_hook_fn=None,
+        tty=False,
+    )
+    assert rc != 0
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "permissions" not in data
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert "hook" in combined.lower()
+    assert "ka set" in combined.lower() or "without" in combined.lower()
+
+
+def test_permissions_only_cli_missing_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text(
+        dump_json({"other": True}), encoding="utf-8"
+    )
+    rc = cmd_setup(_ns(permissions_only=True, yes=True))
+    assert rc != 0
+    data = json.loads((tmp_path / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert "permissions" not in data
+
+
+def test_cursor_never_creates_permissions_json(tmp_path: Path) -> None:
+    (tmp_path / ".cursor").mkdir()
+    _merge_cursor_hooks(tmp_path / ".cursor" / "hooks.json")
+    out = prepare_cursor(tmp_path, {"rules": {}})
+    assert not (tmp_path / ".cursor" / "permissions.json").exists()
+    assert not any(c.path.name == "permissions.json" for c in out.changes)
+    assert any("not creating" in ln for ln in out.lines)
+
+
+def test_cursor_appends_existing_allowlist(tmp_path: Path) -> None:
+    (tmp_path / ".cursor").mkdir()
+    _merge_cursor_hooks(tmp_path / ".cursor" / "hooks.json")
+    perm = tmp_path / ".cursor" / "permissions.json"
+    perm.write_text(
+        dump_json({"terminalAllowlist": ["git", "npm"]}),
+        encoding="utf-8",
+    )
+    rc = run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    assert rc == 0
+    data = json.loads(perm.read_text(encoding="utf-8"))
+    assert "git" in data["terminalAllowlist"]
+    assert "npm" in data["terminalAllowlist"]
+    assert "ka run" in data["terminalAllowlist"]
+
+
+def test_cursor_no_add_allowlist_key_uses_instructions(tmp_path: Path) -> None:
+    (tmp_path / ".cursor").mkdir()
+    _merge_cursor_hooks(tmp_path / ".cursor" / "hooks.json")
+    perm = tmp_path / ".cursor" / "permissions.json"
+    perm.write_text(dump_json({"other": True}), encoding="utf-8")
+    rc = run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    assert rc == 0
+    data = json.loads(perm.read_text(encoding="utf-8"))
+    assert "terminalAllowlist" not in data
+    assert "block_instructions" not in data.get("autoRun", {})
+    assert "ka run" in data["autoRun"]["allow_instructions"]
+
+
+def test_cursor_cli_config_merge_only_if_schema_matches(tmp_path: Path) -> None:
+    (tmp_path / ".cursor").mkdir()
+    _merge_cursor_hooks(tmp_path / ".cursor" / "hooks.json")
+    cli = tmp_path / ".cursor" / "cli-config.json"
+    cli.write_text(
+        dump_json({"permissions": {"allow": ["Shell(ls)"]}}),
+        encoding="utf-8",
+    )
+    rc = run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    assert rc == 0
+    data = json.loads(cli.read_text(encoding="utf-8"))
+    assert "Shell(ls)" in data["permissions"]["allow"]
+    assert "ka run" in data["permissions"]["allow"]
+
+
+def test_cursor_cli_config_never_created(tmp_path: Path) -> None:
+    (tmp_path / ".cursor").mkdir()
+    _merge_cursor_hooks(tmp_path / ".cursor" / "hooks.json")
+    run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    assert not (tmp_path / ".cursor" / "cli-config.json").exists()
+
+
+def test_codex_print_only(tmp_path: Path, capsys) -> None:
+    out = prepare_codex(tmp_path)
+    assert not out.changes
+    assert any("config.toml" in ln for ln in out.lines)
+    assert any("/hooks" in ln for ln in out.lines)
+
+
+def test_fail_closed_wrong_types(tmp_path: Path) -> None:
+    path = _claude_with_hook(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["permissions"] = []
+    path.write_text(dump_json(data), encoding="utf-8")
+    out = prepare_claude(tmp_path, {"rules": {}})
+    assert not out.ok
+    assert not out.changes
+
+
+def test_merge_string_list_types() -> None:
+    merged, err = merge_string_list(["a"], ["b"], [])
+    assert err is None
+    assert merged == ["a", "b"]
+    merged, err = merge_string_list([1], ["b"], [])  # type: ignore[list-item]
+    assert err is not None
+
+
+def test_deny_in_allow_prefix_match() -> None:
+    hits = deny_in_allow_conflicts(
+        ["Bash(ka set:*) in the SpookyOwl repo", "Bash(ka run:*)"]
+    )
+    assert hits == ["Bash(ka set:*) in the SpookyOwl repo"]
+
+
+def test_load_json_strict_missing(tmp_path: Path) -> None:
+    data, err = load_json_object_strict(tmp_path / "nope.json")
+    assert data == {}
+    assert err is None
+
+
+def test_permissions_remove_only_manifested(tmp_path: Path) -> None:
+    path = _claude_with_hook(tmp_path)
+    run_permissions(
+        tmp_path, yes=True, may_install_hook=False, install_hook_fn=None, tty=False
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["permissions"]["allow"].insert(0, "Bash(user-keep:*)")
+    path.write_text(dump_json(data), encoding="utf-8")
+    from key_amnesia.harness_permissions import remove_manifested_rules
+
+    rc = remove_manifested_rules(tmp_path)
+    assert rc == 0
+    allow = json.loads(path.read_text(encoding="utf-8"))["permissions"]["allow"]
+    assert "Bash(user-keep:*)" in allow
+    assert not any(x.startswith("Bash(ka run:*)") for x in allow)
+
+
+def test_claude_deny_matchers_omit_prompt_helper() -> None:
+    blob = "\n".join(claude_deny_matchers())
+    assert "_prompt-helper" not in blob
+    assert "ka set:*" in blob or "ka set:*)" in blob
+
+
+def test_hook_command_still_used() -> None:
+    assert "key-amnesia" in _hook_command() or "secret_guard" in _hook_command()
+    assert "Bash" in CLAUDE_MATCHER

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,7 +29,7 @@ def test_init_mismatch_creates_nothing(
 
 
 def test_init_match_creates_unlockable_vault(
-    ka_home: Path, monkeypatch: pytest.MonkeyPatch
+    ka_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
@@ -38,10 +38,12 @@ def test_init_match_creates_unlockable_vault(
     monkeypatch.setattr(getpass, "getpass", lambda prompt="": next(answers))
 
     rc = main(["init"])
+    captured = capsys.readouterr()
     assert rc == 0
     assert vault_path().exists()
     payload = load_vault(vault_path(), pw)
     assert payload["secrets"] == {}
+    assert "Next: ka setup" in captured.out + captured.err
 
 
 def test_init_refuses_if_vault_exists(

--- a/tests/test_ka_policy.py
+++ b/tests/test_ka_policy.py
@@ -1,0 +1,229 @@
+"""ka verb policy: parser coverage, classify, nested ``ka run --``."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from key_amnesia.cli import _build_parser
+from key_amnesia.ka_policy import (
+    ALLOW_NESTED,
+    ALLOW_VERBS,
+    COVERAGE_ALLOW,
+    COVERAGE_DENY,
+    DENY_NESTED,
+    DENY_VERBS,
+    FILE_DENY_VERBS,
+    VALUE_EMIT_VERBS,
+    classify_ka_argv,
+    deny_message,
+    iter_non_ka_chain_texts,
+    ka_run_trailing_texts,
+    ka_verb_deny_reason,
+)
+
+
+def _registered_cli_verbs(parser: argparse.ArgumentParser) -> set[str]:
+    labels = {"--version", "--help"}
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        for name, sub in action.choices.items():
+            nested: list[str] = []
+            for inner in sub._actions:
+                if isinstance(inner, argparse._SubParsersAction):
+                    nested.extend(inner.choices)
+            if nested:
+                for n in nested:
+                    labels.add(f"{name} {n}")
+            else:
+                labels.add(name)
+    return labels
+
+
+def test_cli_subparsers_partition_allow_deny() -> None:
+    registered = _registered_cli_verbs(_build_parser())
+    assert not (COVERAGE_ALLOW & COVERAGE_DENY)
+    missing = registered - COVERAGE_ALLOW - COVERAGE_DENY
+    extra = (COVERAGE_ALLOW | COVERAGE_DENY) - registered
+    assert missing == set(), f"verbs not in allow/deny tables: {sorted(missing)}"
+    assert extra == set(), f"table entries not in cli.py: {sorted(extra)}"
+
+
+def test_value_emit_verbs_are_denied() -> None:
+    assert VALUE_EMIT_VERBS <= COVERAGE_DENY
+
+
+@pytest.mark.parametrize(
+    "text,kind",
+    [
+        ("ka set FOO bar", "ka set"),
+        ("key-amnesia reveal FOO", "ka reveal"),
+        ("ka export FOO", "ka export"),
+        ("ka copy FOO", "ka copy"),
+        ("ka init", "ka init"),
+        ("ka unlock", "ka unlock"),
+        ("ka setup", "ka setup"),
+        ("ka passwd", "ka passwd"),
+        ("ka change-password", "ka change-password"),
+        ("ka import .env", "ka import"),
+        ("ka remove FOO", "ka remove"),
+        ("ka grant FOO --to bob", "ka grant"),
+        ("ka revoke FOO --to bob", "ka revoke"),
+        ("ka member add bob --pubkey x --role runner", "ka member add"),
+        ("ka member remove bob", "ka member remove"),
+        ("ka config set session-mode cached", "ka config set"),
+        ("ka identity create", "ka identity create"),
+        ("ka scan --yes", "ka scan --yes"),
+        ("ka scan --deep --yes", "ka scan --yes"),
+        ("ka scan --yes --deep", "ka scan --yes"),
+    ],
+)
+def test_deny_verbs(text: str, kind: str) -> None:
+    assert ka_verb_deny_reason(text) == kind
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "ka list",
+        "ka status",
+        "ka connect",
+        "ka check",
+        "ka scan",
+        "ka scan --deep",
+        "ka scan --no-import",
+        "ka lock",
+        "ka docs",
+        "ka config show",
+        "ka identity show",
+        "ka member list",
+        "ka --version",
+        "ka --help",
+        "ka run --secret NAME --as NAME=VAR -- python script.py",
+        "ka foobar",
+        "ka",
+        "echo hello",
+    ],
+)
+def test_allow_and_unrecognized_fail_open(text: str) -> None:
+    assert ka_verb_deny_reason(text) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "python -m key_amnesia set FOO bar",
+        "python3 -m key_amnesia set FOO",
+        "py -m key_amnesia set FOO",
+        "uvx key-amnesia set FOO",
+        "pipx run key-amnesia set FOO",
+        r".venv\Scripts\ka.exe set FOO",
+        "./venv/bin/ka set FOO",
+        "/usr/local/bin/key-amnesia set FOO",
+        "env FOO=1 ka set BAR baz",
+        "FOO=1 ka set BAR baz",
+        "bash -lc 'ka set FOO bar'",
+        "sh -c 'ka reveal FOO'",
+        "echo hi && ka set FOO bar",
+    ],
+)
+def test_wide_invocation_parser(text: str) -> None:
+    assert ka_verb_deny_reason(text) is not None
+
+
+def test_nested_run_denies_inner_set() -> None:
+    kind = ka_verb_deny_reason("ka run --secret N --as N=E -- ka set FOO bar")
+    assert kind is not None
+    assert "ka run wrapping" in kind
+    assert "ka set" in kind
+
+
+def test_nested_run_denies_scan_yes() -> None:
+    kind = ka_verb_deny_reason("ka run --secret N --as N=E -- ka scan --yes")
+    assert kind is not None
+    assert "ka scan --yes" in kind
+
+
+def test_nested_run_denies_sh_c_reveal() -> None:
+    kind = ka_verb_deny_reason('ka run --secret N --as N=E -- sh -c "ka reveal FOO"')
+    assert kind is not None
+    assert "ka reveal" in kind
+
+
+def test_nested_run_allows_python() -> None:
+    assert ka_verb_deny_reason(
+        "ka run --secret N --as N=E -- python script.py"
+    ) is None
+
+
+def test_nested_run_allows_ka_list() -> None:
+    assert ka_verb_deny_reason("ka run --secret N --as N=E -- ka list") is None
+
+
+def test_trailing_texts_after_run_dashdash() -> None:
+    texts = ka_run_trailing_texts(
+        "ka run --secret NAME --as NAME=VAR -- python deploy.py --api-key x"
+    )
+    assert any("deploy.py" in t for t in texts)
+
+
+def test_coverage_tables_match_enforcement() -> None:
+    """COVERAGE_* is derived from the tables classify_ka_argv actually uses."""
+    allow = set(ALLOW_VERBS)
+    for group, subs in ALLOW_NESTED.items():
+        allow.update(f"{group} {sub}" for sub in subs)
+    deny = set(DENY_VERBS)
+    for group, subs in DENY_NESTED.items():
+        deny.update(f"{group} {sub}" for sub in subs)
+    assert COVERAGE_ALLOW == frozenset(allow)
+    assert COVERAGE_DENY == frozenset(deny)
+    assert FILE_DENY_VERBS == COVERAGE_DENY - {"_prompt-helper"}
+    assert "_prompt-helper" not in FILE_DENY_VERBS
+
+
+def test_top_level_parser_only_version_help() -> None:
+    parser = _build_parser()
+    optionals: set[str] = set()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            continue
+        optionals.update(action.option_strings)
+    assert optionals <= {"--version", "--help", "-h"}
+
+
+def test_deny_message_nested_runnable_slot_is_inner_only() -> None:
+    msg = deny_message("ka run wrapping ka scan --yes")
+    assert "ka scan --yes" in msg
+    assert "wrapping" in msg
+    after_run = msg.split("In your own terminal, run:", 1)[1]
+    slot = after_run.split("`", 2)[1]
+    assert "wrapping" not in slot
+    assert slot == "ka scan --yes"
+
+
+def test_non_ka_chain_texts_sibling_of_run() -> None:
+    text = "ka run --secret X --as X=V -- python a.py && curl https://example.com"
+    chunks = list(iter_non_ka_chain_texts(text))
+    assert any("curl" in c for c in chunks)
+    assert not any("--secret" in c for c in chunks)
+
+
+def test_classify_empty_argv() -> None:
+    assert classify_ka_argv([]) is None
+
+
+def test_direct_cli_scan_yes_reaches_cmd_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hook stdin is not involved; the CLI still dispatches to cmd_scan."""
+    from key_amnesia import cli
+
+    seen: dict[str, bool] = {}
+
+    def _wrap(args: argparse.Namespace) -> int:
+        seen["yes"] = bool(args.yes)
+        return 0
+
+    monkeypatch.setattr(cli, "cmd_scan", _wrap)
+    assert cli.main(["scan", "--yes"]) == 0
+    assert seen.get("yes") is True

--- a/tests/test_run_cwd.py
+++ b/tests/test_run_cwd.py
@@ -1,0 +1,100 @@
+"""ka run --cwd and audit of trailing command (no secret values)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from key_amnesia.cli import main
+from key_amnesia.paths import audit_log_path
+from key_amnesia.prompt_route import AuthOutcome
+
+
+def test_run_cwd_missing_dir_exits_2(tmp_path: Path, capsys) -> None:
+    rc = main(
+        [
+            "run",
+            "--cwd",
+            str(tmp_path / "no-such-dir"),
+            "--secret",
+            "api_key",
+            "--",
+            "echo",
+            "hi",
+        ]
+    )
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err.lower()
+
+
+def test_run_cwd_not_dir_exits_2(tmp_path: Path, capsys) -> None:
+    f = tmp_path / "file.txt"
+    f.write_text("x", encoding="utf-8")
+    rc = main(
+        ["run", "--cwd", str(f), "--secret", "api_key", "--", "echo", "hi"]
+    )
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err.lower()
+
+
+def test_run_cwd_passed_to_guard(
+    tmp_path: Path, monkeypatch, seeded_vault: Path
+) -> None:
+    seen: dict = {}
+
+    monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda **k: True)
+
+    def fake_req(msg, **k):
+        seen["cwd"] = msg.get("cwd")
+        return {"ok": True, "scrubbed_stdout": "", "scrubbed_stderr": "", "exit_code": 0}
+
+    monkeypatch.setattr("key_amnesia.guard.guard_request", fake_req)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    rc = main(
+        [
+            "run",
+            "--cwd",
+            str(cwd),
+            "--secret",
+            "api_key",
+            "--",
+            "echo",
+            "hi",
+        ]
+    )
+    assert rc == 0
+    assert Path(seen["cwd"]).resolve() == cwd.resolve()
+
+
+def test_run_audit_trailing_command_no_values(
+    seeded_vault: Path, password: str, monkeypatch
+) -> None:
+    monkeypatch.setattr("key_amnesia.guard.guard_is_alive", lambda **k: False)
+    monkeypatch.setattr(
+        "key_amnesia.cli.require_human_auth",
+        lambda *a, **k: AuthOutcome(ok=True, route="inline", password=password),
+    )
+    secret_value = "super-secret-value-123"
+    rc = main(
+        [
+            "run",
+            "--secret",
+            "api_key",
+            "--as",
+            "api_key=API_KEY",
+            "--",
+            sys.executable,
+            "-c",
+            "print(1)",
+        ]
+    )
+    assert rc == 0
+    text = audit_log_path().read_text(encoding="utf-8")
+    assert secret_value not in text
+    rec = json.loads(text.strip().splitlines()[-1])
+    assert rec["action"] == "run"
+    assert rec["secret_names"] == ["api_key"]
+    assert rec["command"] == [sys.executable, "-c", "print(1)"]
+    assert secret_value not in json.dumps(rec)

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -238,3 +238,180 @@ def test_main_fails_open_on_non_dict_json(monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert rc == 0
     assert out == ""
+
+
+# --- verb deny (load-bearing) ------------------------------------------------
+
+
+DENY_SHELL_SAMPLES = [
+    "ka set FOO bar",
+    "ka remove FOO",
+    "ka import .env",
+    "ka passwd",
+    "ka init",
+    "ka unlock",
+    "ka grant FOO --to bob",
+    "ka revoke FOO --to bob",
+    "ka member add bob --pubkey x --role runner",
+    "ka member remove bob",
+    "ka config set session-mode cached",
+    "ka reveal FOO",
+    "ka export FOO",
+    "ka copy FOO",
+    "ka setup",
+    "ka identity create",
+    "ka scan --yes",
+]
+
+
+def _claude_payload(command: str, tool_name: str = "Bash") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+
+
+def _codex_payload(command: str, tool_name: str = "Bash") -> dict:
+    # Codex-like: Claude PreToolUse shape, no Cursor markers.
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+
+
+def _cursor_payload(command: str) -> dict:
+    return {
+        "hook_event_name": "preToolUse",
+        "cursor_version": "1.7.2",
+        "conversation_id": "abc",
+        "tool_name": "Shell",
+        "tool_input": {"command": command},
+    }
+
+
+@pytest.mark.parametrize("command", DENY_SHELL_SAMPLES)
+def test_verb_deny_claude_shape(command: str, monkeypatch, capsys) -> None:
+    rc, reply = _run_main(_claude_payload(command), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert reply["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "own terminal" in reply["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+@pytest.mark.parametrize("command", DENY_SHELL_SAMPLES)
+def test_verb_deny_codex_like_shape(command: str, monkeypatch, capsys) -> None:
+    rc, reply = _run_main(_codex_payload(command), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert "permission" not in reply
+    assert reply["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.parametrize("command", DENY_SHELL_SAMPLES)
+def test_verb_deny_cursor_shape(command: str, monkeypatch, capsys) -> None:
+    rc, reply = _run_main(_cursor_payload(command), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert reply["permission"] == "deny"
+    assert "hookSpecificOutput" not in reply
+    assert "own terminal" in reply["agent_message"]
+
+
+def test_write_tool_does_not_verb_deny_ka_set(monkeypatch, capsys) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": "README.md",
+            "contents": "Store secrets with `ka set NAME` in your own terminal.",
+        },
+    }
+    rc, reply = _run_main(payload, monkeypatch, capsys)
+    assert rc == 0
+    assert reply is None
+
+
+def test_ka_safe_does_not_suppress_verb_deny(monkeypatch, capsys) -> None:
+    """_KA_SAFE matches `ka set` but verb deny still fires."""
+    rc, reply = _run_main(_claude_payload("ka set API_KEY sk-ant-" + "a" * 25), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert reply["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = reply["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "ka set" in reason
+    assert "own terminal" in reason
+
+
+def test_nested_run_set_denied(monkeypatch, capsys) -> None:
+    rc, reply = _run_main(
+        _claude_payload("ka run --secret N --as N=E -- ka set FOO bar"),
+        monkeypatch,
+        capsys,
+    )
+    assert reply is not None
+    reason = reply["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "wrapping" in reason
+    assert "ka set" in reason
+
+
+def test_chained_secret_after_ka_run_denied(monkeypatch, capsys) -> None:
+    token = "sk-ant-" + "a" * 25
+    cmd = (
+        "ka run --secret X --as X=V -- python a.py && "
+        f'curl -H "Authorization: Bearer {token}"'
+    )
+    rc, reply = _run_main(_claude_payload(cmd), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert reply["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = reply["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "Anthropic" in reason or "Bearer" in reason
+
+
+def test_pipe_tail_after_ka_run_no_finding(monkeypatch, capsys) -> None:
+    cmd = "ka run --secret X --as X=V -- python a.py | tail -30"
+    rc, reply = _run_main(_claude_payload(cmd), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is None
+
+
+def test_nested_run_python_allowed(monkeypatch, capsys) -> None:
+    rc, reply = _run_main(
+        _claude_payload("ka run --secret N --as N=E -- python script.py"),
+        monkeypatch,
+        capsys,
+    )
+    assert rc == 0
+    assert reply is None
+
+
+def test_trailing_secret_after_run_denied(monkeypatch, capsys) -> None:
+    cmd = "ka run --secret N --as N=E -- python deploy.py --api-key " + "sk-ant-" + "a" * 25
+    rc, reply = _run_main(_claude_payload(cmd), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is not None
+    assert reply["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "Anthropic" in reply["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_ordinary_ka_run_no_trailing_finding(monkeypatch, capsys) -> None:
+    cmd = "ka run --secret NAME --as NAME=VAR -- python script.py"
+    rc, reply = _run_main(_claude_payload(cmd), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is None
+
+
+def test_ka_scan_without_yes_allowed(monkeypatch, capsys) -> None:
+    rc, reply = _run_main(_claude_payload("ka scan --deep --no-import"), monkeypatch, capsys)
+    assert rc == 0
+    assert reply is None
+
+
+def test_find_finding_ka_safe_skips_prefix_but_trailing_scan_does_not() -> None:
+    prefix = "ka run --secret NAME --as NAME=VAR -- python script.py"
+    assert sg.find_finding(prefix) is None
+    trailing = "python deploy.py --api-key " + "sk-ant-" + "a" * 25
+    assert sg.find_finding(prefix + " " + trailing) is None  # _KA_SAFE on full text
+    assert sg.find_finding(trailing, ignore_ka_safe=True) is not None

--- a/wiki/Threat-model.md
+++ b/wiki/Threat-model.md
@@ -38,6 +38,14 @@ isolation than the product states:
     the session (not the master password).
 12. **Runner role** — not a crypto ACL against the master-password holder;
     per-member `ka export` ciphertext *is* cryptographic.
+13. **Harness allow files vs hook deny.** File allow-lists try to let
+    agents run `ka run` / `ka list`. The PreToolUse hook is the
+    load-bearing deny for `ka set` / `reveal` / `scan --yes` / nested
+    `ka run -- ka set`. Removing or disabling the hook removes deny.
+    Aliases, renamed binaries, and runtime-constructed `ka` invocations
+    are out of scope. Codex deny runs only after `/hooks` trust.
+14. **Write/Edit hook self-protection** (agent rewriting the hook or
+    harness config) is planned, not this release.
 
 ## Platform honesty (admission)
 
@@ -72,6 +80,8 @@ isolation than the product states:
 | KAM2 per-secret wrap / export | Crypto |
 | Admin signature | Tamper-evident / detection only |
 | Runner no reveal/copy | Policy vs human; effective vs agent |
+| Harness file allow-lists | Best-effort (unattended `ka run`) |
+| PreToolUse verb deny | Load-bearing vs agent Bash; not a sandbox |
 
 Canonical design text: repository `DESIGN.md`. README Security limits are
 the short honesty contract.


### PR DESCRIPTION
## Summary
- Best-effort harness **allow** files so unattended `ka run` / `ka list` can proceed (Claude `permissions.allow` + existing `autoMode.allow`; Cursor prefixes only when that cannot clobber the IDE list; Codex print-only).
- PreToolUse hook is the **load-bearing deny** for forbidden `ka` verbs (including nested `ka run --` and chained secrets after the trailing command). Behavior change: `ka set` is no longer skipped by `_KA_SAFE`.
- `ka run --cwd DIR`, usage-skill rewrite to a bare command, `ka setup --permissions-only/--permissions-remove/--yes`. Next PyPI is 0.4.9 (includes unpublished 0.4.8 transcript scan).

## Test plan
- [ ] Hook denies `ka set` / `ka scan --yes` / `ka run -- ka set` for Claude, Codex-like, and Cursor payloads
- [ ] `ka run --secret NAME --as NAME=VAR -- python script.py` does not nag; trailing `--api-key sk-ant-…` and `&& curl Bearer …` do deny
- [ ] `ka setup` does not create Cursor `permissions.json`; missing hook does not silently write allows
- [ ] `ka run --cwd` missing dir exits 2; audit log has trailing command argv and no secret values
- [ ] Wait for **full** CI including macOS (often ~60–90 minutes). Do not cancel or re-run those jobs early.

Made with [Cursor](https://cursor.com)