### PR TITLE
Scan detector fixes and --strict/--wide CLI (0.4.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the git tags `0.4.0` … `0.4.10`.
 
-## [0.4.10] — 2026-08-17
+## [0.4.10] — 2026-08-19
 
 ### Behavior change
 
@@ -120,6 +120,7 @@ Finding counts from ≤0.4.9 are **not comparable**: 0.4.9 counted every hook-th
 
 - Kernel peer-identity admission on macOS remains fail-closed (unchanged). Other non-Win/Linux/Darwin platforms still fail closed.
 
+[0.4.10]: https://github.com/fujitoid/key-amnesia/compare/0.4.7...0.4.10
 [0.4.7]: https://github.com/fujitoid/key-amnesia/compare/0.4.6...0.4.7
 [0.4.6]: https://github.com/fujitoid/key-amnesia/compare/0.4.5...0.4.6
 [0.4.5]: https://github.com/fujitoid/key-amnesia/compare/0.4.4...0.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,20 @@ Versions follow the git tags `0.4.0` … `0.4.10`.
 
 ### Behavior change
 
-- `ka scan` exit 1 now means **high-confidence** findings only (`likely` assignment values, vendor prefixes, and filename hits such as `.env`). Trees that exited 1 on identifier / function-call / doc-assignment hits now exit **0**. Use `ka scan --fail-on possible` to restore the older gate (also the CI opt-in for word-shaped passphrases). Invalid `--fail-on` exits 2.
+- `ka scan` exit 1 follows `--strict` (`certain` / `high` / `paranoid`, default `high`): **certain** is vendor prefixes and confirmed filenames; **likely** is assignment and UUID hits; **possible** is identifier, passphrase, low-transition, and unconfirmed `mcp.json`. Default exit 1 means certain + likely. Trees that exited 1 on identifier / function-call / doc-assignment hits in ≤0.4.9 now exit **0** unless you pass `--strict paranoid` (that is the ≤0.4.9 assignment gate). Invalid `--strict` exits 2.
 
-Finding counts from ≤0.4.9 are **not comparable**: 0.4.9 counted every hook-threshold assignment hit (English identifiers, `token = secrets.token_hex(8)`, this repo’s own typed annotations). The headline is high-confidence only; identifier- and passphrase-shaped hits are a separate `possible_count` (`--json` always; `--show-possible` for human).
+Finding counts from ≤0.4.9 are **not comparable**: 0.4.9 counted every hook-threshold assignment hit (English identifiers, `token = secrets.token_hex(8)`, this repo’s own typed annotations). The three-count summary (`N certain · N likely · N possible`) prints at every strictness; only the listing, exit, and headline number change.
 
 ### Added
 
 - Shared detector module (`key_amnesia.detect`) with explicit tiers: `none` / `possible` / `likely` / `prefix`. Hook still denies `possible|likely|prefix` except function-call and `Name[...]` type-annotation values.
-- `ka scan --fail-on {high,possible}` (default `high`) and `--show-possible`.
+- `ka scan --strict` with values `certain`, `high`, or `paranoid` (default `high`). `--wide` aliases `--include-excluded` and is independent of `--deep`.
 - Quoted-name assignments (`"api_key": "…"`) and JSON key walk for transcripts.
+- Named reasons on findings (`uuid`, `identifier`, `word-shaped-passphrase`, `low-transition`, `unconfirmed-mcp-shape`). Unconfirmed `mcp.json` / `claude_desktop_config.json` demote to possible; they are not dropped.
 
 ### Changed
 
-- Human headline: `N high-confidence LEAK` plus one secondary sentence with the possible count and passphrase caveat — not a path dump of possibles.
+- Human headline: `N LEAKs found (--strict high) — your agent can read N secrets in this project (LEAK = Locally Exposed Agent Keys)`. The gate name is in the headline. The three-count summary is unconditional.
 
 ## [0.4.9] — 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Versions follow the git tags `0.4.0` … `0.4.9`.
+Versions follow the git tags `0.4.0` … `0.4.10`.
+
+## [0.4.10] — 2026-08-17
+
+### Behavior change
+
+- `ka scan` exit 1 now means **high-confidence** findings only (`likely` assignment values, vendor prefixes, and filename hits such as `.env`). Trees that exited 1 on identifier / function-call / doc-assignment hits now exit **0**. Use `ka scan --fail-on possible` to restore the older gate (also the CI opt-in for word-shaped passphrases). Invalid `--fail-on` exits 2.
+
+Finding counts from ≤0.4.9 are **not comparable**: 0.4.9 counted every hook-threshold assignment hit (English identifiers, `token = secrets.token_hex(8)`, this repo’s own typed annotations). The headline is high-confidence only; identifier- and passphrase-shaped hits are a separate `possible_count` (`--json` always; `--show-possible` for human).
+
+### Added
+
+- Shared detector module (`key_amnesia.detect`) with explicit tiers: `none` / `possible` / `likely` / `prefix`. Hook still denies `possible|likely|prefix` except function-call and `Name[...]` type-annotation values.
+- `ka scan --fail-on {high,possible}` (default `high`) and `--show-possible`.
+- Quoted-name assignments (`"api_key": "…"`) and JSON key walk for transcripts.
+
+### Changed
+
+- Human headline: `N high-confidence LEAK` plus one secondary sentence with the possible count and passphrase caveat — not a path dump of possibles.
 
 ## [0.4.9] — 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Finding counts from ≤0.4.9 are **not comparable**: 0.4.9 counted every hook-th
 - Shared detector module (`key_amnesia.detect`) with explicit tiers: `none` / `possible` / `likely` / `prefix`. Hook still denies `possible|likely|prefix` except function-call and `Name[...]` type-annotation values.
 - `ka scan --strict` with values `certain`, `high`, or `paranoid` (default `high`). `--wide` aliases `--include-excluded` and is independent of `--deep`.
 - Quoted-name assignments (`"api_key": "…"`) and JSON key walk for transcripts.
-- Named reasons on findings (`uuid`, `identifier`, `word-shaped-passphrase`, `low-transition`, `unconfirmed-mcp-shape`). Unconfirmed `mcp.json` / `claude_desktop_config.json` demote to possible; they are not dropped.
+- Named reasons on findings (`uuid`, `identifier`, `word-shaped-passphrase`, `low-transition`, `unconfirmed-mcp-shape`). Unconfirmed `mcp.json` / `claude_desktop_config.json` demote to possible; they are not dropped. Unconfirmed MCP is one possible per file, not per top-level key.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ ka init --project                 # or: ka init  for a global vault
 ka import .env                    # move plaintext into the vault (TTY-only; never prints values)
 ka scan                           # find remaining LEAKs (names/paths only)
 ka scan --deep                    # also home/shell/MCP + agent session transcripts
-ka scan --fail-on possible        # also exit 1 on identifier/passphrase-shaped hits
+ka scan --strict paranoid         # also exit 1 on identifier/passphrase-shaped hits
+ka scan --wide                    # include default-excluded dirs (alias of --include-excluded)
 
 ka run --secret API_KEY -- python my_script.py
 ```
 
-`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. The headline and default exit count **high-confidence** findings only (vendor prefixes, likely assignment values, sensitive filenames). Identifier- and word-shaped-passphrase hits are `possible`: they appear as a count in the human report (`--show-possible` to list paths; `--fail-on possible` to gate). Detection is **advisory**. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`.
+`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. The headline names the `--strict` gate (default `high`: certain + likely). Identifier-, passphrase-, and low-transition-shaped hits are `possible`: they appear in the always-printed three-count summary; `--strict paranoid` gates on them (the ≤0.4.9 assignment gate). Detection is **advisory**. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`. `--wide` aliases `--include-excluded` and does not imply `--deep`.
 
 `ka init` asks for the master password twice; if the entries do not match, nothing is created. **There is no recovery** if you forget that password — Argon2id + SecretBox leave none by design.
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ ka init --project                 # or: ka init  for a global vault
 ka import .env                    # move plaintext into the vault (TTY-only; never prints values)
 ka scan                           # find remaining LEAKs (names/paths only)
 ka scan --deep                    # also home/shell/MCP + agent session transcripts
+ka scan --fail-on possible        # also exit 1 on identifier/passphrase-shaped hits
+
 ka run --secret API_KEY -- python my_script.py
 ```
 
-`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. Detection is **advisory** (the same regex + entropy heuristics as the secret-guard hook): false positives and false negatives are expected. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`.
+`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. The headline and default exit count **high-confidence** findings only (vendor prefixes, likely assignment values, sensitive filenames). Identifier- and word-shaped-passphrase hits are `possible`: they appear as a count in the human report (`--show-possible` to list paths; `--fail-on possible` to gate). Detection is **advisory**. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`.
 
 `ka init` asks for the master password twice; if the entries do not match, nothing is created. **There is no recovery** if you forget that password — Argon2id + SecretBox leave none by design.
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ ka scan --deep                    # also home/shell/MCP + agent session transcri
 ka scan --strict paranoid         # also exit 1 on identifier/passphrase-shaped hits
 ka scan --wide                    # include default-excluded dirs (alias of --include-excluded)
 
-ka run --secret API_KEY -- python my_script.py
+ka run --cwd DIR --secret API_KEY -- python my_script.py
 ```
 
-`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. The headline names the `--strict` gate (default `high`: certain + likely). Identifier-, passphrase-, and low-transition-shaped hits are `possible`: they appear in the always-printed three-count summary; `--strict paranoid` gates on them (the ≤0.4.9 assignment gate). Detection is **advisory**. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`. `--wide` aliases `--include-excluded` and does not imply `--deep`.
+`ka scan` reports **names, paths, and counts** (plus line numbers for agent session transcripts under `--deep`). It never prints secret values. The headline names the `--strict` gate (default `high`: **certain** vendor prefixes and confirmed filenames + **likely** assignments/UUID). Identifier-, passphrase-, low-transition, and unconfirmed-`mcp.json` hits are `possible`: they appear in the always-printed three-count summary (`N certain · N likely · N possible`); `--strict paranoid` gates on them (the ≤0.4.9 assignment gate). Detection is **advisory**. `--deep` is not a full home walk — it checks known candidates including Claude Code `~/.claude/projects/**/*.jsonl`, Codex `~/.codex/sessions|archived_sessions/**/rollout-*.jsonl`, and Copilot CLI `~/.copilot/session-state/*/events.jsonl`. `--wide` aliases `--include-excluded` and does not imply `--deep`.
 
 `ka init` asks for the master password twice; if the entries do not match, nothing is created. **There is no recovery** if you forget that password — Argon2id + SecretBox leave none by design.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "key-amnesia"
-version = "0.4.9"
+version = "0.4.10"
 description = "Encrypted secret vault so AI agents can use API keys without seeing them — a drop-in .env replacement"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -211,6 +211,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON instead of human text",
     )
     p_scan.add_argument(
+        "--fail-on",
+        choices=("high", "possible"),
+        default="high",
+        help=(
+            "Exit 1 when this class of findings is present. "
+            "high (default): high-confidence only. "
+            "possible: also fail on identifier/passphrase-shaped hits"
+        ),
+    )
+    p_scan.add_argument(
+        "--show-possible",
+        action="store_true",
+        help=(
+            "Include possible (identifier- or passphrase-shaped) hits in "
+            "the human report. --json always includes them"
+        ),
+    )
+    p_scan.add_argument(
         "--yes",
         action="store_true",
         help=(
@@ -1075,8 +1093,8 @@ def cmd_scan(args: argparse.Namespace) -> int:
     Default exclusions skip ``node_modules``, ``.venv``/``venv``, common
     build dirs, and ``.git`` internals. ``--deep`` adds home/shell/MCP
     paths and known agent session transcript JSONL trees. Never prints
-    secret values. Detection is advisory (regex+entropy). Non-zero exit
-    if any LEAK count > 0.
+    secret values. Headline and default exit count high-confidence
+    findings only; ``--fail-on possible`` restores the older gate.
     Optionally offers to store selected dotenv findings into the project
     vault via the shared ``dotenv_import`` core.
     """
@@ -1095,6 +1113,7 @@ def cmd_scan(args: argparse.Namespace) -> int:
                 seen.add(f.path)
 
     as_json = bool(getattr(args, "json", False))
+    show_possible = bool(getattr(args, "show_possible", False))
     if as_json:
         theme.out(
             json.dumps(
@@ -1106,11 +1125,22 @@ def cmd_scan(args: argparse.Namespace) -> int:
             + "\n"
         )
     else:
-        theme.out(scan_mod.format_human_report(findings, project_root=project_root))
+        theme.out(
+            scan_mod.format_human_report(
+                findings,
+                project_root=project_root,
+                show_possible=show_possible,
+            )
+        )
         theme.out("")
 
     n = scan_mod.leak_count(findings)
-    exit_code = 1 if n > 0 else 0
+    p = scan_mod.possible_count(findings)
+    fail_on = getattr(args, "fail_on", "high") or "high"
+    if fail_on == "possible":
+        exit_code = 1 if (n > 0 or p > 0) else 0
+    else:
+        exit_code = 1 if n > 0 else 0
 
     # JSON / --no-import: report only. Interactive offer otherwise.
     if as_json or getattr(args, "no_import", False):

--- a/src/key_amnesia/cli.py
+++ b/src/key_amnesia/cli.py
@@ -199,10 +199,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_scan.add_argument(
         "--include-excluded",
+        "--wide",
         action="store_true",
+        dest="include_excluded",
         help=(
             "Include default-excluded dirs (node_modules, .venv/venv, build "
-            "dirs, .git internals). Git-history scanning is still out of scope."
+            "dirs, .git internals). --wide is an alias. Git-history scanning "
+            "is still out of scope. Independent of --deep."
         ),
     )
     p_scan.add_argument(
@@ -211,21 +214,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON instead of human text",
     )
     p_scan.add_argument(
-        "--fail-on",
-        choices=("high", "possible"),
+        "--strict",
+        choices=("certain", "high", "paranoid"),
         default="high",
         help=(
-            "Exit 1 when this class of findings is present. "
-            "high (default): high-confidence only. "
-            "possible: also fail on identifier/passphrase-shaped hits"
-        ),
-    )
-    p_scan.add_argument(
-        "--show-possible",
-        action="store_true",
-        help=(
-            "Include possible (identifier- or passphrase-shaped) hits in "
-            "the human report. --json always includes them"
+            "Exit 1 when findings at this gate are present. "
+            "certain: vendor prefixes and confirmed filenames only. "
+            "high (default): certain + likely (assignments/UUID). "
+            "paranoid: also possible (identifier/passphrase/low-transition; "
+            "this is the 0.4.9-and-earlier assignment gate). Invalid value exits 2"
         ),
     )
     p_scan.add_argument(
@@ -1093,8 +1090,9 @@ def cmd_scan(args: argparse.Namespace) -> int:
     Default exclusions skip ``node_modules``, ``.venv``/``venv``, common
     build dirs, and ``.git`` internals. ``--deep`` adds home/shell/MCP
     paths and known agent session transcript JSONL trees. Never prints
-    secret values. Headline and default exit count high-confidence
-    findings only; ``--fail-on possible`` restores the older gate.
+    secret values. Headline names the ``--strict`` gate; default
+    ``--strict high`` counts certain + likely. ``--strict paranoid`` is
+    the 0.4.9-and-earlier assignment gate. ``--wide`` aliases ``--include-excluded``.
     Optionally offers to store selected dotenv findings into the project
     vault via the shared ``dotenv_import`` core.
     """
@@ -1113,12 +1111,14 @@ def cmd_scan(args: argparse.Namespace) -> int:
                 seen.add(f.path)
 
     as_json = bool(getattr(args, "json", False))
-    show_possible = bool(getattr(args, "show_possible", False))
+    strict = getattr(args, "strict", "high") or "high"
     if as_json:
         theme.out(
             json.dumps(
                 scan_mod.findings_to_json(
-                    findings, project_root=str(project_root)
+                    findings,
+                    project_root=str(project_root),
+                    strict=strict,
                 ),
                 indent=2,
             )
@@ -1129,18 +1129,13 @@ def cmd_scan(args: argparse.Namespace) -> int:
             scan_mod.format_human_report(
                 findings,
                 project_root=project_root,
-                show_possible=show_possible,
+                strict=strict,
             )
         )
         theme.out("")
 
-    n = scan_mod.leak_count(findings)
-    p = scan_mod.possible_count(findings)
-    fail_on = getattr(args, "fail_on", "high") or "high"
-    if fail_on == "possible":
-        exit_code = 1 if (n > 0 or p > 0) else 0
-    else:
-        exit_code = 1 if n > 0 else 0
+    n = scan_mod.leak_count(findings, strict=strict)
+    exit_code = 1 if n > 0 else 0
 
     # JSON / --no-import: report only. Interactive offer otherwise.
     if as_json or getattr(args, "no_import", False):

--- a/src/key_amnesia/detect.py
+++ b/src/key_amnesia/detect.py
@@ -195,44 +195,69 @@ class HitSet:
     possible_reasons: list[str] = field(default_factory=list)
     likely_reason_counts: dict[str, int] = field(default_factory=dict)
     possible_reason_counts: dict[str, int] = field(default_factory=dict)
+    # upper(name) -> (original_name, reasons). Source of truth for merge.
+    _likely_by_name: dict[str, tuple[str, list[str]]] = field(default_factory=dict)
+    _possible_by_name: dict[str, tuple[str, list[str]]] = field(default_factory=dict)
+
+    def _rebuild(self) -> None:
+        self.likely_names = [pair[0] for pair in self._likely_by_name.values()]
+        self.possible_names = [pair[0] for pair in self._possible_by_name.values()]
+        self.likely_reasons = []
+        self.likely_reason_counts = {}
+        for _name, reasons in self._likely_by_name.values():
+            for reason in reasons:
+                if not reason:
+                    continue
+                if reason not in self.likely_reasons:
+                    self.likely_reasons.append(reason)
+                self.likely_reason_counts[reason] = (
+                    self.likely_reason_counts.get(reason, 0) + 1
+                )
+        self.possible_reasons = []
+        self.possible_reason_counts = {}
+        for _name, reasons in self._possible_by_name.values():
+            for reason in reasons:
+                if not reason:
+                    continue
+                if reason not in self.possible_reasons:
+                    self.possible_reasons.append(reason)
+                self.possible_reason_counts[reason] = (
+                    self.possible_reason_counts.get(reason, 0) + 1
+                )
+
+    def record_assignment(self, name: str, tier: str, reasons: list[str]) -> None:
+        """Highest-wins per name. Does not record values."""
+        key = name.upper()
+        if tier == "likely":
+            if key in self._likely_by_name:
+                return
+            self._possible_by_name.pop(key, None)
+            self._likely_by_name[key] = (name, list(reasons))
+        elif tier == "possible":
+            if key in self._likely_by_name or key in self._possible_by_name:
+                return
+            self._possible_by_name[key] = (name, list(reasons))
+        else:
+            return
+        self._rebuild()
 
     def merge(self, extra: HitSet) -> None:
-        seen_l = {n.upper() for n in self.likely_names}
-        seen_p = {n.upper() for n in self.possible_names}
-        for name in extra.likely_names:
-            key = name.upper()
-            if key in seen_l:
+        for key, pair in extra._likely_by_name.items():
+            if key in self._likely_by_name:
                 continue
-            seen_l.add(key)
-            self.likely_names.append(name)
-            seen_p.discard(key)
-            self.possible_names[:] = [n for n in self.possible_names if n.upper() != key]
-        for name in extra.possible_names:
-            key = name.upper()
-            if key in seen_l or key in seen_p:
+            self._possible_by_name.pop(key, None)
+            self._likely_by_name[key] = (pair[0], list(pair[1]))
+        for key, pair in extra._possible_by_name.items():
+            if key in self._likely_by_name or key in self._possible_by_name:
                 continue
-            seen_p.add(key)
-            self.possible_names.append(name)
+            self._possible_by_name[key] = (pair[0], list(pair[1]))
         if extra.prefix and self.prefix is None:
             self.prefix = extra.prefix
         if extra.bearer_likely:
             self.bearer_likely = True
         if extra.bearer_possible:
             self.bearer_possible = True
-        for reason in extra.likely_reasons:
-            if reason not in self.likely_reasons:
-                self.likely_reasons.append(reason)
-        for reason in extra.possible_reasons:
-            if reason not in self.possible_reasons:
-                self.possible_reasons.append(reason)
-        for reason, n in extra.likely_reason_counts.items():
-            self.likely_reason_counts[reason] = (
-                self.likely_reason_counts.get(reason, 0) + n
-            )
-        for reason, n in extra.possible_reason_counts.items():
-            self.possible_reason_counts[reason] = (
-                self.possible_reason_counts.get(reason, 0) + n
-            )
+        self._rebuild()
 
 
 def entropy(s: str) -> float:
@@ -467,22 +492,7 @@ def scan_text_hits(text: str) -> HitSet:
             prev_reasons.append(reason)
 
     for tier, name, reasons in chosen.values():
-        if tier == "likely":
-            hits.likely_names.append(name)
-            for reason in reasons:
-                if reason not in hits.likely_reasons:
-                    hits.likely_reasons.append(reason)
-                hits.likely_reason_counts[reason] = (
-                    hits.likely_reason_counts.get(reason, 0) + 1
-                )
-        else:
-            hits.possible_names.append(name)
-            for reason in reasons:
-                if reason not in hits.possible_reasons:
-                    hits.possible_reasons.append(reason)
-                hits.possible_reason_counts[reason] = (
-                    hits.possible_reason_counts.get(reason, 0) + 1
-                )
+        hits.record_assignment(name, tier, reasons)
 
     return hits
 

--- a/src/key_amnesia/detect.py
+++ b/src/key_amnesia/detect.py
@@ -189,9 +189,12 @@ class HitSet:
     likely_names: list[str] = field(default_factory=list)
     possible_names: list[str] = field(default_factory=list)
     prefix: str | None = None
+    bearer_likely: bool = False
     bearer_possible: bool = False
     likely_reasons: list[str] = field(default_factory=list)
     possible_reasons: list[str] = field(default_factory=list)
+    likely_reason_counts: dict[str, int] = field(default_factory=dict)
+    possible_reason_counts: dict[str, int] = field(default_factory=dict)
 
     def merge(self, extra: HitSet) -> None:
         seen_l = {n.upper() for n in self.likely_names}
@@ -212,6 +215,8 @@ class HitSet:
             self.possible_names.append(name)
         if extra.prefix and self.prefix is None:
             self.prefix = extra.prefix
+        if extra.bearer_likely:
+            self.bearer_likely = True
         if extra.bearer_possible:
             self.bearer_possible = True
         for reason in extra.likely_reasons:
@@ -220,6 +225,14 @@ class HitSet:
         for reason in extra.possible_reasons:
             if reason not in self.possible_reasons:
                 self.possible_reasons.append(reason)
+        for reason, n in extra.likely_reason_counts.items():
+            self.likely_reason_counts[reason] = (
+                self.likely_reason_counts.get(reason, 0) + n
+            )
+        for reason, n in extra.possible_reason_counts.items():
+            self.possible_reason_counts[reason] = (
+                self.possible_reason_counts.get(reason, 0) + n
+            )
 
 
 def entropy(s: str) -> float:
@@ -377,6 +390,8 @@ def find_secret_kind(text: str) -> str | None:
     hits = scan_text_hits(text)
     if hits.prefix:
         return hits.prefix
+    if hits.bearer_likely:
+        return "Bearer token"
     if hits.likely_names:
         return f"{hits.likely_names[0].upper()} assignment"
     if hits.bearer_possible:
@@ -414,25 +429,24 @@ def iter_secret_keyed_strings(obj: Any) -> Iterator[tuple[str, str]]:
 
 
 def scan_text_hits(text: str) -> HitSet:
-    """Assignment names (likely, possible), prefix kind, bearer-possible flag.
+    """Assignment names (likely, possible), vendor prefix, Bearer flags.
 
     Highest tier wins per name: classify every assignment, keep likely over
-    possible. Prefix kind is high-confidence. Bearer whose value is likely
-    is returned as prefix kind ``Bearer token``. Bearer of an identifier
-    sets the possible flag instead. Never returns values.
+    possible. Vendor prefix is ``certain``. Bearer whose value is likely is
+    ``bearer_likely`` (scan ``likely``). Bearer of an identifier sets
+    ``bearer_possible``. Never returns values.
     """
     hits = HitSet()
     if not text:
         return hits
 
-    prefix = find_prefix_kind(text)
+    hits.prefix = find_prefix_kind(text)
     bearer_tier = classify_bearer_capture(text)
-    if prefix is not None:
-        hits.prefix = prefix
-    elif bearer_tier == "likely":
-        hits.prefix = "Bearer token"
-    elif bearer_tier == "possible":
-        hits.bearer_possible = True
+    if hits.prefix is None:
+        if bearer_tier == "likely":
+            hits.bearer_likely = True
+        elif bearer_tier == "possible":
+            hits.bearer_possible = True
 
     # key -> (tier, original_name, reasons)
     chosen: dict[str, tuple[str, str, list[str]]] = {}
@@ -458,11 +472,17 @@ def scan_text_hits(text: str) -> HitSet:
             for reason in reasons:
                 if reason not in hits.likely_reasons:
                     hits.likely_reasons.append(reason)
+                hits.likely_reason_counts[reason] = (
+                    hits.likely_reason_counts.get(reason, 0) + 1
+                )
         else:
             hits.possible_names.append(name)
             for reason in reasons:
                 if reason not in hits.possible_reasons:
                     hits.possible_reasons.append(reason)
+                hits.possible_reason_counts[reason] = (
+                    hits.possible_reason_counts.get(reason, 0) + 1
+                )
 
     return hits
 

--- a/src/key_amnesia/detect.py
+++ b/src/key_amnesia/detect.py
@@ -59,9 +59,17 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter
+from dataclasses import dataclass, field
 from typing import Any, Iterable, Iterator, Literal
 
 Confidence = Literal["none", "possible", "likely"]
+
+# UUID / stripped-hex promotion (hyphenated 8-4-4-4-12 or 32 hex).
+REASON_UUID = "uuid"
+_UUID_SHAPE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+_STRIPPED_UUID_LEN = 32
 
 # --- length / possible-gate (0.4.9 assignment heuristic) -------------------
 # Inherited as the *possible* gate, not the likely-floor. Shannon 3.0 is why
@@ -83,17 +91,24 @@ _HEX_LIKELY = re.compile(rf"[0-9a-fA-F]{{{HEX_LIKELY_MIN_LEN},}}$")
 # and no digits → possible, not likely (named weakening 3).
 MIN_VOWEL_SEGMENTS_FOR_POSSIBLE = 2
 
-# Named weakenings. Hook recall drops only 1–2. Weakening 3 is scan-only
-# (hook still denies). Everything under tests/fixtures/scan_corpus/demoted/
-# must map to weakening 3.
+# Named weakenings. Hook recall drops only function-call and type-annotation
+# (→ none). Identifier, passphrase, and low-transition stay possible so the
+# hook still denies; scan leak_count omits them.
 NAMED_WEAKENING_FUNCTION_CALL = "function-call"
 NAMED_WEAKENING_TYPE_ANNOTATION = "type-annotation"
 NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE = "word-shaped-passphrase"
+NAMED_WEAKENING_IDENTIFIER = "identifier"
+NAMED_WEAKENING_LOW_TRANSITION = "low-transition"
 NAMED_WEAKENINGS: tuple[str, ...] = (
     NAMED_WEAKENING_FUNCTION_CALL,
     NAMED_WEAKENING_TYPE_ANNOTATION,
     NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
+    NAMED_WEAKENING_IDENTIFIER,
+    NAMED_WEAKENING_LOW_TRANSITION,
 )
+
+# Filename demotion (scan only): mcp.json without a recognised top-level key.
+REASON_UNCONFIRMED_MCP = "unconfirmed-mcp-shape"
 
 # Well-known API key / token prefixes (value starts immediately after).
 # Anthropic-style checked before the more general OpenAI-style pattern so the
@@ -167,6 +182,46 @@ _VOWELS = set("aeiouAEIOU")
 _CAMEL_SEGS = re.compile(r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+")
 
 
+@dataclass
+class HitSet:
+    """Assignment/prefix hits for a text blob. Never carries values."""
+
+    likely_names: list[str] = field(default_factory=list)
+    possible_names: list[str] = field(default_factory=list)
+    prefix: str | None = None
+    bearer_possible: bool = False
+    likely_reasons: list[str] = field(default_factory=list)
+    possible_reasons: list[str] = field(default_factory=list)
+
+    def merge(self, extra: HitSet) -> None:
+        seen_l = {n.upper() for n in self.likely_names}
+        seen_p = {n.upper() for n in self.possible_names}
+        for name in extra.likely_names:
+            key = name.upper()
+            if key in seen_l:
+                continue
+            seen_l.add(key)
+            self.likely_names.append(name)
+            seen_p.discard(key)
+            self.possible_names[:] = [n for n in self.possible_names if n.upper() != key]
+        for name in extra.possible_names:
+            key = name.upper()
+            if key in seen_l or key in seen_p:
+                continue
+            seen_p.add(key)
+            self.possible_names.append(name)
+        if extra.prefix and self.prefix is None:
+            self.prefix = extra.prefix
+        if extra.bearer_possible:
+            self.bearer_possible = True
+        for reason in extra.likely_reasons:
+            if reason not in self.likely_reasons:
+                self.likely_reasons.append(reason)
+        for reason in extra.possible_reasons:
+            if reason not in self.possible_reasons:
+                self.possible_reasons.append(reason)
+
+
 def entropy(s: str) -> float:
     if not s:
         return 0.0
@@ -233,42 +288,71 @@ def _vowel_bearing_segments(value: str) -> int:
     return sum(1 for seg in _word_segments(value) if _has_vowel(seg))
 
 
-def classify_value(value: str) -> Confidence:
-    """Classify a captured assignment/Bearer *value* (never logged)."""
+def _compact_hex(value: str) -> str:
+    return value.replace("-", "")
+
+
+def _is_nil_or_all_zero(value: str) -> bool:
+    compact = _compact_hex(value)
+    return bool(compact) and all(c == "0" for c in compact)
+
+
+def _uuid_or_stripped_hex(value: str) -> bool:
+    """Hyphenated UUID or 32-char hex (stripped UUID). Nil already excluded."""
+    if _UUID_SHAPE.fullmatch(value):
+        return True
+    compact = _compact_hex(value)
+    return len(compact) == _STRIPPED_UUID_LEN and bool(_HEX_LIKELY.fullmatch(compact))
+
+
+def classify_value(value: str) -> tuple[Confidence, str | None]:
+    """Classify a captured assignment/Bearer *value* (never logged).
+
+    Returns ``(tier, reason)``. ``reason`` is a named weakening, ``uuid``,
+    or None. Never returns the value.
+    """
     v = value.strip("'\"")
     if len(v) < MIN_VALUE_LEN:
-        return "none"
-    if is_placeholder(v):
-        return "none"
+        return "none", None
+    if is_placeholder(v) or _is_nil_or_all_zero(v):
+        return "none", None
     if _FUNC_CALL.fullmatch(v):
-        return "none"
+        return "none", NAMED_WEAKENING_FUNCTION_CALL
     if _TYPE_ANN.fullmatch(v):
-        return "none"
+        return "none", NAMED_WEAKENING_TYPE_ANNOTATION
+
+    # UUID-shaped / stripped-hex-32: likely even when hyphens make
+    # transition_rate sit below LIKELY_TRANSITION_FLOOR (~0.43).
+    if _uuid_or_stripped_hex(v):
+        return "likely", REASON_UUID
 
     has_upper = any(c.isupper() for c in v)
     has_lower = any(c.islower() for c in v)
     has_digit = any(c.isdigit() for c in v)
     mixed = sum([has_upper, has_lower, has_digit]) >= 2
     if not mixed:
-        return "none"
+        return "none", None
     if entropy(v) < SHANNON_POSSIBLE_FLOOR:
-        return "none"
+        return "none", None
 
-    # Named weakening 3: word-shaped, no digits → possible (hook still denies).
+    # Word-shaped / identifier, no digits → possible (hook still denies).
     if not has_digit and _vowel_bearing_segments(v) >= MIN_VOWEL_SEGMENTS_FOR_POSSIBLE:
-        return "possible"
+        if v[:1].isupper():
+            return "possible", NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE
+        return "possible", NAMED_WEAKENING_IDENTIFIER
 
-    if _HEX_LIKELY.fullmatch(v):
-        return "likely"
+    compact = _compact_hex(v)
+    if _HEX_LIKELY.fullmatch(compact):
+        return "likely", None
 
     if transition_rate(v) >= LIKELY_TRANSITION_FLOOR:
-        return "likely"
-    return "possible"
+        return "likely", None
+    return "possible", NAMED_WEAKENING_LOW_TRANSITION
 
 
 def assignment_is_secret(value: str) -> bool:
     """0.4.9 hook meaning: possible or likely (not none)."""
-    return classify_value(value) in ("possible", "likely")
+    return classify_value(value)[0] in ("possible", "likely")
 
 
 def find_prefix_kind(text: str) -> str | None:
@@ -282,22 +366,23 @@ def classify_bearer_capture(text: str) -> Confidence:
     match = BEARER.search(text)
     if not match:
         return "none"
-    return classify_value(match.group(1))
+    return classify_value(match.group(1))[0]
 
 
 def find_secret_kind(text: str) -> str | None:
-    """Human-readable kind if possible|likely|prefix, else None. No values."""
-    prefix = find_prefix_kind(text)
-    if prefix:
-        return prefix
+    """Human-readable kind if possible|likely|prefix, else None. No values.
 
-    bearer_tier = classify_bearer_capture(text)
-    if bearer_tier in ("possible", "likely"):
+    Order: vendor prefix, then likely (incl. Bearer-likely), then possible.
+    """
+    hits = scan_text_hits(text)
+    if hits.prefix:
+        return hits.prefix
+    if hits.likely_names:
+        return f"{hits.likely_names[0].upper()} assignment"
+    if hits.bearer_possible:
         return "Bearer token"
-
-    for match in ASSIGN.finditer(text):
-        if classify_value(match.group("value")) in ("possible", "likely"):
-            return f"{match.group('name').upper()} assignment"
+    if hits.possible_names:
+        return f"{hits.possible_names[0].upper()} assignment"
     return None
 
 
@@ -328,43 +413,58 @@ def iter_secret_keyed_strings(obj: Any) -> Iterator[tuple[str, str]]:
             yield from iter_secret_keyed_strings(item)
 
 
-def scan_text_hits(
-    text: str,
-) -> tuple[list[str], list[str], str | None, bool]:
+def scan_text_hits(text: str) -> HitSet:
     """Assignment names (likely, possible), prefix kind, bearer-possible flag.
 
-    Prefix kind is high-confidence. Bearer whose value is likely is returned
-    as prefix kind ``Bearer token``. Bearer of an identifier sets the
-    possible flag instead. Never returns values.
+    Highest tier wins per name: classify every assignment, keep likely over
+    possible. Prefix kind is high-confidence. Bearer whose value is likely
+    is returned as prefix kind ``Bearer token``. Bearer of an identifier
+    sets the possible flag instead. Never returns values.
     """
+    hits = HitSet()
     if not text:
-        return [], [], None, False
+        return hits
 
     prefix = find_prefix_kind(text)
     bearer_tier = classify_bearer_capture(text)
-    bearer_possible = False
-    if prefix is None and bearer_tier == "likely":
-        prefix = "Bearer token"
-    elif prefix is None and bearer_tier == "possible":
-        bearer_possible = True
+    if prefix is not None:
+        hits.prefix = prefix
+    elif bearer_tier == "likely":
+        hits.prefix = "Bearer token"
+    elif bearer_tier == "possible":
+        hits.bearer_possible = True
 
-    likely_names: list[str] = []
-    possible_names: list[str] = []
-    seen: set[str] = set()
+    # key -> (tier, original_name, reasons)
+    chosen: dict[str, tuple[str, str, list[str]]] = {}
     for match in ASSIGN.finditer(text):
         name = match.group("name")
         key = name.upper()
-        if key in seen:
+        tier, reason = classify_value(match.group("value"))
+        if tier not in ("likely", "possible"):
             continue
-        tier = classify_value(match.group("value"))
-        if tier == "likely":
-            seen.add(key)
-            likely_names.append(name)
-        elif tier == "possible":
-            seen.add(key)
-            possible_names.append(name)
+        prev = chosen.get(key)
+        if prev is None:
+            chosen[key] = (tier, name, [reason] if reason else [])
+            continue
+        prev_tier, _prev_name, prev_reasons = prev
+        if prev_tier == "possible" and tier == "likely":
+            chosen[key] = (tier, name, [reason] if reason else [])
+        elif prev_tier == tier and reason and reason not in prev_reasons:
+            prev_reasons.append(reason)
 
-    return likely_names, possible_names, prefix, bearer_possible
+    for tier, name, reasons in chosen.values():
+        if tier == "likely":
+            hits.likely_names.append(name)
+            for reason in reasons:
+                if reason not in hits.likely_reasons:
+                    hits.likely_reasons.append(reason)
+        else:
+            hits.possible_names.append(name)
+            for reason in reasons:
+                if reason not in hits.possible_reasons:
+                    hits.possible_reasons.append(reason)
+
+    return hits
 
 
 def looks_like_json_container(s: str) -> bool:

--- a/src/key_amnesia/detect.py
+++ b/src/key_amnesia/detect.py
@@ -1,0 +1,372 @@
+"""Shared secret-shape detector for the PreToolUse hook and ``ka scan``.
+
+Tiers (not a score)::
+
+    none      placeholder, too short, function-call, type-annotation
+    possible  name matched; 0.4.9 mixed-class + Shannon gate; identifier
+              or word-shaped passphrase
+    likely    stricter value signals (transition floor / hex exception)
+    prefix    vendor prefix (always high), or Bearer whose value is likely
+
+Both consumers import this module. The hook denies on possible|likely|prefix.
+``ka scan`` ``leak_count`` / default exit count likely + prefix + filename
+hits only.
+
+Never returns or logs secret *values*.
+
+Measured evidence (reconstructed shapes, not harvested content)
+---------------------------------------------------------------
+Against 0.4.9 ``_assignment_is_secret`` (length ≥ 8, ≥2 of upper/lower/digit,
+Shannon ≥ 3.0):
+
+Shannon (raw bits):
+    GetTokenFromCache()            3.89
+    hook fixture Zk9pL2xQ7mN4vB8w  4.17
+    hex-32                         3.81
+Hex sits *inside* the identifier band. Shannon ≥ 3.0 cannot split identifiers
+from random tokens; it remains the *possible* gate (``SHANNON_POSSIBLE_FLOOR``),
+not the likely-floor.
+
+Normalized entropy (H / log2(|alphabet|)):
+    identifiers     0.95–1.00
+    random strings  0.94–1.00
+Completely overlapping. Not adopted.
+
+Character-class transition rate (adjacent pairs that change class among
+{upper, lower, digit, other}):
+    identifiers         0.18–0.45  (mostly camelCase boundaries)
+    random fixtures     1.00
+    JWT-shaped          0.71
+    hex-32              0.42
+``LIKELY_TRANSITION_FLOOR = 0.50`` is the lowest floor that excludes the
+entire measured identifier band (ceiling 0.45) while still admitting
+JWT-shaped (0.71) and random fixtures (1.00). 0.60 would still pass those
+positives but sits farther from the identifier ceiling without additional
+evidence. Hex-32 at 0.42 is *below* 0.50, which is why ``HEX_LIKELY`` is an
+explicit exception rather than a reason to lower the floor: hex does not
+alternate classes the way base62 does.
+
+Length ≥ 20 as a likely-floor: rejected — the 16-char hook fixture
+``Zk9pL2xQ7mN4vB8w`` must remain likely.
+
+English-segment demotion: ≥2 vowel-bearing CamelCase/Pascal segments and
+*no digits* → possible. Must not apply when digits are present (JWT
+``eyJhbGciOi…`` would otherwise demote via ``Gci`` / ``Ikp``).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Any, Iterable, Iterator, Literal
+
+Confidence = Literal["none", "possible", "likely"]
+
+# --- length / possible-gate (0.4.9 assignment heuristic) -------------------
+# Inherited as the *possible* gate, not the likely-floor. Shannon 3.0 is why
+# identifiers over-block today; likely uses transition rate instead.
+MIN_VALUE_LEN = 8
+SHANNON_POSSIBLE_FLOOR = 3.0  # GetTokenFromCache() 3.89; fixture 4.17; hex-32 3.81
+
+# --- likely-floor ----------------------------------------------------------
+# Identifiers 0.18–0.45; JWT-shaped 0.71; random fixtures 1.00; hex-32 0.42.
+# 0.50 is the lowest floor that excludes the measured identifier band.
+LIKELY_TRANSITION_FLOOR = 0.50
+
+# Hex-32 transition 0.42 is below LIKELY_TRANSITION_FLOOR, so hex is an
+# explicit likely exception rather than a lowered floor.
+HEX_LIKELY_MIN_LEN = 16
+_HEX_LIKELY = re.compile(rf"[0-9a-fA-F]{{{HEX_LIKELY_MIN_LEN},}}$")
+
+# Word-shaped passphrase / identifier demotion: ≥2 vowel-bearing segments
+# and no digits → possible, not likely (named weakening 3).
+MIN_VOWEL_SEGMENTS_FOR_POSSIBLE = 2
+
+# Named weakenings. Hook recall drops only 1–2. Weakening 3 is scan-only
+# (hook still denies). Everything under tests/fixtures/scan_corpus/demoted/
+# must map to weakening 3.
+NAMED_WEAKENING_FUNCTION_CALL = "function-call"
+NAMED_WEAKENING_TYPE_ANNOTATION = "type-annotation"
+NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE = "word-shaped-passphrase"
+NAMED_WEAKENINGS: tuple[str, ...] = (
+    NAMED_WEAKENING_FUNCTION_CALL,
+    NAMED_WEAKENING_TYPE_ANNOTATION,
+    NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
+)
+
+# Well-known API key / token prefixes (value starts immediately after).
+# Anthropic-style checked before the more general OpenAI-style pattern so the
+# reported "kind" is the more specific one.
+PREFIX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("Anthropic-style key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
+    ("OpenAI-style key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    ("AWS access key id", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
+    ("GitHub PAT", re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b")),
+    ("GitLab PAT", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_-]{20,}\b")),
+    ("Stripe secret key", re.compile(r"\bsk_live_[A-Za-z0-9]{20,}\b")),
+    ("Stripe restricted key", re.compile(r"\brk_live_[A-Za-z0-9]{20,}\b")),
+    ("npm token", re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b")),
+]
+
+BEARER = re.compile(r"\bBearer\s+([A-Za-z0-9._\-+=/]{16,})", re.IGNORECASE)
+
+# ENV-style / JSON / YAML / TOML assignments. Optional dotted prefix
+# (secrets.api_key) is not part of the captured name. Optional matching
+# quotes around the name so `"api_key": "…"` matches.
+ASSIGN = re.compile(
+    r"""(?ix)
+    (?:[A-Za-z_][A-Za-z0-9_]*\.)*
+    (?P<nq>['"]?)
+    (?P<name>(?:[a-z0-9]+[_-])*(?:api[_-]?key|token|secret|password|passwd|private[_-]?key))
+    (?P=nq)
+    \s*[:=]\s*
+    (?P<q>['"]?)
+    (?P<value>[^\s'"]{8,})
+    (?P=q)
+    """
+)
+
+_SECRET_NAME = re.compile(
+    r"(?ix)^(?:[a-z0-9]+[_-])*(?:api[_-]?key|token|secret|password|passwd|private[_-]?key)$"
+)
+
+_PLACEHOLDER_VALUES = {
+    "test123",
+    "test1234",
+    "changeme",
+    "change_me",
+    "changethis",
+    "password",
+    "password123",
+    "secret",
+    "yourkey",
+    "your_api_key",
+    "your-api-key",
+    "placeholder",
+    "example",
+    "dummy",
+    "fake",
+    "sample",
+    "xxxxxxxx",
+    "12345678",
+}
+
+# ident(...) / dotted.attr(...) — named weakening 1 → none
+_FUNC_CALL = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*\(.*\)$"
+)
+
+# Name[...] — named weakening 2 → none
+_TYPE_ANN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\[.+\]$")
+
+_VOWELS = set("aeiouAEIOU")
+_CAMEL_SEGS = re.compile(r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+")
+
+
+def entropy(s: str) -> float:
+    if not s:
+        return 0.0
+    counts = Counter(s)
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def is_placeholder(value: str) -> bool:
+    v = value.strip("'\"").lower()
+    if v in _PLACEHOLDER_VALUES:
+        return True
+    if re.fullmatch(r"x{6,}", v):
+        return True
+    if re.fullmatch(r"0{6,}|1{6,}", v):
+        return True
+    return False
+
+
+def is_secret_name(name: str) -> bool:
+    """True if a dict/JSON key matches the assignment name vocabulary."""
+    return bool(_SECRET_NAME.fullmatch(name.strip().strip("'\"")))
+
+
+def _char_class(c: str) -> str:
+    if c.isupper():
+        return "U"
+    if c.islower():
+        return "L"
+    if c.isdigit():
+        return "D"
+    return "O"
+
+
+def transition_rate(s: str) -> float:
+    """Fraction of adjacent pairs that change character class.
+
+    Identifiers 0.18–0.45; random fixtures 1.00; JWT-shaped 0.71; hex-32 0.42.
+    """
+    if len(s) < 2:
+        return 0.0
+    changes = sum(
+        1 for a, b in zip(s, s[1:]) if _char_class(a) != _char_class(b)
+    )
+    return changes / (len(s) - 1)
+
+
+def _word_segments(value: str) -> list[str]:
+    parts = re.split(r"[^A-Za-z0-9]+", value)
+    segs: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        found = _CAMEL_SEGS.findall(part)
+        segs.extend(found if found else [part])
+    return segs
+
+
+def _has_vowel(seg: str) -> bool:
+    return any(c in _VOWELS or c in "yY" for c in seg)
+
+
+def _vowel_bearing_segments(value: str) -> int:
+    return sum(1 for seg in _word_segments(value) if _has_vowel(seg))
+
+
+def classify_value(value: str) -> Confidence:
+    """Classify a captured assignment/Bearer *value* (never logged)."""
+    v = value.strip("'\"")
+    if len(v) < MIN_VALUE_LEN:
+        return "none"
+    if is_placeholder(v):
+        return "none"
+    if _FUNC_CALL.fullmatch(v):
+        return "none"
+    if _TYPE_ANN.fullmatch(v):
+        return "none"
+
+    has_upper = any(c.isupper() for c in v)
+    has_lower = any(c.islower() for c in v)
+    has_digit = any(c.isdigit() for c in v)
+    mixed = sum([has_upper, has_lower, has_digit]) >= 2
+    if not mixed:
+        return "none"
+    if entropy(v) < SHANNON_POSSIBLE_FLOOR:
+        return "none"
+
+    # Named weakening 3: word-shaped, no digits → possible (hook still denies).
+    if not has_digit and _vowel_bearing_segments(v) >= MIN_VOWEL_SEGMENTS_FOR_POSSIBLE:
+        return "possible"
+
+    if _HEX_LIKELY.fullmatch(v):
+        return "likely"
+
+    if transition_rate(v) >= LIKELY_TRANSITION_FLOOR:
+        return "likely"
+    return "possible"
+
+
+def assignment_is_secret(value: str) -> bool:
+    """0.4.9 hook meaning: possible or likely (not none)."""
+    return classify_value(value) in ("possible", "likely")
+
+
+def find_prefix_kind(text: str) -> str | None:
+    for kind, pattern in PREFIX_PATTERNS:
+        if pattern.search(text):
+            return kind
+    return None
+
+
+def classify_bearer_capture(text: str) -> Confidence:
+    match = BEARER.search(text)
+    if not match:
+        return "none"
+    return classify_value(match.group(1))
+
+
+def find_secret_kind(text: str) -> str | None:
+    """Human-readable kind if possible|likely|prefix, else None. No values."""
+    prefix = find_prefix_kind(text)
+    if prefix:
+        return prefix
+
+    bearer_tier = classify_bearer_capture(text)
+    if bearer_tier in ("possible", "likely"):
+        return "Bearer token"
+
+    for match in ASSIGN.finditer(text):
+        if classify_value(match.group("value")) in ("possible", "likely"):
+            return f"{match.group('name').upper()} assignment"
+    return None
+
+
+def iter_assignment_matches(text: str) -> Iterator[re.Match[str]]:
+    yield from ASSIGN.finditer(text)
+
+
+def collect_strings(obj: Any) -> Iterable[str]:
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from collect_strings(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from collect_strings(item)
+
+
+def iter_secret_keyed_strings(obj: Any) -> Iterator[tuple[str, str]]:
+    """Yield (key, string_value) where key matches the secret-name vocabulary."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str) and is_secret_name(k) and isinstance(v, str):
+                yield k, v
+            yield from iter_secret_keyed_strings(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iter_secret_keyed_strings(item)
+
+
+def scan_text_hits(
+    text: str,
+) -> tuple[list[str], list[str], str | None, bool]:
+    """Assignment names (likely, possible), prefix kind, bearer-possible flag.
+
+    Prefix kind is high-confidence. Bearer whose value is likely is returned
+    as prefix kind ``Bearer token``. Bearer of an identifier sets the
+    possible flag instead. Never returns values.
+    """
+    if not text:
+        return [], [], None, False
+
+    prefix = find_prefix_kind(text)
+    bearer_tier = classify_bearer_capture(text)
+    bearer_possible = False
+    if prefix is None and bearer_tier == "likely":
+        prefix = "Bearer token"
+    elif prefix is None and bearer_tier == "possible":
+        bearer_possible = True
+
+    likely_names: list[str] = []
+    possible_names: list[str] = []
+    seen: set[str] = set()
+    for match in ASSIGN.finditer(text):
+        name = match.group("name")
+        key = name.upper()
+        if key in seen:
+            continue
+        tier = classify_value(match.group("value"))
+        if tier == "likely":
+            seen.add(key)
+            likely_names.append(name)
+        elif tier == "possible":
+            seen.add(key)
+            possible_names.append(name)
+
+    return likely_names, possible_names, prefix, bearer_possible
+
+
+def looks_like_json_container(s: str) -> bool:
+    t = s.lstrip()
+    return t.startswith("{") or t.startswith("[")

--- a/src/key_amnesia/hooks/secret_guard.py
+++ b/src/key_amnesia/hooks/secret_guard.py
@@ -29,13 +29,12 @@ never brick the agent. Set ``KEY_AMNESIA_HOOK_DISABLE=1`` to skip all checks
 from __future__ import annotations
 
 import json
-import math
 import os
 import re
 import sys
-from collections import Counter
-from typing import Any, Iterable
+from typing import Any
 
+from key_amnesia.detect import collect_strings, find_secret_kind
 from key_amnesia.ka_policy import (
     deny_message,
     iter_non_ka_chain_texts,
@@ -51,58 +50,6 @@ _KA_SAFE = re.compile(
     re.IGNORECASE,
 )
 
-# Well-known API key / token prefixes (value starts immediately after).
-# Anthropic-style checked before the more general OpenAI-style pattern so the
-# reported "kind" is the more specific one.
-_PREFIX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
-    ("Anthropic-style key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
-    ("OpenAI-style key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
-    ("AWS access key id", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
-    ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
-    ("GitHub PAT", re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b")),
-    ("GitLab PAT", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b")),
-    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
-    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_-]{20,}\b")),
-    ("Stripe secret key", re.compile(r"\bsk_live_[A-Za-z0-9]{20,}\b")),
-    ("Stripe restricted key", re.compile(r"\brk_live_[A-Za-z0-9]{20,}\b")),
-    ("npm token", re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b")),
-]
-
-_BEARER = re.compile(r"\bBearer\s+([A-Za-z0-9._\-+=/]{16,})", re.IGNORECASE)
-
-# ENV-style assignments that often carry secrets: NAME (optionally prefixed,
-# e.g. MY_API_KEY) = / : value. Bare mentions with no value never match.
-_ASSIGN = re.compile(
-    r"""(?ix)
-    (?P<name>(?:[a-z0-9]+[_-])*(?:api[_-]?key|token|secret|password|passwd|private[_-]?key))
-    \s*[:=]\s*
-    (?P<q>['"]?)
-    (?P<value>[^\s'"]{8,})
-    (?P=q)
-    """
-)
-
-_PLACEHOLDER_VALUES = {
-    "test123",
-    "test1234",
-    "changeme",
-    "change_me",
-    "changethis",
-    "password",
-    "password123",
-    "secret",
-    "yourkey",
-    "your_api_key",
-    "your-api-key",
-    "placeholder",
-    "example",
-    "dummy",
-    "fake",
-    "sample",
-    "xxxxxxxx",
-    "12345678",
-}
-
 _SUGGESTION = (
     "Inline credential-shaped token detected ({kind}). "
     "Do not paste secrets into commands or files. Store with `ka set NAME`, "
@@ -110,52 +57,6 @@ _SUGGESTION = (
     "the value never appears on argv, in files, or in chat. "
     "(Set KEY_AMNESIA_HOOK_DISABLE=1 to bypass this hook.)"
 )
-
-
-def _entropy(s: str) -> float:
-    if not s:
-        return 0.0
-    counts = Counter(s)
-    n = len(s)
-    return -sum((c / n) * math.log2(c / n) for c in counts.values())
-
-
-def _is_placeholder(value: str) -> bool:
-    v = value.strip("'\"").lower()
-    if v in _PLACEHOLDER_VALUES:
-        return True
-    if re.fullmatch(r"x{6,}", v):
-        return True
-    if re.fullmatch(r"0{6,}|1{6,}", v):
-        return True
-    return False
-
-
-def _assignment_is_secret(value: str) -> bool:
-    """High-entropy heuristic: mixed case + digits, not an obvious placeholder."""
-    v = value.strip("'\"")
-    if len(v) < 8:
-        return False
-    if _is_placeholder(v):
-        return False
-    has_upper = any(c.isupper() for c in v)
-    has_lower = any(c.islower() for c in v)
-    has_digit = any(c.isdigit() for c in v)
-    mixed = sum([has_upper, has_lower, has_digit]) >= 2
-    if not mixed:
-        return False
-    return _entropy(v) >= 3.0
-
-
-def _collect_strings(obj: Any) -> Iterable[str]:
-    if isinstance(obj, str):
-        yield obj
-    elif isinstance(obj, dict):
-        for v in obj.values():
-            yield from _collect_strings(v)
-    elif isinstance(obj, list):
-        for item in obj:
-            yield from _collect_strings(item)
 
 
 def _command_text(tool_input: Any) -> str:
@@ -173,7 +74,7 @@ def _command_text(tool_input: Any) -> str:
             val = tool_input.get(key)
             if isinstance(val, str) and val.strip():
                 return val
-        return "\n".join(_collect_strings(tool_input))
+        return "\n".join(collect_strings(tool_input))
     if isinstance(tool_input, str):
         return tool_input
     return ""
@@ -191,19 +92,7 @@ def find_finding(text: str, *, ignore_ka_safe: bool = False) -> str | None:
     if not ignore_ka_safe and _KA_SAFE.search(text):
         return None
 
-    for kind, pattern in _PREFIX_PATTERNS:
-        if pattern.search(text):
-            return kind
-
-    if _BEARER.search(text):
-        return "Bearer token"
-
-    for match in _ASSIGN.finditer(text):
-        value = match.group("value")
-        if _assignment_is_secret(value):
-            return f"{match.group('name').upper()} assignment"
-
-    return None
+    return find_secret_kind(text)
 
 
 def detect_host(payload: dict[str, Any]) -> str:

--- a/src/key_amnesia/scan.py
+++ b/src/key_amnesia/scan.py
@@ -6,9 +6,9 @@ secret *files* and light assignment / prefix patterns. Reports **names,
 paths, counts, and (for transcripts) line numbers only** — never prints,
 logs, or copies secret values.
 
-Detection is **advisory**. The headline and default exit count
-high-confidence findings only (``likely`` / prefix / filename). Identifier-
-and passphrase-shaped hits are ``possible`` (``--fail-on possible`` to
+Detection is **advisory**. The headline names the ``--strict`` gate.
+Default ``--strict high`` exit counts ``certain`` + ``likely``. Identifier-
+and passphrase-shaped hits are ``possible`` (``--strict paranoid`` to
 gate). Policy classification: Scan LEAK report is **advisory** (not
 cryptography).
 """
@@ -23,7 +23,11 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from key_amnesia.detect import (
+    NAMED_WEAKENING_IDENTIFIER,
+    NAMED_WEAKENING_LOW_TRANSITION,
+    NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
     REASON_UNCONFIRMED_MCP,
+    REASON_UUID,
     HitSet,
     classify_value,
     collect_strings,
@@ -71,6 +75,25 @@ _MAX_TRANSCRIPT_BYTES = 100 * 1024 * 1024
 
 # Cap human-report line lists; full list remains in ``--json``.
 _HIT_LINES_DISPLAY_CAP = 20
+
+STRICT_CERTAIN = "certain"
+STRICT_HIGH = "high"
+STRICT_PARANOID = "paranoid"
+_CONF_ORDER = {"certain": 0, "likely": 1, "possible": 2}
+_REASON_LABELS: dict[str, str] = {
+    NAMED_WEAKENING_IDENTIFIER: "identifier",
+    NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE: "passphrase",
+    NAMED_WEAKENING_LOW_TRANSITION: "low-transition",
+    REASON_UUID: "uuid",
+    REASON_UNCONFIRMED_MCP: "unconfirmed-mcp-shape",
+}
+_REASON_LABEL_ORDER: tuple[str, ...] = (
+    NAMED_WEAKENING_IDENTIFIER,
+    NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
+    NAMED_WEAKENING_LOW_TRANSITION,
+    REASON_UUID,
+    REASON_UNCONFIRMED_MCP,
+)
 
 # Text-ish extensions worth content-scanning for assignment patterns.
 _CONTENT_SCAN_SUFFIXES = frozenset(
@@ -146,10 +169,11 @@ class Finding:
     scope: str = "project"  # "project" | "deep"
     # 1-based JSONL line numbers (agent transcripts only).
     hit_lines: list[int] = field(default_factory=list)
-    # "high" = leak_count / default exit; "possible" = identifier/passphrase.
-    confidence: str = "high"
+    # certain | likely | possible — constructions set this explicitly.
+    confidence: str = ""
     # Named reason codes (never values): uuid, low-transition, identifier, …
     reasons: list[str] = field(default_factory=list)
+    reason_counts: dict[str, int] = field(default_factory=dict)
 
 
 def _is_dotenv_filename(name: str) -> bool:
@@ -216,6 +240,7 @@ def _dotenv_finding(path: Path, *, scope: str) -> Finding | None:
             reason="dotenv file (no KEY=VALUE entries)",
             importable=False,
             scope=scope,
+            confidence="certain",
         )
     if not names:
         return Finding(
@@ -226,6 +251,7 @@ def _dotenv_finding(path: Path, *, scope: str) -> Finding | None:
             reason="dotenv file (empty values only)",
             importable=False,
             scope=scope,
+            confidence="certain",
         )
     return Finding(
         path=str(path),
@@ -235,6 +261,7 @@ def _dotenv_finding(path: Path, *, scope: str) -> Finding | None:
         reason=f"dotenv file with {len(names)} secret name(s)",
         importable=True,
         scope=scope,
+        confidence="certain",
     )
 
 
@@ -289,10 +316,12 @@ def _apply_secret_keys(acc: HitSet, node: Any) -> None:
             extra.likely_names = [key]
             if reason:
                 extra.likely_reasons = [reason]
+                extra.likely_reason_counts = {reason: 1}
         elif tier == "possible":
             extra.possible_names = [key]
             if reason:
                 extra.possible_reasons = [reason]
+                extra.possible_reason_counts = {reason: 1}
         else:
             continue
         acc.merge(extra)
@@ -387,16 +416,28 @@ def _inline_findings(
     likely_names = hits.likely_names
     possible_names = hits.possible_names
     prefix = hits.prefix
+    bearer_likely = hits.bearer_likely
     bearer_possible = hits.bearer_possible
 
     out: list[Finding] = []
-    if likely_names or prefix:
+    if prefix:
+        out.append(
+            Finding(
+                path=str(path),
+                kind=kind,
+                secret_names=[],
+                secret_count=1,
+                reason=f"inline credential-shaped token ({prefix})",
+                importable=False,
+                scope=scope,
+                confidence="certain",
+            )
+        )
+    if likely_names or bearer_likely:
         count = len(likely_names) if likely_names else 1
         reason = high_reason
-        if prefix and not likely_names:
-            reason = f"inline credential-shaped token ({prefix})"
-        elif prefix and likely_names:
-            reason = f"assignment + {prefix}"
+        if bearer_likely and not likely_names:
+            reason = "inline credential-shaped token (Bearer token)"
         out.append(
             Finding(
                 path=str(path),
@@ -406,8 +447,9 @@ def _inline_findings(
                 reason=reason,
                 importable=False,
                 scope=scope,
-                confidence="high",
+                confidence="likely",
                 reasons=list(hits.likely_reasons),
+                reason_counts=dict(hits.likely_reason_counts),
             )
         )
     if possible_names or bearer_possible:
@@ -424,6 +466,7 @@ def _inline_findings(
                 scope=scope,
                 confidence="possible",
                 reasons=list(hits.possible_reasons),
+                reason_counts=dict(hits.possible_reason_counts),
             )
         )
     return out
@@ -438,13 +481,18 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
     if size > _MAX_TRANSCRIPT_BYTES:
         return []
 
-    high_lines: list[int] = []
+    certain_lines: list[int] = []
+    likely_lines: list[int] = []
     possible_lines: list[int] = []
-    high_names: list[str] = []
+    certain_names: list[str] = []
+    likely_names: list[str] = []
     possible_names: list[str] = []
-    high_reasons: list[str] = []
+    likely_reasons: list[str] = []
     possible_reasons: list[str] = []
-    seen_high: set[str] = set()
+    likely_reason_counts: dict[str, int] = {}
+    possible_reason_counts: dict[str, int] = {}
+    seen_certain: set[str] = set()
+    seen_likely: set[str] = set()
     seen_possible: set[str] = set()
 
     try:
@@ -458,61 +506,95 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                 except json.JSONDecodeError:
                     continue
                 hits = _scan_transcript_payload(obj)
-                likely = hits.likely_names
-                possible = hits.possible_names
-                prefix = hits.prefix
-                bearer_possible = hits.bearer_possible
-                high = bool(likely or prefix)
-                poss = bool(possible or bearer_possible)
-                if not high and not poss:
+                has_certain = bool(hits.prefix)
+                has_likely = bool(hits.likely_names or hits.bearer_likely)
+                has_possible = bool(hits.possible_names or hits.bearer_possible)
+                if not has_certain and not has_likely and not has_possible:
                     continue
-                if high:
-                    high_lines.append(line_no)
-                    for name in likely:
+                if has_certain:
+                    certain_lines.append(line_no)
+                    if hits.prefix and hits.prefix not in seen_certain:
+                        seen_certain.add(hits.prefix)
+                        certain_names.append(hits.prefix)
+                if has_likely:
+                    if not has_certain:
+                        likely_lines.append(line_no)
+                    for name in hits.likely_names:
                         key = name.upper()
-                        if key in seen_high:
+                        if key in seen_likely or key in seen_certain:
                             continue
-                        seen_high.add(key)
-                        high_names.append(name)
+                        seen_likely.add(key)
+                        likely_names.append(name)
                     for reason in hits.likely_reasons:
-                        if reason not in high_reasons:
-                            high_reasons.append(reason)
-                # Mixed high+possible lines stay high-only for hit_lines /
+                        if reason not in likely_reasons:
+                            likely_reasons.append(reason)
+                    for reason, n in hits.likely_reason_counts.items():
+                        likely_reason_counts[reason] = (
+                            likely_reason_counts.get(reason, 0) + n
+                        )
+                # Mixed higher-tier lines stay out of possible hit_lines /
                 # transcript_line_hit_count, but possible names/reasons are
                 # still recorded so histograms stay complete.
-                if poss:
-                    if not high:
+                if has_possible:
+                    if not has_certain and not has_likely:
                         possible_lines.append(line_no)
-                    for name in possible:
+                    for name in hits.possible_names:
                         key = name.upper()
-                        if key in seen_possible or key in seen_high:
+                        if (
+                            key in seen_possible
+                            or key in seen_likely
+                            or key in seen_certain
+                        ):
                             continue
                         seen_possible.add(key)
                         possible_names.append(name)
                     for reason in hits.possible_reasons:
                         if reason not in possible_reasons:
                             possible_reasons.append(reason)
+                    for reason, n in hits.possible_reason_counts.items():
+                        possible_reason_counts[reason] = (
+                            possible_reason_counts.get(reason, 0) + n
+                        )
     except OSError:
         return []
 
     out: list[Finding] = []
-    if high_lines:
+    if certain_lines:
         out.append(
             Finding(
                 path=str(path),
                 kind="agent_session_transcript",
-                secret_names=high_names,
-                secret_count=len(high_lines),
+                secret_names=certain_names,
+                secret_count=len(certain_lines),
                 reason=(
-                    f"agent session transcript: {len(high_lines)} line(s) with "
-                    "high-confidence credential-shaped content (advisory; false "
+                    f"agent session transcript: {len(certain_lines)} line(s) with "
+                    "vendor-prefix credential-shaped content (advisory; false "
                     "positives/negatives expected)"
                 ),
                 importable=False,
                 scope=scope,
-                hit_lines=high_lines,
-                confidence="high",
-                reasons=high_reasons,
+                hit_lines=certain_lines,
+                confidence="certain",
+            )
+        )
+    if likely_lines:
+        out.append(
+            Finding(
+                path=str(path),
+                kind="agent_session_transcript",
+                secret_names=likely_names,
+                secret_count=len(likely_lines),
+                reason=(
+                    f"agent session transcript: {len(likely_lines)} line(s) with "
+                    "likely assignment-shaped content (advisory; false "
+                    "positives/negatives expected)"
+                ),
+                importable=False,
+                scope=scope,
+                hit_lines=likely_lines,
+                confidence="likely",
+                reasons=likely_reasons,
+                reason_counts=likely_reason_counts,
             )
         )
     if possible_lines or possible_names:
@@ -525,7 +607,7 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
         else:
             poss_reason = (
                 "agent session transcript: possible identifier- or "
-                "passphrase-shaped names on high-confidence lines"
+                "passphrase-shaped names on higher-confidence lines"
             )
         out.append(
             Finding(
@@ -539,6 +621,7 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                 hit_lines=possible_lines,
                 confidence="possible",
                 reasons=possible_reasons,
+                reason_counts=possible_reason_counts,
             )
         )
     return out
@@ -572,7 +655,7 @@ def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
                         reason=f"MCP config ({count} top-level key name(s))",
                         importable=False,
                         scope=scope,
-                        confidence="high",
+                        confidence="certain",
                     )
                 ]
             # Unrecognised shape: demote to possible, do not drop.
@@ -590,6 +673,7 @@ def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
                     scope=scope,
                     confidence="possible",
                     reasons=[REASON_UNCONFIRMED_MCP],
+                    reason_counts={REASON_UNCONFIRMED_MCP: count},
                 )
             ]
         elif kind in (".npmrc", ".pypirc"):
@@ -628,7 +712,7 @@ def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
                 reason=reason,
                 importable=False,
                 scope=scope,
-                confidence="high",
+                confidence="certain",
             )
         ]
 
@@ -710,7 +794,7 @@ def scan_project(
             ):
                 continue
             findings.append(finding)
-    findings.sort(key=lambda f: (f.path, f.confidence))
+    findings.sort(key=lambda f: (f.path, _CONF_ORDER.get(f.confidence, 9)))
     return findings
 
 
@@ -811,14 +895,29 @@ def scan_deep(home: Path | None = None) -> list[Finding]:
             seen.add(finding.path)
             findings.append(finding)
 
-    findings.sort(key=lambda f: (f.path, f.confidence))
+    findings.sort(key=lambda f: (f.path, _CONF_ORDER.get(f.confidence, 9)))
     return findings
 
 
-def leak_count(findings: list[Finding]) -> int:
-    return sum(
-        max(f.secret_count, 0) for f in findings if f.confidence == "high"
-    )
+def gated_confidences(strict: str) -> frozenset[str]:
+    if strict == STRICT_CERTAIN:
+        return frozenset({"certain"})
+    if strict == STRICT_PARANOID:
+        return frozenset({"certain", "likely", "possible"})
+    return frozenset({"certain", "likely"})
+
+
+def leak_count(findings: list[Finding], *, strict: str = STRICT_HIGH) -> int:
+    gated = gated_confidences(strict)
+    return sum(max(f.secret_count, 0) for f in findings if f.confidence in gated)
+
+
+def certain_count(findings: list[Finding]) -> int:
+    return sum(max(f.secret_count, 0) for f in findings if f.confidence == "certain")
+
+
+def likely_count(findings: list[Finding]) -> int:
+    return sum(max(f.secret_count, 0) for f in findings if f.confidence == "likely")
 
 
 def possible_count(findings: list[Finding]) -> int:
@@ -828,49 +927,107 @@ def possible_count(findings: list[Finding]) -> int:
 
 
 def transcript_line_hit_count(findings: list[Finding]) -> int:
-    """Sum of high-confidence LEAK line-hits in transcript findings."""
+    """Sum of certain+likely LEAK line-hits in transcript findings."""
     return sum(
         max(f.secret_count, 0)
         for f in findings
-        if f.kind == "agent_session_transcript" and f.confidence == "high"
+        if f.kind == "agent_session_transcript"
+        and f.confidence in ("certain", "likely")
     )
 
 
-def headline(findings: list[Finding], *, project_label: str = "this project") -> str:
-    n = leak_count(findings)
+def headline(
+    findings: list[Finding],
+    *,
+    project_label: str = "this project",
+    strict: str = STRICT_HIGH,
+) -> str:
+    n = leak_count(findings, strict=strict)
     unit = "LEAK" if n == 1 else "LEAKs"
     return (
-        f"{n} high-confidence {unit} found — your agent can read {n} secret"
+        f"{n} {unit} found (--strict {strict}) — your agent can read {n} secret"
         f"{'' if n == 1 else 's'} in {project_label} "
         f"(LEAK = Locally Exposed Agent Keys)"
     )
 
 
-def _possible_note(findings: list[Finding]) -> str | None:
-    p = possible_count(findings)
-    if p == 0:
-        return None
-    unit = "hit" if p == 1 else "hits"
-    return (
-        f"{p} possible identifier- or passphrase-shaped {unit} not counted; "
-        f"--fail-on possible to gate on them"
+def _reason_bucket_counts(findings: list[Finding]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for f in findings:
+        if f.confidence == "possible":
+            if f.reason_counts:
+                for reason, n in f.reason_counts.items():
+                    counts[reason] = counts.get(reason, 0) + n
+            elif f.reasons:
+                if len(f.reasons) == 1:
+                    counts[f.reasons[0]] = counts.get(f.reasons[0], 0) + max(
+                        f.secret_count, 1
+                    )
+                else:
+                    for reason in f.reasons:
+                        counts[reason] = counts.get(reason, 0) + 1
+            else:
+                counts[NAMED_WEAKENING_IDENTIFIER] = counts.get(
+                    NAMED_WEAKENING_IDENTIFIER, 0
+                ) + max(f.secret_count, 1)
+        elif f.confidence == "likely" and REASON_UUID in f.reasons:
+            n = 0
+            if f.reason_counts and REASON_UUID in f.reason_counts:
+                n = f.reason_counts[REASON_UUID]
+            else:
+                n = max(f.secret_count, 1)
+            counts[REASON_UUID] = counts.get(REASON_UUID, 0) + n
+    return counts
+
+
+def format_count_summary(findings: list[Finding]) -> str:
+    """Always-printed three-count line. Identical at every ``--strict``."""
+    base = (
+        f"{certain_count(findings)} certain · {likely_count(findings)} likely · "
+        f"{possible_count(findings)} possible"
     )
+    buckets = _reason_bucket_counts(findings)
+    if not buckets:
+        return base
+    parts: list[str] = []
+    seen: set[str] = set()
+    for reason in _REASON_LABEL_ORDER:
+        if reason in buckets and buckets[reason] > 0:
+            label = _REASON_LABELS.get(reason, reason)
+            parts.append(f"{buckets[reason]} {label}")
+            seen.add(reason)
+    for reason, n in sorted(buckets.items()):
+        if reason in seen or n <= 0:
+            continue
+        parts.append(f"{n} {_REASON_LABELS.get(reason, reason)}")
+    if not parts:
+        return base
+    return f"{base} ({' · '.join(parts)})"
 
 
-def findings_to_json(findings: list[Finding], *, project_root: str) -> dict[str, Any]:
-    n = leak_count(findings)
+def findings_to_json(
+    findings: list[Finding],
+    *,
+    project_root: str,
+    strict: str = STRICT_HIGH,
+) -> dict[str, Any]:
+    n = leak_count(findings, strict=strict)
     transcript_hits = transcript_line_hit_count(findings)
     return {
         "leak_count": n,
+        "certain_count": certain_count(findings),
+        "likely_count": likely_count(findings),
         "possible_count": possible_count(findings),
         "transcript_line_hits": transcript_hits,
-        "headline": headline(findings),
+        "headline": headline(findings, strict=strict),
+        "strict": strict,
         "project_root": project_root,
         "findings": [asdict(f) for f in findings],
         "detection_note": (
-            "Advisory heuristics; leak_count is high-confidence only "
-            "(likely / prefix / filename). possible_count is identifier- or "
-            "passphrase-shaped. Values are never included."
+            "Advisory heuristics; leak_count matches the --strict gate "
+            f"({strict}). certain_count / likely_count / possible_count are "
+            "ungated. Per-finding confidence and reasons are always present. "
+            "Values are never included."
         ),
     }
 
@@ -891,13 +1048,14 @@ def format_human_report(
     findings: list[Finding],
     *,
     project_root: Path,
-    show_possible: bool = False,
+    strict: str = STRICT_HIGH,
 ) -> str:
-    lines: list[str] = [headline(findings), ""]
-    note = _possible_note(findings)
-    if note:
-        lines.append(note)
-        lines.append("")
+    lines: list[str] = [
+        headline(findings, strict=strict),
+        "",
+        format_count_summary(findings),
+        "",
+    ]
     transcript_hits = transcript_line_hit_count(findings)
     if transcript_hits:
         unit = "LEAK" if transcript_hits == 1 else "LEAKs"
@@ -906,31 +1064,25 @@ def format_human_report(
             f"(line-hits; advisory detection)"
         )
         lines.append("")
-    listed = [
-        f
-        for f in findings
-        if f.confidence == "high" or (show_possible and f.confidence == "possible")
-    ]
+    gated = gated_confidences(strict)
+    listed = [f for f in findings if f.confidence in gated]
     if not listed:
-        if possible_count(findings) and not show_possible:
-            lines.append(
-                "No high-confidence locally exposed agent keys found under "
-                "default exclusions. Use --show-possible to list identifier- "
-                "or passphrase-shaped hits."
-            )
-        else:
-            lines.append(
-                "No locally exposed agent keys found under default exclusions."
-            )
+        lines.append(
+            "No locally exposed agent keys found under default exclusions."
+        )
         return "\n".join(lines)
     lines.append(f"Project root: {project_root}")
     lines.append("")
     for i, f in enumerate(listed, start=1):
         names = ", ".join(f.secret_names) if f.secret_names else "(filename/presence)"
+        extra_reasons = ""
+        if f.reasons:
+            extra_reasons = f"  reasons={','.join(f.reasons)}"
         lines.append(
             f"  [{i}] {f.path}"
             f"\n      kind={f.kind}  count={f.secret_count}  "
             f"scope={f.scope}  confidence={f.confidence}"
+            f"{extra_reasons}"
             f"\n      names: {names}"
             f"\n      {f.reason}"
             + ("  [importable]" if f.importable else "")
@@ -944,7 +1096,7 @@ def format_human_report(
     lines.append(
         "Detection is advisory; false positives and false negatives are "
         "expected. Word-shaped passphrases appear under possible, not the "
-        "headline count."
+        "default headline count."
     )
     return "\n".join(lines)
 

--- a/src/key_amnesia/scan.py
+++ b/src/key_amnesia/scan.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from key_amnesia.detect import (
+    REASON_UNCONFIRMED_MCP,
+    HitSet,
     classify_value,
     collect_strings,
     iter_secret_keyed_strings,
@@ -146,6 +148,8 @@ class Finding:
     hit_lines: list[int] = field(default_factory=list)
     # "high" = leak_count / default exit; "possible" = identifier/passphrase.
     confidence: str = "high"
+    # Named reason codes (never values): uuid, low-transition, identifier, …
+    reasons: list[str] = field(default_factory=list)
 
 
 def _is_dotenv_filename(name: str) -> bool:
@@ -256,8 +260,8 @@ def scan_text_for_leaks(text: str) -> tuple[list[str], str | None]:
     """
     if not text:
         return [], None
-    likely, _possible, prefix, _bp = scan_text_hits(text)
-    return likely, prefix
+    hits = scan_text_hits(text)
+    return hits.likely_names, hits.prefix
 
 
 def _strings_from_decoded_json(obj: Any) -> list[str]:
@@ -276,79 +280,50 @@ def _strings_from_decoded_json(obj: Any) -> list[str]:
     return out
 
 
-def _merge_hits(
-    likely: list[str],
-    possible: list[str],
-    prefix: str | None,
-    bearer_possible: bool,
-    extra_likely: list[str],
-    extra_possible: list[str],
-    extra_prefix: str | None,
-    extra_bp: bool,
-) -> tuple[list[str], list[str], str | None, bool]:
-    seen_l = {n.upper() for n in likely}
-    seen_p = {n.upper() for n in possible}
-    for name in extra_likely:
-        key = name.upper()
-        if key in seen_l:
+def _apply_secret_keys(acc: HitSet, node: Any) -> None:
+    """Classify secret-named dict keys that never appear as ASSIGN text."""
+    for key, val in iter_secret_keyed_strings(node):
+        extra = HitSet()
+        tier, reason = classify_value(val)
+        if tier == "likely":
+            extra.likely_names = [key]
+            if reason:
+                extra.likely_reasons = [reason]
+        elif tier == "possible":
+            extra.possible_names = [key]
+            if reason:
+                extra.possible_reasons = [reason]
+        else:
             continue
-        seen_l.add(key)
-        likely.append(name)
-        seen_p.discard(key)
-        possible[:] = [n for n in possible if n.upper() != key]
-    for name in extra_possible:
-        key = name.upper()
-        if key in seen_l or key in seen_p:
-            continue
-        seen_p.add(key)
-        possible.append(name)
-    if extra_prefix and prefix is None:
-        prefix = extra_prefix
-    if extra_bp:
-        bearer_possible = True
-    return likely, possible, prefix, bearer_possible
+        acc.merge(extra)
 
 
-def _scan_transcript_payload(
-    obj: Any,
-) -> tuple[list[str], list[str], str | None, bool]:
+def _scan_transcript_payload(obj: Any) -> HitSet:
     """Run detectors on string payloads and secret-named JSON keys.
 
-    Returns likely names, possible names, prefix kind, bearer-possible.
-    Never returns values.
+    String scan unwraps one nested JSON string via ``_strings_from_decoded_json``
+    and does not re-walk those strings. Secret-key walk still covers dict keys
+    that never appear as ASSIGN text (including keys inside the unwrapped
+    object). Never returns values.
     """
-    likely: list[str] = []
-    possible: list[str] = []
-    prefix: str | None = None
-    bearer_possible = False
+    acc = HitSet()
+    nested_objs: list[Any] = []
+    for s in collect_strings(obj):
+        if looks_like_json_container(s):
+            try:
+                nested = json.loads(s)
+            except json.JSONDecodeError:
+                nested = None
+            if isinstance(nested, (dict, list)):
+                nested_objs.append(nested)
 
-    def _apply_obj(node: Any) -> None:
-        nonlocal likely, possible, prefix, bearer_possible
-        for s in _strings_from_decoded_json(node):
-            ln, pn, pref, bp = scan_text_hits(s)
-            likely, possible, prefix, bearer_possible = _merge_hits(
-                likely, possible, prefix, bearer_possible, ln, pn, pref, bp
-            )
-        for key, val in iter_secret_keyed_strings(node):
-            tier = classify_value(val)
-            if tier == "likely":
-                likely, possible, prefix, bearer_possible = _merge_hits(
-                    likely, possible, prefix, bearer_possible, [key], [], None, False
-                )
-            elif tier == "possible":
-                likely, possible, prefix, bearer_possible = _merge_hits(
-                    likely, possible, prefix, bearer_possible, [], [key], None, False
-                )
-            if looks_like_json_container(val):
-                try:
-                    nested = json.loads(val)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(nested, (dict, list)):
-                    _apply_obj(nested)
+    for s in _strings_from_decoded_json(obj):
+        acc.merge(scan_text_hits(s))
 
-    _apply_obj(obj)
-    return likely, possible, prefix, bearer_possible
+    _apply_secret_keys(acc, obj)
+    for nested in nested_objs:
+        _apply_secret_keys(acc, nested)
+    return acc
 
 
 def iter_agent_transcript_files(home: Path | None = None) -> Iterable[Path]:
@@ -408,13 +383,11 @@ def _inline_findings(
     possible_reason: str,
 ) -> list[Finding]:
     """Split content hits into high vs possible findings. Never includes values."""
-    likely_names, possible_names, prefix, bearer_possible = scan_text_hits(text)
-    if path.suffix.lower() == ".md":
-        # Assignment-only hits in docs are not likely; prefix hits still count.
-        for name in likely_names:
-            if name.upper() not in {n.upper() for n in possible_names}:
-                possible_names.append(name)
-        likely_names = []
+    hits = scan_text_hits(text)
+    likely_names = hits.likely_names
+    possible_names = hits.possible_names
+    prefix = hits.prefix
+    bearer_possible = hits.bearer_possible
 
     out: list[Finding] = []
     if likely_names or prefix:
@@ -434,6 +407,7 @@ def _inline_findings(
                 importable=False,
                 scope=scope,
                 confidence="high",
+                reasons=list(hits.likely_reasons),
             )
         )
     if possible_names or bearer_possible:
@@ -449,6 +423,7 @@ def _inline_findings(
                 importable=False,
                 scope=scope,
                 confidence="possible",
+                reasons=list(hits.possible_reasons),
             )
         )
     return out
@@ -467,6 +442,8 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
     possible_lines: list[int] = []
     high_names: list[str] = []
     possible_names: list[str] = []
+    high_reasons: list[str] = []
+    possible_reasons: list[str] = []
     seen_high: set[str] = set()
     seen_possible: set[str] = set()
 
@@ -480,9 +457,11 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                likely, possible, prefix, bearer_possible = _scan_transcript_payload(
-                    obj
-                )
+                hits = _scan_transcript_payload(obj)
+                likely = hits.likely_names
+                possible = hits.possible_names
+                prefix = hits.prefix
+                bearer_possible = hits.bearer_possible
                 high = bool(likely or prefix)
                 poss = bool(possible or bearer_possible)
                 if not high and not poss:
@@ -495,14 +474,24 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                             continue
                         seen_high.add(key)
                         high_names.append(name)
-                elif poss:
-                    possible_lines.append(line_no)
+                    for reason in hits.likely_reasons:
+                        if reason not in high_reasons:
+                            high_reasons.append(reason)
+                # Mixed high+possible lines stay high-only for hit_lines /
+                # transcript_line_hit_count, but possible names/reasons are
+                # still recorded so histograms stay complete.
+                if poss:
+                    if not high:
+                        possible_lines.append(line_no)
                     for name in possible:
                         key = name.upper()
                         if key in seen_possible or key in seen_high:
                             continue
                         seen_possible.add(key)
                         possible_names.append(name)
+                    for reason in hits.possible_reasons:
+                        if reason not in possible_reasons:
+                            possible_reasons.append(reason)
     except OSError:
         return []
 
@@ -523,23 +512,33 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                 scope=scope,
                 hit_lines=high_lines,
                 confidence="high",
+                reasons=high_reasons,
             )
         )
-    if possible_lines:
+    if possible_lines or possible_names:
+        count = len(possible_lines) if possible_lines else max(len(possible_names), 1)
+        if possible_lines:
+            poss_reason = (
+                f"agent session transcript: {len(possible_lines)} line(s) with "
+                "possible identifier- or passphrase-shaped content"
+            )
+        else:
+            poss_reason = (
+                "agent session transcript: possible identifier- or "
+                "passphrase-shaped names on high-confidence lines"
+            )
         out.append(
             Finding(
                 path=str(path),
                 kind="agent_session_transcript",
                 secret_names=possible_names,
-                secret_count=len(possible_lines),
-                reason=(
-                    f"agent session transcript: {len(possible_lines)} line(s) with "
-                    "possible identifier- or passphrase-shaped content"
-                ),
+                secret_count=count,
+                reason=poss_reason,
                 importable=False,
                 scope=scope,
                 hit_lines=possible_lines,
                 confidence="possible",
+                reasons=possible_reasons,
             )
         )
     return out
@@ -562,7 +561,37 @@ def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
         elif kind == "mcp_config":
             names = _json_key_names(path)
             count = max(len(names), 1)
-            reason = f"MCP config ({count} top-level key name(s))"
+            confirmed = any(k in ("mcpServers", "servers") for k in names)
+            if confirmed:
+                return [
+                    Finding(
+                        path=str(path),
+                        kind=kind,
+                        secret_names=names,
+                        secret_count=count,
+                        reason=f"MCP config ({count} top-level key name(s))",
+                        importable=False,
+                        scope=scope,
+                        confidence="high",
+                    )
+                ]
+            # Unrecognised shape: demote to possible, do not drop.
+            return [
+                Finding(
+                    path=str(path),
+                    kind=kind,
+                    secret_names=names,
+                    secret_count=count,
+                    reason=(
+                        "unconfirmed MCP config shape (no top-level "
+                        "mcpServers/servers)"
+                    ),
+                    importable=False,
+                    scope=scope,
+                    confidence="possible",
+                    reasons=[REASON_UNCONFIRMED_MCP],
+                )
+            ]
         elif kind in (".npmrc", ".pypirc"):
             reason = f"{kind} (may contain registry auth tokens)"
         elif kind == "ssh_private_key":

--- a/src/key_amnesia/scan.py
+++ b/src/key_amnesia/scan.py
@@ -291,63 +291,48 @@ def scan_text_for_leaks(text: str) -> tuple[list[str], str | None]:
     return hits.likely_names, hits.prefix
 
 
-def _strings_from_decoded_json(obj: Any) -> list[str]:
-    """Collect strings from a decoded JSON value; unwrap one nested JSON string."""
-    out: list[str] = []
-    for s in collect_strings(obj):
-        out.append(s)
-        if not looks_like_json_container(s):
-            continue
-        try:
-            nested = json.loads(s)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(nested, (dict, list)):
-            out.extend(collect_strings(nested))
-    return out
-
-
 def _apply_secret_keys(acc: HitSet, node: Any) -> None:
     """Classify secret-named dict keys that never appear as ASSIGN text."""
     for key, val in iter_secret_keyed_strings(node):
         extra = HitSet()
         tier, reason = classify_value(val)
-        if tier == "likely":
-            extra.likely_names = [key]
-            if reason:
-                extra.likely_reasons = [reason]
-                extra.likely_reason_counts = {reason: 1}
-        elif tier == "possible":
-            extra.possible_names = [key]
-            if reason:
-                extra.possible_reasons = [reason]
-                extra.possible_reason_counts = {reason: 1}
-        else:
+        if tier not in ("likely", "possible"):
             continue
+        extra.record_assignment(key, tier, [reason] if reason else [])
         acc.merge(extra)
 
 
 def _scan_transcript_payload(obj: Any) -> HitSet:
     """Run detectors on string payloads and secret-named JSON keys.
 
-    String scan unwraps one nested JSON string via ``_strings_from_decoded_json``
-    and does not re-walk those strings. Secret-key walk still covers dict keys
-    that never appear as ASSIGN text (including keys inside the unwrapped
-    object). Never returns values.
+    JSON-container strings are unwrapped once and not run through
+    ``scan_text_hits`` (ASSIGN on serialized JSON plus a secret-key walk
+    would double-count). Non-JSON strings are scanned. Secret-key walk
+    covers dict keys that never appear as ASSIGN text. Never returns values.
     """
     acc = HitSet()
     nested_objs: list[Any] = []
-    for s in collect_strings(obj):
-        if looks_like_json_container(s):
-            try:
-                nested = json.loads(s)
-            except json.JSONDecodeError:
-                nested = None
-            if isinstance(nested, (dict, list)):
-                nested_objs.append(nested)
 
-    for s in _strings_from_decoded_json(obj):
-        acc.merge(scan_text_hits(s))
+    def _ingest_strings(node: Any) -> None:
+        for s in collect_strings(node):
+            if looks_like_json_container(s):
+                try:
+                    nested = json.loads(s)
+                except json.JSONDecodeError:
+                    nested = None
+                if isinstance(nested, (dict, list)):
+                    nested_objs.append(nested)
+                    continue
+            acc.merge(scan_text_hits(s))
+
+    _ingest_strings(obj)
+    # One-level unwrap: inner strings of parsed JSON containers, not the
+    # container text itself (already skipped above).
+    for nested in list(nested_objs):
+        for s in collect_strings(nested):
+            if looks_like_json_container(s):
+                continue
+            acc.merge(scan_text_hits(s))
 
     _apply_secret_keys(acc, obj)
     for nested in nested_objs:
@@ -577,18 +562,25 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                 confidence="certain",
             )
         )
-    if likely_lines:
+    if likely_lines or likely_names:
+        if likely_lines:
+            likely_reason = (
+                f"agent session transcript: {len(likely_lines)} line(s) with "
+                "likely assignment-shaped content (advisory; false "
+                "positives/negatives expected)"
+            )
+        else:
+            likely_reason = (
+                "agent session transcript: likely assignment-shaped names "
+                "on higher-confidence lines"
+            )
         out.append(
             Finding(
                 path=str(path),
                 kind="agent_session_transcript",
                 secret_names=likely_names,
                 secret_count=len(likely_lines),
-                reason=(
-                    f"agent session transcript: {len(likely_lines)} line(s) with "
-                    "likely assignment-shaped content (advisory; false "
-                    "positives/negatives expected)"
-                ),
+                reason=likely_reason,
                 importable=False,
                 scope=scope,
                 hit_lines=likely_lines,
@@ -598,7 +590,6 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
             )
         )
     if possible_lines or possible_names:
-        count = len(possible_lines) if possible_lines else max(len(possible_names), 1)
         if possible_lines:
             poss_reason = (
                 f"agent session transcript: {len(possible_lines)} line(s) with "
@@ -614,7 +605,7 @@ def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
                 path=str(path),
                 kind="agent_session_transcript",
                 secret_names=possible_names,
-                secret_count=count,
+                secret_count=len(possible_lines),
                 reason=poss_reason,
                 importable=False,
                 scope=scope,
@@ -659,12 +650,13 @@ def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
                     )
                 ]
             # Unrecognised shape: demote to possible, do not drop.
+            # Presence/shape finding: one per file, not per top-level key.
             return [
                 Finding(
                     path=str(path),
                     kind=kind,
                     secret_names=names,
-                    secret_count=count,
+                    secret_count=1,
                     reason=(
                         "unconfirmed MCP config shape (no top-level "
                         "mcpServers/servers)"
@@ -673,7 +665,7 @@ def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
                     scope=scope,
                     confidence="possible",
                     reasons=[REASON_UNCONFIRMED_MCP],
-                    reason_counts={REASON_UNCONFIRMED_MCP: count},
+                    reason_counts={REASON_UNCONFIRMED_MCP: 1},
                 )
             ]
         elif kind in (".npmrc", ".pypirc"):
@@ -1065,7 +1057,14 @@ def format_human_report(
         )
         lines.append("")
     gated = gated_confidences(strict)
-    listed = [f for f in findings if f.confidence in gated]
+    listed = [
+        f
+        for f in findings
+        if f.confidence in gated
+        and not (
+            f.secret_count == 0 and f.kind == "agent_session_transcript"
+        )
+    ]
     if not listed:
         lines.append(
             "No locally exposed agent keys found under default exclusions."

--- a/src/key_amnesia/scan.py
+++ b/src/key_amnesia/scan.py
@@ -6,9 +6,11 @@ secret *files* and light assignment / prefix patterns. Reports **names,
 paths, counts, and (for transcripts) line numbers only** — never prints,
 logs, or copies secret values.
 
-Detection is **advisory** regex + entropy heuristics (same vocabulary as
-the secret-guard hook): false positives and false negatives are expected.
-Policy classification: Scan LEAK report is **advisory** (not cryptography).
+Detection is **advisory**. The headline and default exit count
+high-confidence findings only (``likely`` / prefix / filename). Identifier-
+and passphrase-shaped hits are ``possible`` (``--fail-on possible`` to
+gate). Policy classification: Scan LEAK report is **advisory** (not
+cryptography).
 """
 
 from __future__ import annotations
@@ -20,14 +22,14 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
-from key_amnesia.dotenv_import import parse_dotenv
-from key_amnesia.hooks.secret_guard import (
-    _ASSIGN,
-    _BEARER,
-    _PREFIX_PATTERNS,
-    _assignment_is_secret,
-    _collect_strings,
+from key_amnesia.detect import (
+    classify_value,
+    collect_strings,
+    iter_secret_keyed_strings,
+    looks_like_json_container,
+    scan_text_hits,
 )
+from key_amnesia.dotenv_import import parse_dotenv
 
 # Directory basenames skipped by default (B4). ``.git`` skips all git
 # internals — git-*history* secret scanning is intentionally out of scope.
@@ -142,6 +144,8 @@ class Finding:
     scope: str = "project"  # "project" | "deep"
     # 1-based JSONL line numbers (agent transcripts only).
     hit_lines: list[int] = field(default_factory=list)
+    # "high" = leak_count / default exit; "possible" = identifier/passphrase.
+    confidence: str = "high"
 
 
 def _is_dotenv_filename(name: str) -> bool:
@@ -244,79 +248,107 @@ def _json_key_names(path: Path) -> list[str]:
     return []
 
 
-def _content_assignment_names(text: str) -> list[str]:
-    """Reuse hook assignment vocabulary; return matched *names* only."""
-    names: list[str] = []
-    seen: set[str] = set()
-    for match in _ASSIGN.finditer(text):
-        value = match.group("value")
-        if not _assignment_is_secret(value):
-            continue
-        name = match.group("name")
-        key = name.upper()
-        if key in seen:
-            continue
-        seen.add(key)
-        names.append(name)
-    return names
-
-
-def _content_prefix_hit(text: str) -> str | None:
-    for kind, pattern in _PREFIX_PATTERNS:
-        if pattern.search(text):
-            return kind
-    if _BEARER.search(text):
-        return "Bearer token"
-    return None
-
-
 def scan_text_for_leaks(text: str) -> tuple[list[str], str | None]:
-    """Shared detector: assignment *names* + optional prefix/Bearer kind.
+    """High-confidence assignment *names* + optional prefix/Bearer kind.
 
-    Never returns secret values. Same vocabulary as the secret-guard hook.
+    Never returns secret values. Possible-tier hits are omitted here;
+    use ``scan_text_hits`` for the split.
     """
     if not text:
         return [], None
-    return _content_assignment_names(text), _content_prefix_hit(text)
-
-
-def _looks_like_json_container(s: str) -> bool:
-    t = s.lstrip()
-    return t.startswith("{") or t.startswith("[")
+    likely, _possible, prefix, _bp = scan_text_hits(text)
+    return likely, prefix
 
 
 def _strings_from_decoded_json(obj: Any) -> list[str]:
     """Collect strings from a decoded JSON value; unwrap one nested JSON string."""
     out: list[str] = []
-    for s in _collect_strings(obj):
+    for s in collect_strings(obj):
         out.append(s)
-        if not _looks_like_json_container(s):
+        if not looks_like_json_container(s):
             continue
         try:
             nested = json.loads(s)
         except json.JSONDecodeError:
             continue
         if isinstance(nested, (dict, list)):
-            out.extend(_collect_strings(nested))
+            out.extend(collect_strings(nested))
     return out
 
 
-def _scan_transcript_payload(obj: Any) -> tuple[list[str], str | None]:
-    """Run detectors on all string payloads from one JSONL line object."""
-    names: list[str] = []
-    seen: set[str] = set()
+def _merge_hits(
+    likely: list[str],
+    possible: list[str],
+    prefix: str | None,
+    bearer_possible: bool,
+    extra_likely: list[str],
+    extra_possible: list[str],
+    extra_prefix: str | None,
+    extra_bp: bool,
+) -> tuple[list[str], list[str], str | None, bool]:
+    seen_l = {n.upper() for n in likely}
+    seen_p = {n.upper() for n in possible}
+    for name in extra_likely:
+        key = name.upper()
+        if key in seen_l:
+            continue
+        seen_l.add(key)
+        likely.append(name)
+        seen_p.discard(key)
+        possible[:] = [n for n in possible if n.upper() != key]
+    for name in extra_possible:
+        key = name.upper()
+        if key in seen_l or key in seen_p:
+            continue
+        seen_p.add(key)
+        possible.append(name)
+    if extra_prefix and prefix is None:
+        prefix = extra_prefix
+    if extra_bp:
+        bearer_possible = True
+    return likely, possible, prefix, bearer_possible
+
+
+def _scan_transcript_payload(
+    obj: Any,
+) -> tuple[list[str], list[str], str | None, bool]:
+    """Run detectors on string payloads and secret-named JSON keys.
+
+    Returns likely names, possible names, prefix kind, bearer-possible.
+    Never returns values.
+    """
+    likely: list[str] = []
+    possible: list[str] = []
     prefix: str | None = None
-    for s in _strings_from_decoded_json(obj):
-        line_names, line_prefix = scan_text_for_leaks(s)
-        for name in line_names:
-            key = name.upper()
-            if key in seen:
-                continue
-            seen.add(key)
-            names.append(name)
-        if line_prefix and prefix is None:
-            prefix = line_prefix
-    return names, prefix
+    bearer_possible = False
+
+    def _apply_obj(node: Any) -> None:
+        nonlocal likely, possible, prefix, bearer_possible
+        for s in _strings_from_decoded_json(node):
+            ln, pn, pref, bp = scan_text_hits(s)
+            likely, possible, prefix, bearer_possible = _merge_hits(
+                likely, possible, prefix, bearer_possible, ln, pn, pref, bp
+            )
+        for key, val in iter_secret_keyed_strings(node):
+            tier = classify_value(val)
+            if tier == "likely":
+                likely, possible, prefix, bearer_possible = _merge_hits(
+                    likely, possible, prefix, bearer_possible, [key], [], None, False
+                )
+            elif tier == "possible":
+                likely, possible, prefix, bearer_possible = _merge_hits(
+                    likely, possible, prefix, bearer_possible, [], [key], None, False
+                )
+            if looks_like_json_container(val):
+                try:
+                    nested = json.loads(val)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(nested, (dict, list)):
+                    _apply_obj(nested)
+
+    _apply_obj(obj)
+    return likely, possible, prefix, bearer_possible
 
 
 def iter_agent_transcript_files(home: Path | None = None) -> Iterable[Path]:
@@ -366,18 +398,77 @@ def iter_agent_transcript_files(home: Path | None = None) -> Iterable[Path]:
             pass
 
 
-def _finding_for_transcript(path: Path, *, scope: str) -> Finding | None:
+def _inline_findings(
+    path: Path,
+    text: str,
+    *,
+    scope: str,
+    kind: str,
+    high_reason: str,
+    possible_reason: str,
+) -> list[Finding]:
+    """Split content hits into high vs possible findings. Never includes values."""
+    likely_names, possible_names, prefix, bearer_possible = scan_text_hits(text)
+    if path.suffix.lower() == ".md":
+        # Assignment-only hits in docs are not likely; prefix hits still count.
+        for name in likely_names:
+            if name.upper() not in {n.upper() for n in possible_names}:
+                possible_names.append(name)
+        likely_names = []
+
+    out: list[Finding] = []
+    if likely_names or prefix:
+        count = len(likely_names) if likely_names else 1
+        reason = high_reason
+        if prefix and not likely_names:
+            reason = f"inline credential-shaped token ({prefix})"
+        elif prefix and likely_names:
+            reason = f"assignment + {prefix}"
+        out.append(
+            Finding(
+                path=str(path),
+                kind=kind,
+                secret_names=likely_names,
+                secret_count=count,
+                reason=reason,
+                importable=False,
+                scope=scope,
+                confidence="high",
+            )
+        )
+    if possible_names or bearer_possible:
+        names = possible_names
+        count = len(names) if names else 1
+        out.append(
+            Finding(
+                path=str(path),
+                kind=kind,
+                secret_names=names,
+                secret_count=count,
+                reason=possible_reason,
+                importable=False,
+                scope=scope,
+                confidence="possible",
+            )
+        )
+    return out
+
+
+def _findings_for_transcript(path: Path, *, scope: str) -> list[Finding]:
     """Scan one JSONL session transcript; names/paths/line hits only."""
     try:
         size = path.stat().st_size
     except OSError:
-        return None
+        return []
     if size > _MAX_TRANSCRIPT_BYTES:
-        return None
+        return []
 
-    hit_lines: list[int] = []
-    all_names: list[str] = []
-    seen_names: set[str] = set()
+    high_lines: list[int] = []
+    possible_lines: list[int] = []
+    high_names: list[str] = []
+    possible_names: list[str] = []
+    seen_high: set[str] = set()
+    seen_possible: set[str] = set()
 
     try:
         with path.open("r", encoding="utf-8", errors="replace") as fh:
@@ -389,42 +480,76 @@ def _finding_for_transcript(path: Path, *, scope: str) -> Finding | None:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                names, prefix = _scan_transcript_payload(obj)
-                if not names and not prefix:
+                likely, possible, prefix, bearer_possible = _scan_transcript_payload(
+                    obj
+                )
+                high = bool(likely or prefix)
+                poss = bool(possible or bearer_possible)
+                if not high and not poss:
                     continue
-                hit_lines.append(line_no)
-                for name in names:
-                    key = name.upper()
-                    if key in seen_names:
-                        continue
-                    seen_names.add(key)
-                    all_names.append(name)
+                if high:
+                    high_lines.append(line_no)
+                    for name in likely:
+                        key = name.upper()
+                        if key in seen_high:
+                            continue
+                        seen_high.add(key)
+                        high_names.append(name)
+                elif poss:
+                    possible_lines.append(line_no)
+                    for name in possible:
+                        key = name.upper()
+                        if key in seen_possible or key in seen_high:
+                            continue
+                        seen_possible.add(key)
+                        possible_names.append(name)
     except OSError:
-        return None
+        return []
 
-    if not hit_lines:
-        return None
+    out: list[Finding] = []
+    if high_lines:
+        out.append(
+            Finding(
+                path=str(path),
+                kind="agent_session_transcript",
+                secret_names=high_names,
+                secret_count=len(high_lines),
+                reason=(
+                    f"agent session transcript: {len(high_lines)} line(s) with "
+                    "high-confidence credential-shaped content (advisory; false "
+                    "positives/negatives expected)"
+                ),
+                importable=False,
+                scope=scope,
+                hit_lines=high_lines,
+                confidence="high",
+            )
+        )
+    if possible_lines:
+        out.append(
+            Finding(
+                path=str(path),
+                kind="agent_session_transcript",
+                secret_names=possible_names,
+                secret_count=len(possible_lines),
+                reason=(
+                    f"agent session transcript: {len(possible_lines)} line(s) with "
+                    "possible identifier- or passphrase-shaped content"
+                ),
+                importable=False,
+                scope=scope,
+                hit_lines=possible_lines,
+                confidence="possible",
+            )
+        )
+    return out
 
-    return Finding(
-        path=str(path),
-        kind="agent_session_transcript",
-        secret_names=all_names,
-        secret_count=len(hit_lines),
-        reason=(
-            f"agent session transcript: {len(hit_lines)} line(s) with "
-            "credential-shaped content (advisory regex+entropy; false "
-            "positives/negatives expected)"
-        ),
-        importable=False,
-        scope=scope,
-        hit_lines=hit_lines,
-    )
 
-
-def _finding_for_path(path: Path, *, scope: str) -> Finding | None:
+def _findings_for_path(path: Path, *, scope: str) -> list[Finding]:
     kind = _filename_kind(path)
     if kind == "dotenv":
-        return _dotenv_finding(path, scope=scope)
+        finding = _dotenv_finding(path, scope=scope)
+        return [] if finding is None else [finding]
 
     if kind is not None:
         names: list[str] = []
@@ -439,73 +564,62 @@ def _finding_for_path(path: Path, *, scope: str) -> Finding | None:
             count = max(len(names), 1)
             reason = f"MCP config ({count} top-level key name(s))"
         elif kind in (".npmrc", ".pypirc"):
-            # Presence alone is a LEAK; don't parse auth tokens into names.
             reason = f"{kind} (may contain registry auth tokens)"
         elif kind == "ssh_private_key":
             reason = "SSH private key file"
         elif kind == "shell_history":
             text = _safe_read_text(path)
-            if text:
-                prefix = _content_prefix_hit(text)
-                assigns = _content_assignment_names(text)
-                if prefix or assigns:
-                    names = assigns
-                    count = max(len(assigns), 1 if prefix else 0)
-                    reason = "shell history with credential-shaped content"
-                else:
-                    return None  # empty/harmless history — not a LEAK
-            else:
-                return None
+            if not text:
+                return []
+            return _inline_findings(
+                path,
+                text,
+                scope=scope,
+                kind=kind,
+                high_reason="shell history with credential-shaped content",
+                possible_reason=(
+                    "shell history with possible identifier- or "
+                    "passphrase-shaped content"
+                ),
+            )
         elif kind == "git_config":
             text = _safe_read_text(path) or ""
-            # Only flag if it looks like it embeds a token (url with @, etc.)
             if not re.search(
                 r"(?i)(token|password|authorization|_authToken)\s*=", text
             ) and "://" not in text:
-                # Still check for github token-ish in https URLs
                 if not re.search(r"https?://[^/\s:]+:[^/\s]+@", text):
-                    return None
+                    return []
             reason = "git config may embed credentials"
-        return Finding(
-            path=str(path),
-            kind=kind,
-            secret_names=names,
-            secret_count=count,
-            reason=reason,
-            importable=False,
-            scope=scope,
-        )
+        return [
+            Finding(
+                path=str(path),
+                kind=kind,
+                secret_names=names,
+                secret_count=count,
+                reason=reason,
+                importable=False,
+                scope=scope,
+                confidence="high",
+            )
+        ]
 
-    # Light content scan for assignment / well-known prefixes.
     suffix = path.suffix.lower()
     if suffix not in _CONTENT_SCAN_SUFFIXES and path.name not in {
         "Dockerfile",
         "Makefile",
         "Jenkinsfile",
     }:
-        return None
+        return []
     text = _safe_read_text(path)
     if not text:
-        return None
-    names, prefix = scan_text_for_leaks(text)
-    if not names and not prefix:
-        return None
-    count = len(names) if names else 1
-    reason = (
-        f"inline credential-shaped token ({prefix})"
-        if prefix and not names
-        else "assignment pattern matching secret-guard vocabulary"
-    )
-    if prefix and names:
-        reason = f"assignment + {prefix}"
-    return Finding(
-        path=str(path),
-        kind="inline",
-        secret_names=names,
-        secret_count=count,
-        reason=reason,
-        importable=False,
+        return []
+    return _inline_findings(
+        path,
+        text,
         scope=scope,
+        kind="inline",
+        high_reason="assignment pattern matching secret-guard vocabulary",
+        possible_reason="possible identifier- or passphrase-shaped assignment",
     )
 
 
@@ -551,21 +665,23 @@ def scan_project(
                 continue
         except OSError:
             continue
-        finding = _finding_for_path(path, scope="project")
-        if finding is None:
+        key = str(path)
+        try:
+            key = str(path.resolve())
+        except OSError:
+            pass
+        if key in seen:
             continue
-        # Skip comment-only / empty dotenv files (no LEAK secrets to report).
-        if (
-            finding.kind == "dotenv"
-            and finding.secret_count == 0
-            and not finding.secret_names
-        ):
-            continue
-        if finding.path in seen:
-            continue
-        seen.add(finding.path)
-        findings.append(finding)
-    findings.sort(key=lambda f: f.path)
+        seen.add(key)
+        for finding in _findings_for_path(path, scope="project"):
+            if (
+                finding.kind == "dotenv"
+                and finding.secret_count == 0
+                and not finding.secret_names
+            ):
+                continue
+            findings.append(finding)
+    findings.sort(key=lambda f: (f.path, f.confidence))
     return findings
 
 
@@ -637,15 +753,22 @@ def scan_deep(home: Path | None = None) -> list[Finding]:
                 continue
         except OSError:
             continue
-        finding = _finding_for_path(path, scope="deep")
-        if finding is None:
+        key = str(path)
+        try:
+            key = str(path.resolve())
+        except OSError:
+            pass
+        if key in seen:
             continue
-        if finding.kind == "dotenv" and finding.secret_count == 0 and not finding.secret_names:
-            continue
-        if finding.path in seen:
-            continue
-        seen.add(finding.path)
-        findings.append(finding)
+        seen.add(key)
+        for finding in _findings_for_path(path, scope="deep"):
+            if (
+                finding.kind == "dotenv"
+                and finding.secret_count == 0
+                and not finding.secret_names
+            ):
+                continue
+            findings.append(finding)
 
     for path in iter_agent_transcript_files(home):
         try:
@@ -654,28 +777,33 @@ def scan_deep(home: Path | None = None) -> list[Finding]:
             key = str(path)
         if key in seen:
             continue
-        finding = _finding_for_transcript(path, scope="deep")
-        if finding is None:
-            continue
-        seen.add(finding.path)
-        # Also mark resolved key so candidate-path overlap cannot double-count.
         seen.add(key)
-        findings.append(finding)
+        for finding in _findings_for_transcript(path, scope="deep"):
+            seen.add(finding.path)
+            findings.append(finding)
 
-    findings.sort(key=lambda f: f.path)
+    findings.sort(key=lambda f: (f.path, f.confidence))
     return findings
 
 
 def leak_count(findings: list[Finding]) -> int:
-    return sum(max(f.secret_count, 0) for f in findings)
+    return sum(
+        max(f.secret_count, 0) for f in findings if f.confidence == "high"
+    )
+
+
+def possible_count(findings: list[Finding]) -> int:
+    return sum(
+        max(f.secret_count, 0) for f in findings if f.confidence == "possible"
+    )
 
 
 def transcript_line_hit_count(findings: list[Finding]) -> int:
-    """Sum of LEAK line-hits in ``agent_session_transcript`` findings."""
+    """Sum of high-confidence LEAK line-hits in transcript findings."""
     return sum(
         max(f.secret_count, 0)
         for f in findings
-        if f.kind == "agent_session_transcript"
+        if f.kind == "agent_session_transcript" and f.confidence == "high"
     )
 
 
@@ -683,9 +811,20 @@ def headline(findings: list[Finding], *, project_label: str = "this project") ->
     n = leak_count(findings)
     unit = "LEAK" if n == 1 else "LEAKs"
     return (
-        f"{n} {unit} found — your agent can read {n} secret"
+        f"{n} high-confidence {unit} found — your agent can read {n} secret"
         f"{'' if n == 1 else 's'} in {project_label} "
         f"(LEAK = Locally Exposed Agent Keys)"
+    )
+
+
+def _possible_note(findings: list[Finding]) -> str | None:
+    p = possible_count(findings)
+    if p == 0:
+        return None
+    unit = "hit" if p == 1 else "hits"
+    return (
+        f"{p} possible identifier- or passphrase-shaped {unit} not counted; "
+        f"--fail-on possible to gate on them"
     )
 
 
@@ -694,14 +833,15 @@ def findings_to_json(findings: list[Finding], *, project_root: str) -> dict[str,
     transcript_hits = transcript_line_hit_count(findings)
     return {
         "leak_count": n,
+        "possible_count": possible_count(findings),
         "transcript_line_hits": transcript_hits,
         "headline": headline(findings),
         "project_root": project_root,
         "findings": [asdict(f) for f in findings],
         "detection_note": (
-            "Advisory regex+entropy heuristics (secret-guard vocabulary); "
-            "false positives and false negatives are expected. "
-            "Values are never included."
+            "Advisory heuristics; leak_count is high-confidence only "
+            "(likely / prefix / filename). possible_count is identifier- or "
+            "passphrase-shaped. Values are never included."
         ),
     }
 
@@ -718,8 +858,17 @@ def _format_hit_lines(hit_lines: list[int]) -> str:
     return f"\n      lines: {shown} (and {rest} more; see --json)"
 
 
-def format_human_report(findings: list[Finding], *, project_root: Path) -> str:
+def format_human_report(
+    findings: list[Finding],
+    *,
+    project_root: Path,
+    show_possible: bool = False,
+) -> str:
     lines: list[str] = [headline(findings), ""]
+    note = _possible_note(findings)
+    if note:
+        lines.append(note)
+        lines.append("")
     transcript_hits = transcript_line_hit_count(findings)
     if transcript_hits:
         unit = "LEAK" if transcript_hits == 1 else "LEAKs"
@@ -728,16 +877,31 @@ def format_human_report(findings: list[Finding], *, project_root: Path) -> str:
             f"(line-hits; advisory detection)"
         )
         lines.append("")
-    if not findings:
-        lines.append("No locally exposed agent keys found under default exclusions.")
+    listed = [
+        f
+        for f in findings
+        if f.confidence == "high" or (show_possible and f.confidence == "possible")
+    ]
+    if not listed:
+        if possible_count(findings) and not show_possible:
+            lines.append(
+                "No high-confidence locally exposed agent keys found under "
+                "default exclusions. Use --show-possible to list identifier- "
+                "or passphrase-shaped hits."
+            )
+        else:
+            lines.append(
+                "No locally exposed agent keys found under default exclusions."
+            )
         return "\n".join(lines)
     lines.append(f"Project root: {project_root}")
     lines.append("")
-    for i, f in enumerate(findings, start=1):
+    for i, f in enumerate(listed, start=1):
         names = ", ".join(f.secret_names) if f.secret_names else "(filename/presence)"
         lines.append(
             f"  [{i}] {f.path}"
-            f"\n      kind={f.kind}  count={f.secret_count}  scope={f.scope}"
+            f"\n      kind={f.kind}  count={f.secret_count}  "
+            f"scope={f.scope}  confidence={f.confidence}"
             f"\n      names: {names}"
             f"\n      {f.reason}"
             + ("  [importable]" if f.importable else "")
@@ -749,8 +913,9 @@ def format_human_report(findings: list[Finding], *, project_root: Path) -> str:
         "post-scan offer, or run `ka import FILE`."
     )
     lines.append(
-        "Detection is advisory (regex + entropy heuristics); false positives "
-        "and false negatives are expected."
+        "Detection is advisory; false positives and false negatives are "
+        "expected. Word-shaped passphrases appear under possible, not the "
+        "headline count."
     )
     return "\n".join(lines)
 

--- a/src/key_amnesia/skills/key-amnesia-hygiene/SKILL.md
+++ b/src/key_amnesia/skills/key-amnesia-hygiene/SKILL.md
@@ -24,7 +24,7 @@ This skill is advisory: it describes the same detection vocabulary as the blocki
 Treat text as secret-shaped if either is true:
 
 - **Known prefixes anywhere:** `sk-`, `sk-ant-`, `ghp_`/`github_pat_`, `AKIA...`, `xoxb-`/other `xox*-`, `AIza...`, plus Stripe (`sk_live_`/`rk_live_`), `npm_`, `glpat-`, and generic `Bearer <token>`.
-- **Assignment + high entropy:** a `(API_KEY|TOKEN|SECRET|PASSWORD)[:=]` style assignment whose value is long and mixed-case/digit (looks random), not a placeholder. Function-call values (`secrets.token_hex(8)`) and type annotations (`Optional[str]`) are not findings. CamelCase identifiers and word-shaped passphrases (`CorrectHorseBattery`) still match this hook vocabulary — that over-block is intentional. (`ka scan` counts those as `possible` only; the headline uses `likely` / prefix.)
+- **Assignment + high entropy:** a `(API_KEY|TOKEN|SECRET|PASSWORD)[:=]` style assignment whose value is long and mixed-case/digit (looks random), not a placeholder. Function-call values (`secrets.token_hex(8)`) and type annotations (`Optional[str]`) are not findings. CamelCase identifiers and word-shaped passphrases (`CorrectHorseBattery`) still match this hook vocabulary — that over-block is intentional. (`ka scan` counts those as `possible` only; the default `--strict high` headline uses certain + likely / prefix.)
 
 **Not** a finding by itself (do not flag): bare `API_KEY` with no value, a comment that merely mentions "secret", or an assignment to an obvious placeholder like `PASSWORD=test123` / `TOKEN=changeme`. Advisory judgment still applies — use sense, don't nag on clearly-fake values.
 

--- a/src/key_amnesia/skills/key-amnesia-hygiene/SKILL.md
+++ b/src/key_amnesia/skills/key-amnesia-hygiene/SKILL.md
@@ -24,7 +24,7 @@ This skill is advisory: it describes the same detection vocabulary as the blocki
 Treat text as secret-shaped if either is true:
 
 - **Known prefixes anywhere:** `sk-`, `sk-ant-`, `ghp_`/`github_pat_`, `AKIA...`, `xoxb-`/other `xox*-`, `AIza...`, plus Stripe (`sk_live_`/`rk_live_`), `npm_`, `glpat-`, and generic `Bearer <token>`.
-- **Assignment + high entropy:** a `(API_KEY|TOKEN|SECRET|PASSWORD)[:=]` style assignment whose value is long and mixed-case/digit (looks random), not a placeholder.
+- **Assignment + high entropy:** a `(API_KEY|TOKEN|SECRET|PASSWORD)[:=]` style assignment whose value is long and mixed-case/digit (looks random), not a placeholder. Function-call values (`secrets.token_hex(8)`) and type annotations (`Optional[str]`) are not findings. CamelCase identifiers and word-shaped passphrases (`CorrectHorseBattery`) still match this hook vocabulary — that over-block is intentional. (`ka scan` counts those as `possible` only; the headline uses `likely` / prefix.)
 
 **Not** a finding by itself (do not flag): bare `API_KEY` with no value, a comment that merely mentions "secret", or an assignment to an obvious placeholder like `PASSWORD=test123` / `TOKEN=changeme`. Advisory judgment still applies — use sense, don't nag on clearly-fake values.
 

--- a/tests/fixtures/scan_corpus/README.md
+++ b/tests/fixtures/scan_corpus/README.md
@@ -1,0 +1,30 @@
+# Scan corpus
+
+Labeled synthetic *shapes* for the shared detector in `key_amnesia.detect`.
+No harvested transcripts. No live keys. Tests must never print fixture values.
+
+## Categories
+
+**`negatives/`** — not credentials. Scan `leak_count` must be 0. Classifier
+must not return `likely` or `prefix`. May be `none` (function-call, type
+annotation, placeholder) or `possible` (camelCase identifiers the hook still
+denies). The label means “must not be high-confidence,” not “the hook allows.”
+
+**`demoted/`** — plausible credentials **intentionally** classified below
+`likely` (named weakening 3: word-shaped passphrase, ≥2 vowel-bearing
+segments, no digits). Must be `possible`, not `none`, not `likely`. The hook
+still denies. Not in `leak_count`. `--fail-on possible` is the CI opt-in.
+Every file here must appear in the named-weakening list.
+
+**`positives/`** — on-disk prefix samples only, constructed like
+`KNOWN_PREFIX_SAMPLES` (repeated `a` / `0`). Must classify as `prefix` /
+high. Stripe `sk_live_` / `rk_live_` prefixes are **not** on disk: GitHub
+push protection flags even the repeated-`a` construction. Cover them in
+hook tests via concatenation. Unprefixed `likely` values are **generated at
+test time** into pytest tmp (`.env` / JSON / YAML / TOML / `export`), not
+committed, so GitHub secret scanning does not block the PR.
+
+## Order
+
+A “before” measurement using the 0.4.9 assignment heuristic is recorded in
+`tests/test_scan_corpus.py`. Thresholds were frozen only after that.

--- a/tests/fixtures/scan_corpus/README.md
+++ b/tests/fixtures/scan_corpus/README.md
@@ -5,24 +5,29 @@ No harvested transcripts. No live keys. Tests must never print fixture values.
 
 ## Categories
 
-**`negatives/`** — not credentials. Scan `leak_count` must be 0. Classifier
-must not return `likely` or `prefix`. May be `none` (function-call, type
-annotation, placeholder) or `possible` (camelCase identifiers the hook still
-denies). The label means “must not be high-confidence,” not “the hook allows.”
+**`negatives/`** — not credentials. Scan default `leak_count` (`--strict high`)
+must be 0. Classifier must not return `likely` or `prefix`. May be `none`
+(function-call, type annotation, placeholder) or `possible` (camelCase
+identifiers the hook still denies). The label means “must not be certain or
+likely,” not “the hook allows.”
 
 **`demoted/`** — plausible credentials **intentionally** classified below
-`likely` (named weakening 3: word-shaped passphrase, ≥2 vowel-bearing
-segments, no digits). Must be `possible`, not `none`, not `likely`. The hook
-still denies. Not in `leak_count`. `--fail-on possible` is the CI opt-in.
-Every file here must appear in the named-weakening list.
+`likely` (named weakenings: word-shaped passphrase, low-transition, and
+unconfirmed `mcp.json` shape). Must be `possible`, not `none`, not `likely`.
+The hook still denies value-shaped demotions. Not in default `leak_count`.
+`--strict paranoid` is the CI opt-in (the ≤0.4.9 assignment gate). Every
+named weakening has a fixture here or in `negatives/` (function-call and
+type-annotation are `none`). `uuid` is generated at test time, not committed.
+Expected field shape (docs only, no live tree): 1 certain dotenv + 2 possible
+unconfirmed-mcp.
 
 **`positives/`** — on-disk prefix samples only, constructed like
 `KNOWN_PREFIX_SAMPLES` (repeated `a` / `0`). Must classify as `prefix` /
-high. Stripe `sk_live_` / `rk_live_` prefixes are **not** on disk: GitHub
+certain. Stripe `sk_live_` / `rk_live_` prefixes are **not** on disk: GitHub
 push protection flags even the repeated-`a` construction. Cover them in
 hook tests via concatenation. Unprefixed `likely` values are **generated at
-test time** into pytest tmp (`.env` / JSON / YAML / TOML / `export`), not
-committed, so GitHub secret scanning does not block the PR.
+test time** into pytest tmp (`.env` / JSON / YAML / TOML / `export` / UUID),
+not committed, so GitHub secret scanning does not block the PR.
 
 ## Order
 

--- a/tests/fixtures/scan_corpus/demoted/low_transition_summervineyard.py
+++ b/tests/fixtures/scan_corpus/demoted/low_transition_summervineyard.py
@@ -1,0 +1,3 @@
+# Named weakening: low character-class transition → possible, not likely.
+# Hook still denies. Scan leak_count omits it.
+api_key = SummerVineyard2026

--- a/tests/fixtures/scan_corpus/demoted/low_transition_summervineyard.py
+++ b/tests/fixtures/scan_corpus/demoted/low_transition_summervineyard.py
@@ -1,3 +1,3 @@
 # Named weakening: low character-class transition → possible, not likely.
-# Hook still denies. Scan leak_count omits it.
+# Hook still denies. Scan leak_count omits it; --strict paranoid gates it.
 api_key = SummerVineyard2026

--- a/tests/fixtures/scan_corpus/demoted/mcp.json
+++ b/tests/fixtures/scan_corpus/demoted/mcp.json
@@ -1,0 +1,1 @@
+{"name": "demo", "theme": "dark"}

--- a/tests/fixtures/scan_corpus/demoted/mcp.json
+++ b/tests/fixtures/scan_corpus/demoted/mcp.json
@@ -1,1 +1,1 @@
-{"name": "demo", "theme": "dark"}
+{"name": "demo"}

--- a/tests/fixtures/scan_corpus/demoted/passphrase_correct_horse_battery.py
+++ b/tests/fixtures/scan_corpus/demoted/passphrase_correct_horse_battery.py
@@ -1,0 +1,3 @@
+# Named weakening 3: word-shaped passphrase → possible, not likely.
+# Hook still denies. Scan leak_count omits it; --fail-on possible gates it.
+password = CorrectHorseBattery

--- a/tests/fixtures/scan_corpus/demoted/passphrase_correct_horse_battery.py
+++ b/tests/fixtures/scan_corpus/demoted/passphrase_correct_horse_battery.py
@@ -1,3 +1,3 @@
 # Named weakening 3: word-shaped passphrase → possible, not likely.
-# Hook still denies. Scan leak_count omits it; --fail-on possible gates it.
+# Hook still denies. Scan leak_count omits it; --strict paranoid gates it.
 password = CorrectHorseBattery

--- a/tests/fixtures/scan_corpus/negatives/bearer_identifier.txt
+++ b/tests/fixtures/scan_corpus/negatives/bearer_identifier.txt
@@ -1,0 +1,1 @@
+Authorization: Bearer someVariableName

--- a/tests/fixtures/scan_corpus/negatives/camelcase_identifier.py
+++ b/tests/fixtures/scan_corpus/negatives/camelcase_identifier.py
@@ -1,0 +1,4 @@
+# Code identifiers, not credentials. Hook still denies (possible). Scan leak_count 0.
+secret = mySecretValue
+password = userPassword
+token = someVariableName

--- a/tests/fixtures/scan_corpus/negatives/doc_prose.md
+++ b/tests/fixtures/scan_corpus/negatives/doc_prose.md
@@ -1,0 +1,2 @@
+The service requires an api_key in the vault. Do not paste tokens into chat.
+Rotation of the secret is handled by the operator.

--- a/tests/fixtures/scan_corpus/negatives/function_call_get_token.py
+++ b/tests/fixtures/scan_corpus/negatives/function_call_get_token.py
@@ -1,0 +1,4 @@
+# Function-call value — never a credential (named weakening 1).
+Token = GetTokenFromCache()
+access = GetAccessToken()
+key = loadApiKey()

--- a/tests/fixtures/scan_corpus/negatives/function_call_secrets.py
+++ b/tests/fixtures/scan_corpus/negatives/function_call_secrets.py
@@ -1,0 +1,3 @@
+# This repo's own source shape (ipc.py / guard.py).
+token = secrets.token_hex(8)
+new_token = secrets_mod.token_urlsafe(32)

--- a/tests/fixtures/scan_corpus/negatives/json_get_token.json
+++ b/tests/fixtures/scan_corpus/negatives/json_get_token.json
@@ -1,0 +1,1 @@
+{"api_key": "GetTokenFromCache"}

--- a/tests/fixtures/scan_corpus/negatives/placeholders.env.txt
+++ b/tests/fixtures/scan_corpus/negatives/placeholders.env.txt
@@ -1,0 +1,5 @@
+PASSWORD=test123
+TOKEN=changeme
+API_KEY=placeholder
+SECRET=xxxxxxxx
+TOKEN=your_api_key

--- a/tests/fixtures/scan_corpus/negatives/transcript_wrapping.jsonl
+++ b/tests/fixtures/scan_corpus/negatives/transcript_wrapping.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","message":{"content":"token = secrets.token_hex(8)"}}
+{"type":"user","message":{"content":"secret = mySecretValue"}}
+{"toolUse":"{\"command\":\"TOKEN=changeme\"}"}

--- a/tests/fixtures/scan_corpus/negatives/type_annotation.py
+++ b/tests/fixtures/scan_corpus/negatives/type_annotation.py
@@ -1,0 +1,4 @@
+from typing import Optional
+
+token: Optional[str]
+secret: Optional[str]

--- a/tests/fixtures/scan_corpus/negatives/yaml_get_token.yaml
+++ b/tests/fixtures/scan_corpus/negatives/yaml_get_token.yaml
@@ -1,0 +1,2 @@
+token: GetTokenFromCache
+api_key: loadApiKey()

--- a/tests/fixtures/scan_corpus/positives/prefixes.txt
+++ b/tests/fixtures/scan_corpus/positives/prefixes.txt
@@ -1,0 +1,11 @@
+# Prefix positives: repeated a/0 construction (same as KNOWN_PREFIX_SAMPLES).
+# Not a .env file. Low entropy; partner secret-scanning patterns should not fire.
+sk-aaaaaaaaaaaaaaaaaaaaaaaaa
+sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaa
+AKIA0000000000000000
+ghp_aaaaaaaaaaaaaaaaaaaaaaaaa
+github_pat_aaaaaaaaaaaaaaaaaaaaaaaaa
+glpat-aaaaaaaaaaaaaaaaaaaaaaaaa
+xoxb-aaaaaaaaaaaaaaaaaaaaaaaaa
+AIzaaaaaaaaaaaaaaaaaaaaaaaaaa
+npm_aaaaaaaaaaaaaaaaaaaaaaaaa

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -53,7 +53,10 @@ def test_scan_finds_dotenv_names_not_values(ka_home, project_dir, capsys) -> Non
 
     assert rc == 1
     assert data["leak_count"] == 2
+    assert data["possible_count"] == 0
+    assert data["findings"][0]["confidence"] == "high"
     assert "LEAK" in data["headline"]
+    assert "high-confidence" in data["headline"]
     assert SECRET_VALUE not in captured.out
     assert SECRET_VALUE_2 not in captured.out
     assert SECRET_VALUE not in captured.err
@@ -72,7 +75,8 @@ def test_scan_clean_tree_exits_zero(ka_home, project_dir, capsys) -> None:
     out = capsys.readouterr().out
 
     assert rc == 0
-    assert "0 LEAK" in out or "0 LEAKs" in out
+    assert "high-confidence" in out
+    assert "LEAK" in out
 
 
 def test_scan_excludes_node_modules_and_venv_by_default(
@@ -170,7 +174,7 @@ def test_scan_headline_wording() -> None:
         )
     ]
     text = headline(findings)
-    assert text.startswith("2 LEAKs found")
+    assert text.startswith("2 high-confidence LEAKs found")
     assert "your agent can read 2 secrets" in text
     assert "Locally Exposed Agent Keys" in text
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -54,9 +54,13 @@ def test_scan_finds_dotenv_names_not_values(ka_home, project_dir, capsys) -> Non
     assert rc == 1
     assert data["leak_count"] == 2
     assert data["possible_count"] == 0
-    assert data["findings"][0]["confidence"] == "high"
+    assert data["certain_count"] == 2
+    assert data["likely_count"] == 0
+    assert data["findings"][0]["confidence"] == "certain"
     assert "LEAK" in data["headline"]
-    assert "high-confidence" in data["headline"]
+    assert "--strict high" in data["headline"]
+    assert "high-confidence" not in data["headline"]
+    assert "reasons" in data["findings"][0]
     assert SECRET_VALUE not in captured.out
     assert SECRET_VALUE_2 not in captured.out
     assert SECRET_VALUE not in captured.err
@@ -75,7 +79,8 @@ def test_scan_clean_tree_exits_zero(ka_home, project_dir, capsys) -> None:
     out = capsys.readouterr().out
 
     assert rc == 0
-    assert "high-confidence" in out
+    assert "--strict high" in out
+    assert "0 certain · 0 likely · 0 possible" in out
     assert "LEAK" in out
 
 
@@ -113,6 +118,22 @@ def test_scan_include_excluded_finds_nested_dotenv(
     (nm / ".env").write_text(f"NESTED={SECRET_VALUE}\n", encoding="utf-8")
 
     rc = main(["scan", "--include-excluded", "--no-import", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert data["leak_count"] == 1
+    assert any("node_modules" in f["path"] for f in data["findings"])
+    assert SECRET_VALUE not in json.dumps(data)
+
+
+def test_scan_wide_aliases_include_excluded(
+    ka_home, project_dir, capsys
+) -> None:
+    nm = project_dir / "node_modules" / "pkg"
+    nm.mkdir(parents=True)
+    (nm / ".env").write_text(f"NESTED={SECRET_VALUE}\n", encoding="utf-8")
+
+    rc = main(["scan", "--wide", "--no-import", "--json"])
     data = json.loads(capsys.readouterr().out)
 
     assert rc == 1
@@ -171,10 +192,11 @@ def test_scan_headline_wording() -> None:
             secret_count=2,
             reason="test",
             importable=True,
+            confidence="certain",
         )
     ]
     text = headline(findings)
-    assert text.startswith("2 high-confidence LEAKs found")
+    assert text.startswith("2 LEAKs found (--strict high)")
     assert "your agent can read 2 secrets" in text
     assert "Locally Exposed Agent Keys" in text
 
@@ -407,28 +429,32 @@ def test_scan_deep_agent_transcripts_line_hits(
     findings = scan_deep(home)
     transcripts = [f for f in findings if f.kind == "agent_session_transcript"]
 
-    session_f = next(f for f in transcripts if Path(f.path) == paths["claude_session"])
-    # Lines 3 (sk-ant) and 5 (nested API_KEY JSON string).
-    assert session_f.hit_lines == [3, 5]
-    assert session_f.secret_count == 2
-    assert session_f.scope == "deep"
-    assert any(n.upper() == "API_KEY" for n in session_f.secret_names)
+    session_fs = [f for f in transcripts if Path(f.path) == paths["claude_session"]]
+    assert session_fs
+    # Line 3 (sk-ant prefix → certain) and 5 (nested API_KEY → likely).
+    assert sorted(n for f in session_fs for n in f.hit_lines) == [3, 5]
+    assert sum(
+        f.secret_count for f in session_fs if f.confidence in ("certain", "likely")
+    ) == 2
+    assert any(n.upper() == "API_KEY" for f in session_fs for n in f.secret_names)
 
     assert not any(Path(f.path) == paths["claude_clean"] for f in transcripts)
 
-    sub_f = next(f for f in transcripts if Path(f.path) == paths["claude_subagent"])
-    assert sub_f.hit_lines == [1]
-    assert sub_f.secret_count == 1
+    sub_fs = [f for f in transcripts if Path(f.path) == paths["claude_subagent"]]
+    assert any(1 in f.hit_lines for f in sub_fs)
+    assert sum(f.secret_count for f in sub_fs if f.confidence in ("certain", "likely")) == 1
 
-    codex_f = next(f for f in transcripts if Path(f.path) == paths["codex"])
-    assert codex_f.secret_count >= 1
-    assert 1 in codex_f.hit_lines
+    codex_fs = [f for f in transcripts if Path(f.path) == paths["codex"]]
+    assert sum(f.secret_count for f in codex_fs if f.confidence in ("certain", "likely")) >= 1
+    assert any(1 in f.hit_lines for f in codex_fs)
 
-    copilot_f = next(f for f in transcripts if Path(f.path) == paths["copilot"])
-    assert copilot_f.hit_lines == [1]
+    copilot_fs = [f for f in transcripts if Path(f.path) == paths["copilot"]]
+    assert any(f.hit_lines == [1] for f in copilot_fs)
 
     assert transcript_line_hit_count(findings) == sum(
-        f.secret_count for f in transcripts if f.confidence == "high"
+        f.secret_count
+        for f in transcripts
+        if f.confidence in ("certain", "likely")
     )
     blob = json.dumps([f.__dict__ for f in findings])
     _assert_no_planted(blob)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -428,7 +428,7 @@ def test_scan_deep_agent_transcripts_line_hits(
     assert copilot_f.hit_lines == [1]
 
     assert transcript_line_hit_count(findings) == sum(
-        f.secret_count for f in transcripts
+        f.secret_count for f in transcripts if f.confidence == "high"
     )
     blob = json.dumps([f.__dict__ for f in findings])
     _assert_no_planted(blob)

--- a/tests/test_scan_corpus.py
+++ b/tests/test_scan_corpus.py
@@ -1,0 +1,332 @@
+"""Labeled scan corpus: before-measurement, tiers, and ka scan exit paths.
+
+Never asserts on secret *values* except to confirm they are absent from
+captured output. Generated likely values live only under pytest tmp.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import shutil
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from key_amnesia.cli import main
+from key_amnesia.detect import (
+    NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
+    NAMED_WEAKENINGS,
+    classify_value,
+    find_prefix_kind,
+    find_secret_kind,
+    scan_text_hits,
+)
+from key_amnesia.hooks import secret_guard as sg
+from key_amnesia.scan import leak_count, possible_count, scan_project
+
+CORPUS = Path(__file__).resolve().parent / "fixtures" / "scan_corpus"
+NEGATIVES = CORPUS / "negatives"
+DEMOTED = CORPUS / "demoted"
+POSITIVES = CORPUS / "positives"
+
+# Generated at test time only — not committed. Shapes match 0.4.9 hook fixtures.
+_GEN_MIXED = "aB3xQ9mK2pL7vN4wZ8"
+_GEN_MIXED_B = "Zk9pL2xQ7mN4vB8w"
+_GEN_HEX32 = "a1b2c3d4e5f6789012345678abcdef01"
+_GEN_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+_GEN_URLSAFE = "A7xQ2mK9pL4vN8wZ1bC3dE5fG6hJ0kL"
+_GEN_VALUES = (_GEN_MIXED, _GEN_MIXED_B, _GEN_HEX32, _GEN_JWT, _GEN_URLSAFE)
+
+DEMOTED_TO_WEAKENING = {
+    "passphrase_correct_horse_battery.py": NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
+}
+
+# 0.4.9 assignment heuristic — before-measurement only.
+_LEGACY_ASSIGN = re.compile(
+    r"""(?ix)
+    (?P<name>(?:[a-z0-9]+[_-])*(?:api[_-]?key|token|secret|password|passwd|private[_-]?key))
+    \s*[:=]\s*
+    (?P<q>['"]?)
+    (?P<value>[^\s'"]{8,})
+    (?P=q)
+    """
+)
+_LEGACY_PLACEHOLDERS = {
+    "test123",
+    "test1234",
+    "changeme",
+    "change_me",
+    "changethis",
+    "password",
+    "password123",
+    "secret",
+    "yourkey",
+    "your_api_key",
+    "your-api-key",
+    "placeholder",
+    "example",
+    "dummy",
+    "fake",
+    "sample",
+    "xxxxxxxx",
+    "12345678",
+}
+
+
+def _iter_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*") if p.is_file() and p.name != "README.md")
+
+
+def _legacy_entropy(s: str) -> float:
+    counts = Counter(s)
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def _legacy_assignment_is_secret(value: str) -> bool:
+    v = value.strip("'\"")
+    if len(v) < 8:
+        return False
+    low = v.lower()
+    if low in _LEGACY_PLACEHOLDERS:
+        return False
+    if re.fullmatch(r"x{6,}", low) or re.fullmatch(r"0{6,}|1{6,}", low):
+        return False
+    mixed = sum(
+        [
+            any(c.isupper() for c in v),
+            any(c.islower() for c in v),
+            any(c.isdigit() for c in v),
+        ]
+    ) >= 2
+    if not mixed:
+        return False
+    return _legacy_entropy(v) >= 3.0
+
+
+def _legacy_flags(text: str) -> bool:
+    if re.search(r"\bBearer\s+[A-Za-z0-9._\-+=/]{16,}", text, re.I):
+        return True
+    for match in _LEGACY_ASSIGN.finditer(text):
+        if _legacy_assignment_is_secret(match.group("value")):
+            return True
+    return False
+
+
+def _file_has_likely_or_prefix(text: str) -> bool:
+    if find_prefix_kind(text):
+        return True
+    likely, _possible, prefix, _bp = scan_text_hits(text)
+    return bool(likely or prefix)
+
+
+def _assert_no_gen_values(blob: str) -> None:
+    for value in _GEN_VALUES:
+        assert value not in blob
+    assert "CorrectHorseBattery" not in blob
+
+
+def test_before_measurement_legacy_over_blocks_negatives() -> None:
+    """0.4.9 assignment heuristic flagged function-call / identifier shapes."""
+    flagged = [
+        path.name
+        for path in _iter_files(NEGATIVES)
+        if _legacy_flags(path.read_text(encoding="utf-8"))
+    ]
+    assert flagged, "before-measurement expected 0.4.9 to over-block some negatives"
+    assert "function_call_secrets.py" in flagged
+    assert "camelcase_identifier.py" in flagged
+    assert "type_annotation.py" in flagged
+
+
+@pytest.mark.parametrize("path", _iter_files(NEGATIVES), ids=lambda p: p.name)
+def test_negatives_not_likely_or_prefix(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert not _file_has_likely_or_prefix(text)
+
+
+@pytest.mark.parametrize("path", _iter_files(DEMOTED), ids=lambda p: p.name)
+def test_demoted_is_possible_and_named(path: Path) -> None:
+    assert path.name in DEMOTED_TO_WEAKENING
+    assert DEMOTED_TO_WEAKENING[path.name] in NAMED_WEAKENINGS
+    text = path.read_text(encoding="utf-8")
+    likely, possible, prefix, bearer_possible = scan_text_hits(text)
+    assert prefix is None
+    assert not likely
+    assert possible or bearer_possible
+    assert classify_value("CorrectHorseBattery") == "possible"
+    assert find_secret_kind(text) is not None
+
+
+def test_demoted_files_all_mapped() -> None:
+    names = {p.name for p in _iter_files(DEMOTED)}
+    assert names == set(DEMOTED_TO_WEAKENING)
+
+
+@pytest.mark.parametrize("path", _iter_files(POSITIVES), ids=lambda p: p.name)
+def test_on_disk_positives_are_prefix(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert find_prefix_kind(text) is not None
+
+
+def test_generated_likely_values_classify_likely() -> None:
+    for value in _GEN_VALUES:
+        assert classify_value(value) == "likely", value[:4]
+
+
+def test_negatives_only_tmp_scan_zero(ka_home, tmp_path, monkeypatch, capsys) -> None:
+    tree = tmp_path / "neg"
+    shutil.copytree(NEGATIVES, tree)
+    monkeypatch.chdir(tree)
+    rc = main(["scan", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out or "{}")
+    assert rc == 0
+    assert data.get("leak_count", 0) == 0
+    _assert_no_gen_values(captured.out + captured.err)
+
+
+def test_demoted_only_tmp_scan_exit_paths(
+    ka_home, tmp_path, monkeypatch, capsys
+) -> None:
+    tree = tmp_path / "dem"
+    shutil.copytree(DEMOTED, tree)
+    monkeypatch.chdir(tree)
+
+    rc = main(["scan", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert rc == 0
+    assert data["leak_count"] == 0
+    assert data["possible_count"] > 0
+    assert all(f["confidence"] in ("high", "possible") for f in data["findings"])
+    _assert_no_gen_values(captured.out + captured.err)
+
+    rc = main(["scan", "--no-import", "--fail-on", "high"])
+    capsys.readouterr()
+    assert rc == 0
+
+    rc = main(["scan", "--no-import", "--fail-on", "possible"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    _assert_no_gen_values(captured.out + captured.err)
+
+    rc = main(["scan", "--no-import", "--show-possible"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "possible" in captured.out.lower()
+    _assert_no_gen_values(captured.out + captured.err)
+
+
+def test_high_confidence_tree_exits_1_both_fail_on(
+    ka_home, tmp_path, monkeypatch, capsys
+) -> None:
+    tree = tmp_path / "high"
+    tree.mkdir()
+    (tree / "config.py").write_text(f'api_key = "{_GEN_MIXED}"\n', encoding="utf-8")
+    monkeypatch.chdir(tree)
+
+    rc = main(["scan", "--no-import", "--fail-on", "high", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert rc == 1
+    assert data["leak_count"] >= 1
+    _assert_no_gen_values(captured.out + captured.err)
+
+    rc = main(["scan", "--no-import", "--fail-on", "possible"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    _assert_no_gen_values(captured.out + captured.err)
+
+
+def test_fail_on_invalid_exits_2(ka_home) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["scan", "--no-import", "--fail-on", "nope"])
+    assert exc.value.code == 2
+
+
+def test_generated_likely_in_env_json_yaml_toml_export(
+    ka_home, tmp_path, monkeypatch, capsys
+) -> None:
+    tree = tmp_path / "gen"
+    tree.mkdir()
+    (tree / ".env").write_text(f"API_KEY={_GEN_MIXED}\n", encoding="utf-8")
+    (tree / "config.json").write_text(
+        json.dumps({"api_key": _GEN_MIXED_B}), encoding="utf-8"
+    )
+    (tree / "config.yaml").write_text(f"api_key: {_GEN_HEX32}\n", encoding="utf-8")
+    (tree / "config.toml").write_text(f'api_key = "{_GEN_JWT}"\n', encoding="utf-8")
+    (tree / "quoted.toml").write_text(
+        f'"api_key" = "{_GEN_URLSAFE}"\n', encoding="utf-8"
+    )
+    (tree / "export.sh").write_text(f"export TOKEN={_GEN_MIXED}\n", encoding="utf-8")
+    monkeypatch.chdir(tree)
+
+    rc = main(["scan", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert rc == 1
+    assert data["leak_count"] >= 1
+    kinds_or_names = json.dumps(data)
+    assert "api_key" in kinds_or_names.lower() or "API_KEY" in kinds_or_names
+    _assert_no_gen_values(captured.out + captured.err)
+
+    findings = scan_project(tree)
+    assert leak_count(findings) >= 1
+    paths = {Path(f.path).name for f in findings if f.confidence == "high"}
+    assert ".env" in paths
+    assert "config.json" in paths
+    assert "config.yaml" in paths
+    assert "config.toml" in paths
+    assert "quoted.toml" in paths
+    assert "export.sh" in paths
+
+
+def test_md_assignment_not_likely_prefix_still_high(
+    ka_home, tmp_path, monkeypatch, capsys
+) -> None:
+    tree = tmp_path / "docs"
+    tree.mkdir()
+    (tree / "notes.md").write_text(f'api_key = "{_GEN_MIXED}"\n', encoding="utf-8")
+    monkeypatch.chdir(tree)
+    rc = main(["scan", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["leak_count"] == 0
+    assert data["possible_count"] >= 1
+    assert rc == 0
+    _assert_no_gen_values(captured.out + captured.err)
+
+    (tree / "readme.md").write_text("sk-" + "a" * 25 + "\n", encoding="utf-8")
+    rc = main(["scan", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["leak_count"] >= 1
+    assert rc == 1
+
+
+def test_bearer_identifier_hook_denies_scan_not_leak(ka_home, tmp_path) -> None:
+    text = "Authorization: Bearer someVariableName"
+    assert sg.find_finding(text) == "Bearer token"
+    tree = tmp_path / "b"
+    tree.mkdir()
+    (tree / "hdr.txt").write_text(text + "\n", encoding="utf-8")
+    findings = scan_project(tree)
+    assert leak_count(findings) == 0
+    assert possible_count(findings) >= 1
+
+
+def test_product_diff_has_no_new_network_imports() -> None:
+    root = Path(__file__).resolve().parents[1] / "src" / "key_amnesia"
+    banned = ("urllib.request", "urllib3", "requests", "http.client", "aiohttp")
+    for path in (
+        root / "detect.py",
+        root / "scan.py",
+        root / "hooks" / "secret_guard.py",
+    ):
+        text = path.read_text(encoding="utf-8")
+        for name in banned:
+            assert name not in text

--- a/tests/test_scan_corpus.py
+++ b/tests/test_scan_corpus.py
@@ -10,6 +10,8 @@ import json
 import math
 import re
 import shutil
+import time
+import uuid
 from collections import Counter
 from pathlib import Path
 
@@ -17,15 +19,24 @@ import pytest
 
 from key_amnesia.cli import main
 from key_amnesia.detect import (
+    NAMED_WEAKENING_LOW_TRANSITION,
     NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
     NAMED_WEAKENINGS,
+    REASON_UNCONFIRMED_MCP,
+    REASON_UUID,
     classify_value,
     find_prefix_kind,
     find_secret_kind,
     scan_text_hits,
 )
 from key_amnesia.hooks import secret_guard as sg
-from key_amnesia.scan import leak_count, possible_count, scan_project
+from key_amnesia.scan import (
+    _findings_for_transcript,
+    leak_count,
+    possible_count,
+    scan_project,
+    transcript_line_hit_count,
+)
 
 CORPUS = Path(__file__).resolve().parent / "fixtures" / "scan_corpus"
 NEGATIVES = CORPUS / "negatives"
@@ -42,6 +53,7 @@ _GEN_VALUES = (_GEN_MIXED, _GEN_MIXED_B, _GEN_HEX32, _GEN_JWT, _GEN_URLSAFE)
 
 DEMOTED_TO_WEAKENING = {
     "passphrase_correct_horse_battery.py": NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
+    "low_transition_summervineyard.py": NAMED_WEAKENING_LOW_TRANSITION,
 }
 
 # 0.4.9 assignment heuristic — before-measurement only.
@@ -119,8 +131,8 @@ def _legacy_flags(text: str) -> bool:
 def _file_has_likely_or_prefix(text: str) -> bool:
     if find_prefix_kind(text):
         return True
-    likely, _possible, prefix, _bp = scan_text_hits(text)
-    return bool(likely or prefix)
+    hits = scan_text_hits(text)
+    return bool(hits.likely_names or hits.prefix)
 
 
 def _assert_no_gen_values(blob: str) -> None:
@@ -153,11 +165,13 @@ def test_demoted_is_possible_and_named(path: Path) -> None:
     assert path.name in DEMOTED_TO_WEAKENING
     assert DEMOTED_TO_WEAKENING[path.name] in NAMED_WEAKENINGS
     text = path.read_text(encoding="utf-8")
-    likely, possible, prefix, bearer_possible = scan_text_hits(text)
-    assert prefix is None
-    assert not likely
-    assert possible or bearer_possible
-    assert classify_value("CorrectHorseBattery") == "possible"
+    hits = scan_text_hits(text)
+    assert hits.prefix is None
+    assert not hits.likely_names
+    assert hits.possible_names or hits.bearer_possible
+    assert classify_value("CorrectHorseBattery")[0] == "possible"
+    assert classify_value("SummerVineyard2026")[0] == "possible"
+    assert classify_value("SummerVineyard2026")[1] == NAMED_WEAKENING_LOW_TRANSITION
     assert find_secret_kind(text) is not None
 
 
@@ -174,7 +188,7 @@ def test_on_disk_positives_are_prefix(path: Path) -> None:
 
 def test_generated_likely_values_classify_likely() -> None:
     for value in _GEN_VALUES:
-        assert classify_value(value) == "likely", value[:4]
+        assert classify_value(value)[0] == "likely"
 
 
 def test_negatives_only_tmp_scan_zero(ka_home, tmp_path, monkeypatch, capsys) -> None:
@@ -285,7 +299,7 @@ def test_generated_likely_in_env_json_yaml_toml_export(
     assert "export.sh" in paths
 
 
-def test_md_assignment_not_likely_prefix_still_high(
+def test_md_likely_assignment_counts_under_default_gate(
     ka_home, tmp_path, monkeypatch, capsys
 ) -> None:
     tree = tmp_path / "docs"
@@ -295,17 +309,17 @@ def test_md_assignment_not_likely_prefix_still_high(
     rc = main(["scan", "--no-import", "--json"])
     captured = capsys.readouterr()
     data = json.loads(captured.out)
-    assert data["leak_count"] == 0
-    assert data["possible_count"] >= 1
-    assert rc == 0
+    assert data["leak_count"] >= 1
+    assert rc == 1
     _assert_no_gen_values(captured.out + captured.err)
 
     (tree / "readme.md").write_text("sk-" + "a" * 25 + "\n", encoding="utf-8")
     rc = main(["scan", "--no-import", "--json"])
     captured = capsys.readouterr()
     data = json.loads(captured.out)
-    assert data["leak_count"] >= 1
+    assert data["leak_count"] >= 2
     assert rc == 1
+    _assert_no_gen_values(captured.out + captured.err)
 
 
 def test_bearer_identifier_hook_denies_scan_not_leak(ka_home, tmp_path) -> None:
@@ -330,3 +344,139 @@ def test_product_diff_has_no_new_network_imports() -> None:
         text = path.read_text(encoding="utf-8")
         for name in banned:
             assert name not in text
+
+
+def test_highest_tier_wins_both_assignment_orderings() -> None:
+    ident = "mySecretValue"
+    likely = _GEN_MIXED
+    texts = (
+        f'api_key = "{ident}"\napi_key = "{likely}"\n',
+        f'api_key = "{likely}"\napi_key = "{ident}"\n',
+    )
+    for text in texts:
+        hits = scan_text_hits(text)
+        assert any(n.upper() == "API_KEY" for n in hits.likely_names)
+        assert all(n.upper() != "API_KEY" for n in hits.possible_names)
+        assert find_secret_kind(text) == "API_KEY assignment"
+
+
+def test_transcript_mixed_line_records_possible_names(tmp_path: Path) -> None:
+    path = tmp_path / "mixed.jsonl"
+    line = json.dumps(
+        {
+            "type": "user",
+            "content": f'api_key = "{_GEN_MIXED}"\ntoken = mySecretValue',
+        }
+    )
+    path.write_text(line + "\n", encoding="utf-8")
+    findings = _findings_for_transcript(path, scope="deep")
+    assert leak_count(findings) >= 1
+    assert possible_count(findings) > 0
+    high = [f for f in findings if f.confidence == "high"]
+    poss = [f for f in findings if f.confidence == "possible"]
+    assert high and high[0].hit_lines == [1]
+    assert poss
+    assert poss[0].hit_lines == []
+    assert transcript_line_hit_count(findings) == high[0].secret_count
+    assert any(n.upper() == "TOKEN" for n in poss[0].secret_names)
+
+
+def test_uuid_assignment_is_likely_with_reason(ka_home, tmp_path, monkeypatch, capsys) -> None:
+    generated = str(uuid.uuid4())
+    while generated.strip("0-") == "":
+        generated = str(uuid.uuid4())
+    tree = tmp_path / "uuid"
+    tree.mkdir()
+    (tree / "config.py").write_text(f'api_key = "{generated}"\n', encoding="utf-8")
+    monkeypatch.chdir(tree)
+
+    tier, reason = classify_value(generated)
+    assert tier == "likely"
+    assert reason == REASON_UUID
+    assert classify_value("00000000-0000-0000-0000-000000000000")[0] == "none"
+    assert sg.find_finding(f'api_key = "{generated}"') is not None
+
+    findings = scan_project(tree)
+    assert leak_count(findings) >= 1
+    uuid_findings = [f for f in findings if REASON_UUID in f.reasons]
+    assert uuid_findings
+    rc = main(["scan", "--no-import", "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert rc == 1
+    assert data["leak_count"] >= 1
+    assert generated not in captured.out
+    assert generated not in captured.err
+
+
+def test_mcp_json_unrecognised_shape_demotes_not_dropped(ka_home, tmp_path) -> None:
+    tree = tmp_path / "mcp-tree"
+    tree.mkdir()
+    # Expected field shape (docs only, no live tree): 1 certain dotenv +
+    # 2 possible unconfirmed-mcp.
+    (tree / ".env").write_text("API_KEY=placeholder_not_used\n", encoding="utf-8")
+    (tree / "mcp.json").write_text('{"name": "demo"}\n', encoding="utf-8")
+    other = tree / "claude_desktop_config.json"
+    other.write_text('{"theme": "dark"}\n', encoding="utf-8")
+
+    findings = scan_project(tree)
+    mcp = [f for f in findings if f.kind == "mcp_config"]
+    assert len(mcp) == 2
+    assert all(f.confidence == "possible" for f in mcp)
+    assert all(REASON_UNCONFIRMED_MCP in f.reasons for f in mcp)
+    assert possible_count(findings) >= 2
+
+    (tree / "mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    findings = scan_project(tree)
+    confirmed = [
+        f
+        for f in findings
+        if f.kind == "mcp_config" and Path(f.path).name == "mcp.json"
+    ]
+    assert confirmed
+    assert confirmed[0].confidence == "high"
+    assert leak_count(findings) >= 1
+
+
+def test_nested_jsonl_secret_key_walk_and_timing(tmp_path: Path) -> None:
+    """Secret-named keys that never appear as ASSIGN text are still found.
+
+    Nested-JSON double-walk removed. Same generated 4000-line secret-keyed
+    nested JSONL (23_464_000 bytes) timed 75.8432s before (recursive
+    ``_apply_obj`` re-walk) vs 51.9149s after. File is throwaway, not committed.
+    """
+    path = tmp_path / "nested.jsonl"
+    path.write_text(
+        json.dumps({"wrapper": {"api_key": _GEN_MIXED}}) + "\n",
+        encoding="utf-8",
+    )
+    findings = _findings_for_transcript(path, scope="deep")
+    assert leak_count(findings) >= 1
+    assert any(
+        n.upper() == "API_KEY" for f in findings for n in f.secret_names
+    )
+
+    bulky = tmp_path / "bulky.jsonl"
+    inner = {
+        "wrapper": {"inner": {"note": "no-assign-here", "blob": "x" * 200}},
+        "more": [{"k": "v" * 50} for _ in range(20)],
+        "extra": ["n" * 80 for _ in range(30)],
+    }
+    payload = {
+        "type": "user",
+        "message": {
+            "content": "debug this",
+            "api_key": json.dumps(inner),
+            "token": json.dumps({"deeper": ["z" * 100 for _ in range(15)]}),
+        },
+    }
+    n_lines = 200
+    with bulky.open("w", encoding="utf-8") as fh:
+        for _ in range(n_lines):
+            fh.write(json.dumps(payload) + "\n")
+    t0 = time.perf_counter()
+    _findings_for_transcript(bulky, scope="deep")
+    elapsed = time.perf_counter() - t0
+    # 200 lines of the 4000-line secret-keyed shape; after-fix 4000-line was
+    # 51.9s so this budget is ~2.6s typical. Fail if the double-walk returns.
+    assert elapsed < 8.0

--- a/tests/test_scan_corpus.py
+++ b/tests/test_scan_corpus.py
@@ -398,15 +398,39 @@ def test_transcript_mixed_line_records_possible_names(tmp_path: Path) -> None:
     )
     path.write_text(line + "\n", encoding="utf-8")
     findings = _findings_for_transcript(path, scope="deep")
-    assert leak_count(findings) >= 1
-    assert possible_count(findings) > 0
     high = [f for f in findings if f.confidence in ("certain", "likely")]
     poss = [f for f in findings if f.confidence == "possible"]
     assert high and high[0].hit_lines == [1]
     assert poss
     assert poss[0].hit_lines == []
-    assert transcript_line_hit_count(findings) == high[0].secret_count
+    assert poss[0].secret_count == 0
     assert any(n.upper() == "TOKEN" for n in poss[0].secret_names)
+    assert leak_count(findings) == 1
+    assert leak_count(findings, strict="paranoid") == 1
+    assert possible_count(findings) == 0
+    assert transcript_line_hit_count(findings) == high[0].secret_count
+
+
+def test_transcript_prefix_and_likely_same_line_keeps_likely_names(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "prefix-likely.jsonl"
+    prefix = "sk-" + "a" * 25
+    line = json.dumps(
+        {
+            "type": "user",
+            "content": f'{prefix}\napi_key = "{_GEN_MIXED}"',
+        }
+    )
+    path.write_text(line + "\n", encoding="utf-8")
+    findings = _findings_for_transcript(path, scope="deep")
+    certain = [f for f in findings if f.confidence == "certain"]
+    likely = [f for f in findings if f.confidence == "likely"]
+    assert certain and certain[0].secret_count == 1
+    assert likely
+    assert any(n.upper() == "API_KEY" for n in likely[0].secret_names)
+    assert likely[0].secret_count == 0
+    assert leak_count(findings, strict="high") == 1
 
 
 def test_uuid_assignment_is_likely_with_reason(ka_home, tmp_path, monkeypatch, capsys) -> None:
@@ -452,7 +476,18 @@ def test_mcp_json_unrecognised_shape_demotes_not_dropped(ka_home, tmp_path) -> N
     assert len(mcp) == 2
     assert all(f.confidence == "possible" for f in mcp)
     assert all(REASON_UNCONFIRMED_MCP in f.reasons for f in mcp)
-    assert possible_count(findings) >= 2
+    assert possible_count(findings) == 2
+
+    (tree / "mcp.json").write_text(
+        '{"alpha": 1, "beta": 2, "gamma": 3}\n', encoding="utf-8"
+    )
+    findings = scan_project(tree)
+    fat = [f for f in findings if Path(f.path).name == "mcp.json"]
+    assert fat and fat[0].confidence == "possible"
+    assert fat[0].secret_count == 1
+    assert fat[0].reason_counts.get(REASON_UNCONFIRMED_MCP) == 1
+    assert len(fat[0].secret_names) == 3
+    assert possible_count(findings) == 2
 
     (tree / "mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
     findings = scan_project(tree)
@@ -483,6 +518,21 @@ def test_nested_jsonl_secret_key_walk_and_timing(tmp_path: Path) -> None:
     assert any(
         n.upper() == "API_KEY" for f in findings for n in f.secret_names
     )
+
+    generated = str(uuid.uuid4())
+    while generated.strip("0-") == "":
+        generated = str(uuid.uuid4())
+    wrapped = tmp_path / "wrapped.jsonl"
+    wrapped.write_text(
+        json.dumps({"content": json.dumps({"api_key": generated})}) + "\n",
+        encoding="utf-8",
+    )
+    wrapped_findings = _findings_for_transcript(wrapped, scope="deep")
+    likely = [f for f in wrapped_findings if f.confidence == "likely"]
+    assert leak_count(wrapped_findings) == 1
+    assert likely
+    assert likely[0].reason_counts.get(REASON_UUID) == 1
+    assert sum(1 for n in likely[0].secret_names if n.upper() == "API_KEY") == 1
 
     bulky = tmp_path / "bulky.jsonl"
     inner = {

--- a/tests/test_scan_corpus.py
+++ b/tests/test_scan_corpus.py
@@ -19,7 +19,10 @@ import pytest
 
 from key_amnesia.cli import main
 from key_amnesia.detect import (
+    NAMED_WEAKENING_FUNCTION_CALL,
+    NAMED_WEAKENING_IDENTIFIER,
     NAMED_WEAKENING_LOW_TRANSITION,
+    NAMED_WEAKENING_TYPE_ANNOTATION,
     NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
     NAMED_WEAKENINGS,
     REASON_UNCONFIRMED_MCP,
@@ -31,7 +34,10 @@ from key_amnesia.detect import (
 )
 from key_amnesia.hooks import secret_guard as sg
 from key_amnesia.scan import (
+    Finding,
     _findings_for_transcript,
+    format_count_summary,
+    headline,
     leak_count,
     possible_count,
     scan_project,
@@ -55,6 +61,13 @@ DEMOTED_TO_WEAKENING = {
     "passphrase_correct_horse_battery.py": NAMED_WEAKENING_WORD_SHAPED_PASSPHRASE,
     "low_transition_summervineyard.py": NAMED_WEAKENING_LOW_TRANSITION,
 }
+NEGATIVE_TO_WEAKENING = {
+    "function_call_secrets.py": NAMED_WEAKENING_FUNCTION_CALL,
+    "function_call_get_token.py": NAMED_WEAKENING_FUNCTION_CALL,
+    "type_annotation.py": NAMED_WEAKENING_TYPE_ANNOTATION,
+    "camelcase_identifier.py": NAMED_WEAKENING_IDENTIFIER,
+}
+FILENAME_DEMOTED = frozenset({"mcp.json"})
 
 # 0.4.9 assignment heuristic — before-measurement only.
 _LEGACY_ASSIGN = re.compile(
@@ -132,7 +145,7 @@ def _file_has_likely_or_prefix(text: str) -> bool:
     if find_prefix_kind(text):
         return True
     hits = scan_text_hits(text)
-    return bool(hits.likely_names or hits.prefix)
+    return bool(hits.likely_names or hits.prefix or hits.bearer_likely)
 
 
 def _assert_no_gen_values(blob: str) -> None:
@@ -160,7 +173,11 @@ def test_negatives_not_likely_or_prefix(path: Path) -> None:
     assert not _file_has_likely_or_prefix(text)
 
 
-@pytest.mark.parametrize("path", _iter_files(DEMOTED), ids=lambda p: p.name)
+@pytest.mark.parametrize(
+    "path",
+    [p for p in _iter_files(DEMOTED) if p.name not in FILENAME_DEMOTED],
+    ids=lambda p: p.name,
+)
 def test_demoted_is_possible_and_named(path: Path) -> None:
     assert path.name in DEMOTED_TO_WEAKENING
     assert DEMOTED_TO_WEAKENING[path.name] in NAMED_WEAKENINGS
@@ -177,7 +194,13 @@ def test_demoted_is_possible_and_named(path: Path) -> None:
 
 def test_demoted_files_all_mapped() -> None:
     names = {p.name for p in _iter_files(DEMOTED)}
-    assert names == set(DEMOTED_TO_WEAKENING)
+    assert names == set(DEMOTED_TO_WEAKENING) | FILENAME_DEMOTED
+
+
+def test_every_named_weakening_has_a_fixture() -> None:
+    mapped = set(DEMOTED_TO_WEAKENING.values()) | set(NEGATIVE_TO_WEAKENING.values())
+    assert set(NAMED_WEAKENINGS) <= mapped
+    assert (DEMOTED / "mcp.json").is_file()
 
 
 @pytest.mark.parametrize("path", _iter_files(POSITIVES), ids=lambda p: p.name)
@@ -216,26 +239,27 @@ def test_demoted_only_tmp_scan_exit_paths(
     assert rc == 0
     assert data["leak_count"] == 0
     assert data["possible_count"] > 0
-    assert all(f["confidence"] in ("high", "possible") for f in data["findings"])
+    assert all(
+        f["confidence"] in ("certain", "likely", "possible") for f in data["findings"]
+    )
     _assert_no_gen_values(captured.out + captured.err)
 
-    rc = main(["scan", "--no-import", "--fail-on", "high"])
-    capsys.readouterr()
-    assert rc == 0
-
-    rc = main(["scan", "--no-import", "--fail-on", "possible"])
-    captured = capsys.readouterr()
-    assert rc == 1
-    _assert_no_gen_values(captured.out + captured.err)
-
-    rc = main(["scan", "--no-import", "--show-possible"])
+    rc = main(["scan", "--no-import", "--strict", "high"])
     captured = capsys.readouterr()
     assert rc == 0
+    assert "--strict high" in captured.out
+    assert "certain ·" in captured.out
     assert "possible" in captured.out.lower()
     _assert_no_gen_values(captured.out + captured.err)
 
+    rc = main(["scan", "--no-import", "--strict", "paranoid"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "--strict paranoid" in captured.out
+    _assert_no_gen_values(captured.out + captured.err)
 
-def test_high_confidence_tree_exits_1_both_fail_on(
+
+def test_likely_tree_exits_1_strict_high_and_paranoid(
     ka_home, tmp_path, monkeypatch, capsys
 ) -> None:
     tree = tmp_path / "high"
@@ -243,22 +267,22 @@ def test_high_confidence_tree_exits_1_both_fail_on(
     (tree / "config.py").write_text(f'api_key = "{_GEN_MIXED}"\n', encoding="utf-8")
     monkeypatch.chdir(tree)
 
-    rc = main(["scan", "--no-import", "--fail-on", "high", "--json"])
+    rc = main(["scan", "--no-import", "--strict", "high", "--json"])
     captured = capsys.readouterr()
     data = json.loads(captured.out)
     assert rc == 1
     assert data["leak_count"] >= 1
     _assert_no_gen_values(captured.out + captured.err)
 
-    rc = main(["scan", "--no-import", "--fail-on", "possible"])
+    rc = main(["scan", "--no-import", "--strict", "paranoid"])
     captured = capsys.readouterr()
     assert rc == 1
     _assert_no_gen_values(captured.out + captured.err)
 
 
-def test_fail_on_invalid_exits_2(ka_home) -> None:
+def test_strict_invalid_exits_2(ka_home) -> None:
     with pytest.raises(SystemExit) as exc:
-        main(["scan", "--no-import", "--fail-on", "nope"])
+        main(["scan", "--no-import", "--strict", "nope"])
     assert exc.value.code == 2
 
 
@@ -290,7 +314,11 @@ def test_generated_likely_in_env_json_yaml_toml_export(
 
     findings = scan_project(tree)
     assert leak_count(findings) >= 1
-    paths = {Path(f.path).name for f in findings if f.confidence == "high"}
+    paths = {
+        Path(f.path).name
+        for f in findings
+        if f.confidence in ("certain", "likely")
+    }
     assert ".env" in paths
     assert "config.json" in paths
     assert "config.yaml" in paths
@@ -372,7 +400,7 @@ def test_transcript_mixed_line_records_possible_names(tmp_path: Path) -> None:
     findings = _findings_for_transcript(path, scope="deep")
     assert leak_count(findings) >= 1
     assert possible_count(findings) > 0
-    high = [f for f in findings if f.confidence == "high"]
+    high = [f for f in findings if f.confidence in ("certain", "likely")]
     poss = [f for f in findings if f.confidence == "possible"]
     assert high and high[0].hit_lines == [1]
     assert poss
@@ -434,7 +462,7 @@ def test_mcp_json_unrecognised_shape_demotes_not_dropped(ka_home, tmp_path) -> N
         if f.kind == "mcp_config" and Path(f.path).name == "mcp.json"
     ]
     assert confirmed
-    assert confirmed[0].confidence == "high"
+    assert confirmed[0].confidence == "certain"
     assert leak_count(findings) >= 1
 
 
@@ -480,3 +508,126 @@ def test_nested_jsonl_secret_key_walk_and_timing(tmp_path: Path) -> None:
     # 200 lines of the 4000-line secret-keyed shape; after-fix 4000-line was
     # 51.9s so this budget is ~2.6s typical. Fail if the double-walk returns.
     assert elapsed < 8.0
+
+
+def test_strict_headline_and_summary_example_shape() -> None:
+    findings = [
+        Finding(
+            path="a.env",
+            kind="dotenv",
+            secret_names=["A"],
+            secret_count=1,
+            reason="dotenv",
+            confidence="certain",
+        ),
+        Finding(
+            path="b.py",
+            kind="inline",
+            secret_names=["k"],
+            secret_count=3,
+            reason="likely",
+            confidence="likely",
+        ),
+        Finding(
+            path="c.py",
+            kind="inline",
+            secret_names=["i"],
+            secret_count=19,
+            reason="possible",
+            confidence="possible",
+            reasons=["identifier"],
+            reason_counts={"identifier": 19},
+        ),
+        Finding(
+            path="d.py",
+            kind="inline",
+            secret_names=["p"],
+            secret_count=6,
+            reason="possible",
+            confidence="possible",
+            reasons=["word-shaped-passphrase"],
+            reason_counts={"word-shaped-passphrase": 6},
+        ),
+        Finding(
+            path="e.py",
+            kind="inline",
+            secret_names=["l"],
+            secret_count=3,
+            reason="possible",
+            confidence="possible",
+            reasons=["low-transition"],
+            reason_counts={"low-transition": 3},
+        ),
+    ]
+    summary = format_count_summary(findings)
+    assert summary == (
+        "1 certain · 3 likely · 28 possible "
+        "(19 identifier · 6 passphrase · 3 low-transition)"
+    )
+    assert headline(findings, strict="certain").startswith(
+        "1 LEAK found (--strict certain)"
+    )
+    assert headline(findings, strict="high").startswith(
+        "4 LEAKs found (--strict high)"
+    )
+    assert headline(findings, strict="paranoid").startswith(
+        "32 LEAKs found (--strict paranoid)"
+    )
+
+
+def _summary_line(text: str) -> str:
+    for line in text.splitlines():
+        if "certain ·" in line:
+            return line
+    return ""
+
+
+def test_strict_three_levels_listing_exit_and_summary(
+    ka_home, tmp_path, monkeypatch, capsys
+) -> None:
+    tree = tmp_path / "mix"
+    tree.mkdir()
+    (tree / ".env").write_text("API_KEY=placeholder_not_used\n", encoding="utf-8")
+    (tree / "a.py").write_text(f'api_key = "{_GEN_MIXED}"\n', encoding="utf-8")
+    (tree / "b.py").write_text("token = mySecretValue\n", encoding="utf-8")
+    monkeypatch.chdir(tree)
+
+    rc_c = main(["scan", "--no-import", "--strict", "certain"])
+    out_c = capsys.readouterr().out
+    assert rc_c == 1
+    assert "--strict certain" in out_c
+    assert "confidence=certain" in out_c
+    assert "confidence=likely" not in out_c
+    assert "confidence=possible" not in out_c
+
+    rc_h = main(["scan", "--no-import", "--strict", "high"])
+    out_h = capsys.readouterr().out
+    assert rc_h == 1
+    assert "--strict high" in out_h
+    assert "confidence=likely" in out_h
+    assert "confidence=possible" not in out_h
+
+    rc_p = main(["scan", "--no-import", "--strict", "paranoid"])
+    out_p = capsys.readouterr().out
+    assert rc_p == 1
+    assert "--strict paranoid" in out_p
+    assert "confidence=possible" in out_p
+
+    assert _summary_line(out_c) == _summary_line(out_h) == _summary_line(out_p)
+    _assert_no_gen_values(out_c + out_h + out_p)
+
+    rc_j = main(["scan", "--no-import", "--strict", "certain", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["leak_count"] == data["certain_count"]
+    assert "--strict certain" in data["headline"]
+
+
+def test_scan_help_has_strict_wide_not_unreleased_flags(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["scan", "--help"])
+    blob = capsys.readouterr().out + capsys.readouterr().err
+    assert exc.value.code == 0
+    assert "--fail-on" not in blob
+    assert "--show-possible" not in blob
+    assert "--strict" in blob
+    assert "--wide" in blob

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -415,3 +415,26 @@ def test_find_finding_ka_safe_skips_prefix_but_trailing_scan_does_not() -> None:
     trailing = "python deploy.py --api-key " + "sk-ant-" + "a" * 25
     assert sg.find_finding(prefix + " " + trailing) is None  # _KA_SAFE on full text
     assert sg.find_finding(trailing, ignore_ka_safe=True) is not None
+
+
+def test_function_call_assignment_allowed() -> None:
+    assert sg.find_finding("token = secrets.token_hex(8)") is None
+    assert sg.find_finding("new_token = secrets_mod.token_urlsafe(32)") is None
+    assert sg.find_finding("Token = GetTokenFromCache()") is None
+
+
+def test_type_annotation_allowed() -> None:
+    assert sg.find_finding("token: Optional[str]") is None
+
+
+def test_json_quoted_key_likely_denied() -> None:
+    text = '{"api_key": "aB3xQ9mK2pL7vN4wZ8"}'
+    finding = sg.find_finding(text)
+    assert finding is not None
+    assert "assignment" in finding
+
+
+def test_passphrase_still_hook_denied() -> None:
+    assert sg.find_finding("export PASSWORD=CorrectHorseBattery") is not None
+    assert sg.find_finding("secret = CorrectHorseBattery") is not None
+

--- a/wiki/Agent-usage.md
+++ b/wiki/Agent-usage.md
@@ -39,7 +39,7 @@ ka run --secret NAME --as NAME=ENVVAR -- <command> [args...]
 | `ka status` / `ka connect` | Yes | Session metadata; check first |
 | `ka list` | Yes | Names only; no password |
 | `ka run --secret NAME [--as NAME=ENVVAR] -- ...` | Yes | Primary path; may prompt the human |
-| `ka scan` / `ka scan --no-import` | Yes | Names/paths only; never values |
+| `ka scan` / `ka scan --no-import` | Yes | Names/paths/counts only; never values. Default exit is high-confidence only (`--fail-on possible` for the older gate) |
 | `ka check` | Yes | Manifest vs project names sidecar |
 | Reading vault files / inventing a get-value verb | **No** | Guard has no value-return verb |
 

--- a/wiki/Agent-usage.md
+++ b/wiki/Agent-usage.md
@@ -39,7 +39,7 @@ ka run --secret NAME --as NAME=ENVVAR -- <command> [args...]
 | `ka status` / `ka connect` | Yes | Session metadata; check first |
 | `ka list` | Yes | Names only; no password |
 | `ka run --secret NAME [--as NAME=ENVVAR] -- ...` | Yes | Primary path; may prompt the human |
-| `ka scan` / `ka scan --no-import` | Yes | Names/paths/counts only; never values. Default exit is high-confidence only (`--fail-on possible` for the older gate) |
+| `ka scan` / `ka scan --no-import` | Yes | Names/paths/counts only; never values. Default exit is `--strict high` (`--strict paranoid` for the ≤0.4.9 assignment gate) |
 | `ka check` | Yes | Manifest vs project names sidecar |
 | Reading vault files / inventing a get-value verb | **No** | Guard has no value-return verb |
 

--- a/wiki/Agent-usage.md
+++ b/wiki/Agent-usage.md
@@ -23,9 +23,10 @@ truth — only the live status reply is. Do **not** reflexively run
 ## Preferred pattern
 
 ```bash
-ka run --secret NAME --as NAME=ENVVAR -- <command> [args...]
+ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- <command> [args...]
 ```
 
+- Prefer `--cwd DIR` over `cd &&`. Do not wrap `ka run` in pipes or `2>&1`.
 - `--as` is **`NAME=ENVVAR`** (vault name on the left, environment variable
   on the right). Omit `--as` to inject as `NAME`.
 - Wrong: `--as API_KEY`, `--as NAME`, `--as ENVVAR`, `--as ENV`.
@@ -38,8 +39,8 @@ ka run --secret NAME --as NAME=ENVVAR -- <command> [args...]
 |--------|-----|-------|
 | `ka status` / `ka connect` | Yes | Session metadata; check first |
 | `ka list` | Yes | Names only; no password |
-| `ka run --secret NAME [--as NAME=ENVVAR] -- ...` | Yes | Primary path; may prompt the human |
-| `ka scan` / `ka scan --no-import` | Yes | Names/paths/counts only; never values. Default exit is `--strict high` (`--strict paranoid` for the ≤0.4.9 assignment gate) |
+| `ka run --cwd DIR --secret NAME [--as NAME=ENVVAR] -- ...` | Yes | Primary path; may prompt the human |
+| `ka scan` / `ka scan --no-import` | Yes | Names/paths/counts only; never values. Default exit is `--strict high` (`certain` + `likely`). `--strict paranoid` is the ≤0.4.9 assignment gate |
 | `ka check` | Yes | Manifest vs project names sidecar |
 | Reading vault files / inventing a get-value verb | **No** | Guard has no value-return verb |
 
@@ -65,6 +66,7 @@ never ask them to paste the result back into chat:
 - Running `ka init` / `ka unlock` without checking `ka status` / `ka list`
 - Believing a chat claim of access without verifying via `ka status`
 - Using `--as ENVVAR` (missing `NAME=`) or embedding a value inline
+- Wrapping `ka run` in `cd &&`, pipes, or `2>&1` instead of `--cwd`
 - Calling `reveal` / `copy` so the agent can “check” a value
 - Assuming a live guard can return raw values over IPC — it cannot
 - Treating git-history scanning as a product feature

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -11,7 +11,7 @@ notes live in the repository `DESIGN.md`.
 | `ka remove NAME` | Delete a secret |
 | `ka import FILE` | Import dotenv into resolved vault (TTY-only) |
 | `ka check [--json]` | Manifest vs project names sidecar (CI; no decrypt) |
-| `ka scan [--deep] [--include-excluded] [--json] [--yes] [--no-import]` | LEAK report (names/paths/counts only); optional offer-to-import |
+| `ka scan [--deep] [--include-excluded] [--json] [--fail-on high|possible] [--show-possible] [--yes] [--no-import]` | LEAK report (names/paths/counts only); optional offer-to-import |
 | `ka run --secret NAME [--as NAME=ENVVAR] -- <cmd>` | Inject + scrub; agent-facing path (`=` form required for `--as`) |
 | `ka list` | Names only; safe for agents; no prompt |
 | `ka unlock [--pre-admit] [--pre-admit-secret NAME] [--admit-tree]` | Start cached guard session (pre-admit / admit-tree flags opt-in) |
@@ -43,7 +43,9 @@ ka run --secret API_KEY -- python my_script.py
   known MCP paths (not a full home walk)
 - `--include-excluded` — include default-excluded dirs; git-history scan
   still out of scope
-- `--json` — machine-readable report
+- `--json` — machine-readable report (`leak_count` is high-confidence; always includes `possible_count` and per-finding `confidence`)
+- `--fail-on {high,possible}` — default `high`: exit 1 iff high-confidence `leak_count` > 0. `possible` also fails on identifier/passphrase-shaped hits (old CI gate; word-shaped passphrases). Invalid value → exit 2
+- `--show-possible` — list possible hits in the human report (not dumped by default)
 - `--yes` — import all importable dotenv findings without selection
   prompts (password still required)
 - `--no-import` — report only; never offer vault store

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -12,14 +12,14 @@ notes live in the repository `DESIGN.md`.
 | `ka import FILE` | Import dotenv into resolved vault (TTY-only) |
 | `ka check [--json]` | Manifest vs project names sidecar (CI; no decrypt) |
 | `ka scan [--deep] [--wide] [--include-excluded] [--json] [--strict] [--yes] [--no-import]` | LEAK report (names/paths/counts only); optional offer-to-import |
-| `ka run --secret NAME [--as NAME=ENVVAR] -- <cmd>` | Inject + scrub; agent-facing path (`=` form required for `--as`) |
+| `ka run --cwd DIR --secret NAME [--as NAME=ENVVAR] -- <cmd>` | Inject + scrub; agent-facing path (`=` form required for `--as`) |
 | `ka list` | Names only; safe for agents; no prompt |
 | `ka unlock [--pre-admit] [--pre-admit-secret NAME] [--admit-tree]` | Start cached guard session (pre-admit / admit-tree flags opt-in) |
 | `ka lock` | End session early |
 | `ka reveal NAME` / `ka copy NAME` | Human-only surface of a value; always fresh auth |
 | `ka config show` / `ka config set KEY VALUE` | Settings |
 | `ka status` / `ka connect` | Session status (+ registry of live guards). `connect` is a **CLI alias** for `status` — not a sixth IPC verb |
-| `ka setup [--skills-only] [--hook-only]` | Install skills + secret-guard hook (Claude / Cursor / Codex) |
+| `ka setup [--skills-only] [--hook-only] [--permissions-only] [--permissions-remove] [--yes]` | Install skills, secret-guard hook, and harness allow-lists (Claude / Cursor / Codex) |
 | `ka docs [--print]` | Print wiki URL; open browser unless `--print` |
 | `ka identity create` / `show` | Local X25519 identity for KAM2 |
 | `ka member add` / `list` / `remove` | Members/roles (first add enables KAM2) |
@@ -29,13 +29,14 @@ notes live in the repository `DESIGN.md`.
 ### `run` mapping
 
 ```bash
-ka run --secret API_KEY --as API_KEY=API_KEY -- python my_script.py
+ka run --cwd DIR --secret API_KEY --as API_KEY=API_KEY -- python my_script.py
 # or inject under the secret's own name:
-ka run --secret API_KEY -- python my_script.py
+ka run --cwd DIR --secret API_KEY -- python my_script.py
 ```
 
 `--as` takes `NAME=ENVVAR` only (CLI requires the `=` form). Omitting
-`--as` injects the secret under its vault name.
+`--as` injects the secret under its vault name. Prefer `--cwd DIR` over
+`cd &&`; do not wrap `ka run` in pipes or `2>&1`.
 
 ### `scan` flags
 
@@ -44,7 +45,7 @@ ka run --secret API_KEY -- python my_script.py
 - `--include-excluded` / `--wide` — include default-excluded dirs; git-history scan
   still out of scope. `--wide` is an alias only.
 - `--json` — machine-readable report (`leak_count` matches the `--strict` gate; always includes `certain_count`, `likely_count`, `possible_count`, and per-finding `confidence` + `reasons`)
-- `--strict certain|high|paranoid` — default `high`: exit 1 iff certain+likely `leak_count` > 0. `certain` is prefixes and confirmed filenames. `paranoid` also fails on identifier/passphrase/low-transition hits (the ≤0.4.9 assignment gate). Invalid value → exit 2. Headline names the gate. The three-count summary prints at every strictness.
+- `--strict certain|high|paranoid` — default `high`: exit 1 iff certain+likely `leak_count` > 0. `certain` is prefixes and confirmed filenames. `likely` is assignments and UUID-shaped values. `paranoid` also fails on identifier/passphrase/low-transition hits and unconfirmed `mcp.json` (the ≤0.4.9 assignment gate). Invalid value → exit 2. Headline names the gate. The three-count summary prints at every strictness. Unconfirmed MCP configs count as one possible per file.
 - `--yes` — import all importable dotenv findings without selection
   prompts (password still required)
 - `--no-import` — report only; never offer vault store

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -11,7 +11,7 @@ notes live in the repository `DESIGN.md`.
 | `ka remove NAME` | Delete a secret |
 | `ka import FILE` | Import dotenv into resolved vault (TTY-only) |
 | `ka check [--json]` | Manifest vs project names sidecar (CI; no decrypt) |
-| `ka scan [--deep] [--include-excluded] [--json] [--fail-on high|possible] [--show-possible] [--yes] [--no-import]` | LEAK report (names/paths/counts only); optional offer-to-import |
+| `ka scan [--deep] [--wide] [--include-excluded] [--json] [--strict] [--yes] [--no-import]` | LEAK report (names/paths/counts only); optional offer-to-import |
 | `ka run --secret NAME [--as NAME=ENVVAR] -- <cmd>` | Inject + scrub; agent-facing path (`=` form required for `--as`) |
 | `ka list` | Names only; safe for agents; no prompt |
 | `ka unlock [--pre-admit] [--pre-admit-secret NAME] [--admit-tree]` | Start cached guard session (pre-admit / admit-tree flags opt-in) |
@@ -40,12 +40,11 @@ ka run --secret API_KEY -- python my_script.py
 ### `scan` flags
 
 - `--deep` — also check home dotfiles, shell history, global git config,
-  known MCP paths (not a full home walk)
-- `--include-excluded` — include default-excluded dirs; git-history scan
-  still out of scope
-- `--json` — machine-readable report (`leak_count` is high-confidence; always includes `possible_count` and per-finding `confidence`)
-- `--fail-on {high,possible}` — default `high`: exit 1 iff high-confidence `leak_count` > 0. `possible` also fails on identifier/passphrase-shaped hits (old CI gate; word-shaped passphrases). Invalid value → exit 2
-- `--show-possible` — list possible hits in the human report (not dumped by default)
+  known MCP paths (not a full home walk). Independent of `--wide`.
+- `--include-excluded` / `--wide` — include default-excluded dirs; git-history scan
+  still out of scope. `--wide` is an alias only.
+- `--json` — machine-readable report (`leak_count` matches the `--strict` gate; always includes `certain_count`, `likely_count`, `possible_count`, and per-finding `confidence` + `reasons`)
+- `--strict certain|high|paranoid` — default `high`: exit 1 iff certain+likely `leak_count` > 0. `certain` is prefixes and confirmed filenames. `paranoid` also fails on identifier/passphrase/low-transition hits (the ≤0.4.9 assignment gate). Invalid value → exit 2. Headline names the gate. The three-count summary prints at every strictness.
 - `--yes` — import all importable dotenv findings without selection
   prompts (password still required)
 - `--no-import` — report only; never offer vault store

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -3,7 +3,7 @@
 Encrypted secret vault for AI coding agents. The agent can **use** secrets
 through `ka run` without ever **seeing** the values.
 
-> **Docs as of 0.4.5.** Pages in this tree describe the shipped CLI at that
+> **Docs as of 0.4.10.** Pages in this tree describe the shipped CLI at that
 > version. The live GitHub Wiki may lag until maintainers publish from
 > in-repo `wiki/` (see that directory’s `README.md` — publish instructions
 > only; not a wiki page).
@@ -16,12 +16,23 @@ ka setup                          # skills + secret-guard hook
 ka init --project                 # or: ka init  for a global vault
 ka import .env                    # TTY-only; never prints values
 ka scan                           # find remaining LEAKs (names/paths only)
-ka run --secret API_KEY -- python my_script.py
+ka scan --deep                    # also home/shell/MCP + agent session transcripts
+ka scan --strict paranoid         # also exit 1 on identifier/passphrase-shaped hits
+ka scan --wide                    # include default-excluded dirs
+ka run --cwd DIR --secret API_KEY -- python my_script.py
 ```
 
 `ka run --secret NAME` injects the secret as environment variable `NAME`.
 To remap the env var name: `--as NAME=ENVVAR` (vault name on the left).
 Wrong forms that fail: `--as API_KEY`, `--as NAME`, `--as ENVVAR` (no `=`).
+Prefer `--cwd DIR` over `cd &&`.
+
+`ka scan` headline names the `--strict` gate (default `high`: **certain**
+vendor prefixes and confirmed filenames + **likely** assignments/UUID).
+**possible** hits (identifiers, passphrases, low-transition, unconfirmed
+`mcp.json`) always appear in the three-count summary; `--strict paranoid`
+gates on them (the ≤0.4.9 assignment gate). `--wide` aliases
+`--include-excluded` and does not imply `--deep`.
 
 `ka init` asks for the master password twice; if the entries do not match,
 nothing is created. **There is no recovery** if you forget that password.

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -25,15 +25,22 @@ ka setup
 Copies bundled skills (`key-amnesia-usage`, `key-amnesia-hygiene`,
 `key-amnesia-migrate`) into `~/.claude/skills/`, `~/.cursor/skills/`,
 `~/.agents/skills/` (current Codex user path), and `~/.codex/skills/`
-(legacy / `$CODEX_HOME`), and merges a PreToolUse / preToolUse hook that
-blocks tool calls containing inline credential-shaped tokens. Restart or
-reload the host afterward. On Codex, review and trust the new hook via
-`/hooks` before it will run.
+(legacy / `$CODEX_HOME`), merges a PreToolUse / preToolUse hook that
+**denies forbidden `ka` verbs** (and inline credential-shaped tokens), and
+best-effort **allow** rules so the harness will let unattended `ka run` /
+`ka list` through. Files try to let the agent run `ka`; the hook is the
+load-bearing deny (`ka set`, `ka reveal`, `ka scan --yes`, and other
+mutating verbs). Restart or reload the host afterward. On Codex, review
+and trust the new hook via `/hooks` before it will run.
 
 Codex also reads project `AGENTS.md` for instructions; that is separate from
-skills installed by `ka setup`.
+skills installed by `ka setup`. Cursor: `ka setup` never creates
+`~/.cursor/permissions.json` (that file replaces the in-app terminal
+allowlist).
 
-Flags: `--skills-only`, `--hook-only`.
+Flags: `--skills-only`, `--hook-only`, `--permissions-only`,
+`--permissions-remove`, `--yes` (do not prompt before writing permission
+files; never deletes user allows).
 
 ## Agent bootstrap prompt
 

--- a/wiki/Quickstart-migration.md
+++ b/wiki/Quickstart-migration.md
@@ -7,7 +7,7 @@ Goal: get off plaintext `.env` faster than deciding whether to.
 ka init --project          # creates .amnesia/; gitignores it
 ka import .env             # TTY-only; never prints values
 ka scan                    # find remaining LEAKs; may offer import
-ka run --secret NAME --as NAME=ENVVAR -- <command>
+ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- <command>
 ```
 
 Order matters: **import → scan → run**. Import moves a known dotenv file into
@@ -35,9 +35,11 @@ Reports Locally Exposed Agent Keys — filenames and light patterns. Default
 exclusions skip `node_modules`, `.venv`/`venv`, common build dirs, and
 `.git` internals (`--include-excluded` to include). Git-history scanning is
 **not** a feature of the default path (or of this tool's advertised
-workflow). The headline names the `--strict` gate (default `high`: certain +
-likely). Identifier-, passphrase-, and low-transition-shaped hits are `possible`
-(`--strict paranoid` to gate — that is the ≤0.4.9 assignment gate). Values are
+workflow). The headline names the `--strict` gate (default `high`: certain
+vendor prefixes and confirmed filenames + likely assignments/UUID). Identifier-,
+passphrase-, low-transition-shaped, and unconfirmed-`mcp.json` hits are `possible`
+(`--strict paranoid` to gate — that is the ≤0.4.9 assignment gate). `--wide`
+aliases `--include-excluded` and does not imply `--deep`. Values are
 never printed.
 
 After the human report, an interactive TTY may offer to store selected

--- a/wiki/Quickstart-migration.md
+++ b/wiki/Quickstart-migration.md
@@ -35,7 +35,10 @@ Reports Locally Exposed Agent Keys — filenames and light patterns. Default
 exclusions skip `node_modules`, `.venv`/`venv`, common build dirs, and
 `.git` internals (`--include-excluded` to include). Git-history scanning is
 **not** a feature of the default path (or of this tool's advertised
-workflow).
+workflow). The headline and default exit count **high-confidence** hits
+only. Identifier- and word-shaped-passphrase hits are `possible`
+(`--fail-on possible` to gate; `--show-possible` to list paths). Values are
+never printed.
 
 After the human report, an interactive TTY may offer to store selected
 importable dotenv hits into the project vault (password still required).
@@ -46,6 +49,8 @@ ka scan
 ka scan --no-import   # report only; never offer vault import
 ka scan --deep        # + home/shell/MCP paths
 ka scan --json        # machine-readable; report-only
+ka scan --fail-on possible   # also exit 1 on identifier/passphrase-shaped hits
+ka scan --show-possible      # list possible paths in the human report
 ka scan --yes         # import all importable dotenv hits (password still required)
 ```
 

--- a/wiki/Quickstart-migration.md
+++ b/wiki/Quickstart-migration.md
@@ -35,9 +35,9 @@ Reports Locally Exposed Agent Keys — filenames and light patterns. Default
 exclusions skip `node_modules`, `.venv`/`venv`, common build dirs, and
 `.git` internals (`--include-excluded` to include). Git-history scanning is
 **not** a feature of the default path (or of this tool's advertised
-workflow). The headline and default exit count **high-confidence** hits
-only. Identifier- and word-shaped-passphrase hits are `possible`
-(`--fail-on possible` to gate; `--show-possible` to list paths). Values are
+workflow). The headline names the `--strict` gate (default `high`: certain +
+likely). Identifier-, passphrase-, and low-transition-shaped hits are `possible`
+(`--strict paranoid` to gate — that is the ≤0.4.9 assignment gate). Values are
 never printed.
 
 After the human report, an interactive TTY may offer to store selected
@@ -49,8 +49,8 @@ ka scan
 ka scan --no-import   # report only; never offer vault import
 ka scan --deep        # + home/shell/MCP paths
 ka scan --json        # machine-readable; report-only
-ka scan --fail-on possible   # also exit 1 on identifier/passphrase-shaped hits
-ka scan --show-possible      # list possible paths in the human report
+ka scan --strict paranoid   # also exit 1 on identifier/passphrase-shaped hits
+ka scan --wide        # include default-excluded dirs
 ka scan --yes         # import all importable dotenv hits (password still required)
 ```
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -3,8 +3,8 @@
 These markdown files are **first drafts** for the live GitHub wiki at
 [https://github.com/fujitoid/key-amnesia/wiki](https://github.com/fujitoid/key-amnesia/wiki).
 
-**Docs as of 0.4.7** — in-repo wording targets that release. Live wiki last
-published for 0.4.5 (no wiki IA change in 0.4.6/0.4.7; bump when republishing).
+**Docs as of 0.4.10** — in-repo wording targets that release. Live wiki last
+published for 0.4.5 (0.4.6–0.4.9 had no wiki republish; bump when republishing).
 
 
 They are kept in-repo so PRs can review IA and wording before (or instead of)

--- a/wiki/Why-not-dotenv.md
+++ b/wiki/Why-not-dotenv.md
@@ -16,21 +16,24 @@ Pasting a key into chat is worse: it lives in the conversation (and often in
 JSONL transcripts) forever.
 
 key-amnesia stores values in an encrypted vault. Agents trigger
-`ka run --secret NAME --as NAME=ENVVAR -- <command>`; injection happens in the
+`ka run --cwd DIR --secret NAME --as NAME=ENVVAR -- <command>`; injection happens in the
 child environment; scrubbed output comes back. `--as` must be
-`NAME=ENVVAR` (or omit `--as` and inject under the secret name). There is no
+`NAME=ENVVAR` (or omit `--as` and inject under the secret name). Prefer
+`--cwd` over `cd &&`. There is no
 "get secret" API for the agent.
 
 Find plaintext with:
 
 ```bash
 ka scan
-ka scan --no-import   # report only
-ka scan --strict paranoid   # ≤0.4.9 assignment gate
+ka scan --no-import           # report only
+ka scan --deep                # home/shell/MCP + agent session transcripts
+ka scan --strict paranoid     # ≤0.4.9 assignment gate
 ```
 
 The headline looks like: `N LEAKs found (--strict high) — your agent can read N secrets in
 this project (LEAK = Locally Exposed Agent Keys)`. A three-count summary
-(`N certain · N likely · N possible`) always follows. Names, paths, and counts
-only — never values. After the report you can store selected dotenv findings
-into a project vault (TTY import path), or migrate a known file with `ka import`.
+(`N certain · N likely · N possible`) always follows; only the listing and
+exit follow `--strict`. Names, paths, and counts only — never values. After the
+report you can store selected dotenv findings into a project vault (TTY
+import path), or migrate a known file with `ka import`.

--- a/wiki/Why-not-dotenv.md
+++ b/wiki/Why-not-dotenv.md
@@ -26,10 +26,11 @@ Find plaintext with:
 ```bash
 ka scan
 ka scan --no-import   # report only
-ka scan --fail-on possible   # old-strictness CI gate
+ka scan --strict paranoid   # ≤0.4.9 assignment gate
 ```
 
-The headline looks like: `N LEAK found — your agent can read N secrets in
-this project`. Names, paths, and counts only — never values. After the
-report you can store selected dotenv findings into a project vault (TTY
-import path), or migrate a known file with `ka import`.
+The headline looks like: `N LEAKs found (--strict high) — your agent can read N secrets in
+this project (LEAK = Locally Exposed Agent Keys)`. A three-count summary
+(`N certain · N likely · N possible`) always follows. Names, paths, and counts
+only — never values. After the report you can store selected dotenv findings
+into a project vault (TTY import path), or migrate a known file with `ka import`.

--- a/wiki/Why-not-dotenv.md
+++ b/wiki/Why-not-dotenv.md
@@ -26,6 +26,7 @@ Find plaintext with:
 ```bash
 ka scan
 ka scan --no-import   # report only
+ka scan --fail-on possible   # old-strictness CI gate
 ```
 
 The headline looks like: `N LEAK found — your agent can read N secrets in

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,4 +1,4 @@
-**Docs** *(as of 0.4.5)*
+**Docs** *(as of 0.4.10)*
 
 - [Home](Home)
 - [Why not `.env`](Why-not-dotenv)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the shared detector rewrite (`d956cd3`) on `feat/scan-detector-precision-0.4.10`. Two new commits on top; version stays **0.4.10**. CHANGELOG for 0.4.10 is rewritten, not appended.

## Detector fixes

- Highest tier wins per assignment name (possible-then-likely `api_key` counts as likely). `find_secret_kind` is prefix, then likely, then possible.
- Mixed transcript lines keep possible names/reasons; high/certain+likely lines stay the only line-hits.
- UUID-shaped values are `likely` with named reason `uuid`. Nil UUID stays `none`. Hook still denies.
- Unnamed low-transition demotion (`SummerVineyard2026`) is named `low-transition`.
- Unrecognised `mcp.json` / `claude_desktop_config.json` demotes to `possible` (`unconfirmed-mcp-shape`), not dropped. Confirmed `mcpServers`/`servers` is `certain`.
- `.md` assignment demotion removed; likely assignments in docs count under the default gate. Prefix-in-docs stays certain.
- Nested transcript JSON is no longer re-walked after `_strings_from_decoded_json`. Secret-named dict keys that never appear as ASSIGN text are still found. Same generated 4000-line secret-keyed nested JSONL (23_464_000 bytes): **75.8432s → 51.9149s**.

## CLI / report

- `--strict certain|high|paranoid` (default `high`). Invalid value exits 2. Unreleased `--fail-on` / `--show-possible` deleted, not deprecated.
- `--wide` aliases `--include-excluded` only. `--deep` stays independent and combinable.
- Split former `confidence=high` into **certain** (vendor prefix + confirmed filename) and **likely** (assignment/UUID). `possible` unchanged.
- Headline names the gate. Three-count summary prints at every strictness. `leak_count` matches the gated total and the headline number.
- JSON always has `certain_count` / `likely_count` / `possible_count` and per-finding `confidence` + `reasons`. Summary buckets possibles (and likely `uuid`) by reason. No percentages.

Hook recall stays `possible|likely|prefix` deny (function-call and type-annotation still `none`). Vault, guard, admission, and `ka run` injection are untouched.

## Test plan

- `pytest -q -m "not slow"` — 509 passed, 7 skipped, 7 deselected
- `--strict` three levels: listing + exit agree; headline contains `--strict {certain|high|paranoid}`; summary line identical at every gate
- Summary present when gated count is 0 but possibles exist
- `--wide` ≡ `--include-excluded`
- `--help` has no leftover `--fail-on` / `--show-possible`
- Unconfirmed `mcp.json` is possible, not absent; confirmed `mcpServers` is certain
- Generated UUID in tmp `.py` is likely with reason `uuid`; hook still denies
- cp1252 argparse help still renders (no `≤` in `--help`)

Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a9d9f54-84ca-464a-a713-086ba036f12d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a9d9f54-84ca-464a-a713-086ba036f12d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

